### PR TITLE
[Task] Add Jules post-PR governance workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -14,6 +14,9 @@ body:
         Se esta for uma child task entre lanes, preencha `Task mae`,
         `Lane solicitante` e `Criterio de consumo`. Se nao for child task, use
         `n/a` nesses campos e `- nenhuma registrada` em `Tasks filhas`.
+        Para PRs abertas primeiro pelo Jules, a task retroativa deve usar
+        `Workspace da task = jules://github/pr/<numero-da-pr>` e o label
+        `automation:jules`.
   - type: input
     id: parent_epic
     attributes:
@@ -65,8 +68,8 @@ body:
     id: task_workspace
     attributes:
       label: Workspace da task
-      description: Path relativo da worktree oficial da task.
-      placeholder: .claude/worktrees/frontend/25-exemplo-task/
+      description: Path relativo da worktree oficial da task, ou `jules://github/pr/<numero>` para task retroativa de PR do Jules.
+      placeholder: .claude/worktrees/frontend/25-exemplo-task/ ou jules://github/pr/17
     validations:
       required: true
   - type: textarea

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,11 @@
 
 Closes #
 
+> Excecao controlada: se a PR tiver sido publicada pelo Jules, o `Closes #`
+> pode ser adicionado depois que a task retroativa for criada. Use
+> `Workspace da task = jules://github/pr/<numero-da-pr>` e mantenha o label
+> `automation:jules`.
+
 ## Resumo
 
 - descreva o escopo principal desta PR
@@ -9,7 +14,7 @@ Closes #
 ## Paralelismo
 
 - lane da task: `lane:frontend | lane:backend | lane:ops-quality`
-- worktree usada: `.claude/worktrees/<lane>/<issue-number>-<slug>/`
+- worktree usada: `.claude/worktrees/<lane>/<issue-number>-<slug>/ | jules://github/pr/<numero-da-pr>`
 - esta e a unica PR oficial da task: `sim | nao`
 - risco da task: `risk:safe | risk:shared | risk:contract-sensitive`
 - task mae: `#<numero> | n/a`
@@ -33,7 +38,7 @@ Closes #
 
 ## Checklist
 
-- [ ] a branch segue `task/<issue-number>-<slug>`
+- [ ] a branch segue `task/<issue-number>-<slug>` ou a PR foi publicada pelo Jules e ja recebeu task retroativa vinculada
 - [ ] a issue vinculada esta atualizada com checklist/status/evidencias
 - [ ] a issue vinculada registra owner atual, lane oficial, workspace da task, write-set esperado e `risk:*`
 - [ ] docs relevantes foram atualizados quando necessario

--- a/.github/workflows/jules-pr-governance.yml
+++ b/.github/workflows/jules-pr-governance.yml
@@ -1,0 +1,96 @@
+name: Jules PR Governance
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  guide-jules-pr:
+    runs-on: ubuntu-latest
+    env:
+      JULES_GITHUB_LOGIN: ${{ vars.JULES_GITHUB_LOGIN }}
+    steps:
+      - name: Guide Jules PRs into the governance flow
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = "<!-- jules-governance-comment -->";
+            const pr = context.payload.pull_request;
+            const prAuthor = (pr.user?.login || "").trim().toLowerCase();
+            const configured = (process.env.JULES_GITHUB_LOGIN || "")
+              .trim()
+              .toLowerCase();
+            const isJulesPr = configured
+              ? prAuthor === configured
+              : prAuthor.includes("jules") && prAuthor.endsWith("[bot]");
+
+            if (!isJulesPr) {
+              core.info(`PR #${pr.number} nao pertence ao Jules. Workflow ignorado.`);
+              return;
+            }
+
+            const linkedIssueMatch = (pr.body || "").match(/\bCloses\s+#(\d+)\b/i);
+            const linkedIssue = linkedIssueMatch ? linkedIssueMatch[1] : null;
+            const guidance = linkedIssue
+              ? [
+                  `A PR do Jules ja esta vinculada a #${linkedIssue}.`,
+                  `Confirme que a issue #${linkedIssue} continua com o label \`automation:jules\`, lane/risk corretos e \`Workspace da task = jules://github/pr/${pr.number}\`.`,
+                  `Depois disso, o restante do fluxo segue igual ao das demais tasks: validacao, review humana, merge e fechamento da issue.`,
+                ]
+              : [
+                  "Esta PR foi publicada pelo Jules e usa a excecao controlada de governanca `PR-first`.",
+                  `Crie a task issue depois da PR com \`scripts/register_jules_pr.ps1 -Pr ${pr.number}\` ou pelo template manual.`,
+                  `Na task, use \`Workspace da task = jules://github/pr/${pr.number}\` e aplique o label \`automation:jules\`.`,
+                  "Atualize o corpo desta PR com `Closes #<issue>` assim que a task existir.",
+                  "A workflow `PR Issue Guardrails` vai permanecer vermelha ate a issue ser criada e vinculada.",
+                ];
+
+            const commentBody = [
+              marker,
+              "## Jules Governance",
+              "",
+              ...guidance.map((line) => `- ${line}`),
+            ].join("\n");
+
+            try {
+              await github.rest.issues.addLabels({
+                ...context.repo,
+                issue_number: pr.number,
+                labels: ["automation:jules"],
+              });
+            } catch (error) {
+              core.warning(`Nao foi possivel aplicar o label automation:jules na PR #${pr.number}: ${error.message}`);
+            }
+
+            const { data: comments } = await github.rest.issues.listComments({
+              ...context.repo,
+              issue_number: pr.number,
+              per_page: 100,
+            });
+
+            const existing = comments.find((comment) =>
+              typeof comment.body === "string" && comment.body.includes(marker),
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                ...context.repo,
+                comment_id: existing.id,
+                body: commentBody,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: pr.number,
+                body: commentBody,
+              });
+            }

--- a/.github/workflows/pr-issue-guardrails.yml
+++ b/.github/workflows/pr-issue-guardrails.yml
@@ -17,6 +17,8 @@ permissions:
 jobs:
   validate-pr-issue-contract:
     runs-on: ubuntu-latest
+    env:
+      JULES_GITHUB_LOGIN: ${{ vars.JULES_GITHUB_LOGIN }}
     steps:
       - name: Validate branch, issue, lanes, and critical paths
         uses: actions/github-script@v7
@@ -199,27 +201,67 @@ jobs:
               return riskRank[left] >= riskRank[right] ? left : right;
             }
 
+            function extractLinkedIssueNumber(prBody) {
+              const match = (prBody || "").match(/\bCloses\s+#(\d+)\b/i);
+              return match ? Number(match[1]) : null;
+            }
+
+            function isJulesPr(login) {
+              const normalized = (login || "").trim().toLowerCase();
+              if (!normalized) {
+                return false;
+              }
+
+              const configured = (process.env.JULES_GITHUB_LOGIN || "")
+                .trim()
+                .toLowerCase();
+
+              if (configured) {
+                return normalized === configured;
+              }
+
+              return normalized.includes("jules") && normalized.endsWith("[bot]");
+            }
+
             const branch = context.payload.pull_request.head.ref;
-            const branchMatch = branch.match(/^task\/(\d+)-([a-z0-9][a-z0-9-]*)$/);
-
-            if (!branchMatch) {
-              core.setFailed(
-                `Branch invalida: "${branch}". Use task/<issue-number>-<slug>.`,
-              );
-              return;
-            }
-
-            const issueNumber = Number(branchMatch[1]);
-            const branchSlug = branchMatch[2];
             const body = context.payload.pull_request.body || "";
-            const closesPattern = new RegExp(`\\bCloses\\s+#${issueNumber}\\b`, "i");
+            const prNumber = context.payload.pull_request.number;
+            const prAuthorLogin = context.payload.pull_request.user?.login || "";
+            const julesPr = isJulesPr(prAuthorLogin);
 
-            if (!closesPattern.test(body)) {
-              core.setFailed(
-                `A PR deve conter "Closes #${issueNumber}" no corpo para fechar a task correta.`,
-              );
-              return;
+            let issueNumber = null;
+            let branchSlug = null;
+
+            if (julesPr) {
+              issueNumber = extractLinkedIssueNumber(body);
+              if (!issueNumber) {
+                core.setFailed(
+                  `PR do Jules detectada sem task vinculada. Crie a task issue depois da PR, use "Workspace da task" = "jules://github/pr/${prNumber}", aplique o label "automation:jules" e atualize o corpo da PR com "Closes #<issue>".`,
+                );
+                return;
+              }
+            } else {
+              const branchMatch = branch.match(/^task\/(\d+)-([a-z0-9][a-z0-9-]*)$/);
+              if (!branchMatch) {
+                core.setFailed(
+                  `Branch invalida: "${branch}". Use task/<issue-number>-<slug>.`,
+                );
+                return;
+              }
+
+              issueNumber = Number(branchMatch[1]);
+              branchSlug = branchMatch[2];
+
+              const closesPattern = new RegExp(`\\bCloses\\s+#${issueNumber}\\b`, "i");
+              if (!closesPattern.test(body)) {
+                core.setFailed(
+                  `A PR deve conter "Closes #${issueNumber}" no corpo para fechar a task correta.`,
+                );
+                return;
+              }
             }
+
+            const closesPattern = new RegExp(`\\bCloses\\s+#${issueNumber}\\b`, "i");
 
             const { data: issue } = await github.rest.issues.get({
               ...context.repo,
@@ -245,6 +287,13 @@ jobs:
             if (!labels.includes("kind:task")) {
               core.setFailed(
                 `A issue #${issueNumber} precisa ter o label "kind:task". Epics nao devem ser fechados por PR.`,
+              );
+              return;
+            }
+
+            if (julesPr && !labels.includes("automation:jules")) {
+              core.setFailed(
+                `A issue #${issueNumber} vinculada a uma PR do Jules precisa ter o label "automation:jules".`,
               );
               return;
             }
@@ -467,14 +516,24 @@ jobs:
               }
             }
 
-            const expectedWorkspaceFragment = normalizePath(
-              `.claude/worktrees/${laneSection}/${issueNumber}-${branchSlug}`,
-            );
-            if (!workspace.includes(expectedWorkspaceFragment)) {
-              core.setFailed(
-                `O workspace da issue #${issueNumber} deve apontar para ".claude/worktrees/${laneSection}/${issueNumber}-${branchSlug}/". Valor atual: "${workspace}".`,
+            if (julesPr) {
+              const expectedWorkspace = `jules://github/pr/${prNumber}`;
+              if (workspace !== expectedWorkspace) {
+                core.setFailed(
+                  `A issue #${issueNumber} vinculada a uma PR do Jules deve declarar "Workspace da task" como "${expectedWorkspace}". Valor atual: "${workspace}".`,
+                );
+                return;
+              }
+            } else {
+              const expectedWorkspaceFragment = normalizePath(
+                `.claude/worktrees/${laneSection}/${issueNumber}-${branchSlug}`,
               );
-              return;
+              if (!workspace.includes(expectedWorkspaceFragment)) {
+                core.setFailed(
+                  `O workspace da issue #${issueNumber} deve apontar para ".claude/worktrees/${laneSection}/${issueNumber}-${branchSlug}/". Valor atual: "${workspace}".`,
+                );
+                return;
+              }
             }
 
             const duplicatePrs = await github.paginate(github.rest.pulls.list, {
@@ -493,6 +552,7 @@ jobs:
                 duplicateBody,
               );
               const sameBranchIssue =
+                !julesPr &&
                 typeof pullRequest.head?.ref === "string" &&
                 pullRequest.head.ref.startsWith(`task/${issueNumber}-`);
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,21 @@ repositorio.
 9. A task so conta como concluida depois do merge confirmado da PR. Epics fecham
    manualmente.
 
+## Excecao controlada para Jules
+
+- A excecao existe apenas para PRs publicadas pelo Jules (Google Labs).
+- Nessas PRs, o fluxo pode comecar por PR e a task issue pode ser criada
+  depois, desde que a governanca seja regularizada imediatamente.
+- A task retroativa do Jules deve:
+  - usar o label `automation:jules`
+  - registrar `Workspace da task` como `jules://github/pr/<numero-da-pr>`
+  - manter `Owner atual`, `Lane oficial`, `Write-set esperado` e
+    `Classificacao de risco` normalmente
+  - atualizar a PR com `Closes #<issue>` assim que a issue existir
+- A excecao nao libera merge sem task. Enquanto a issue nao existir e nao
+  estiver vinculada, a PR do Jules deve permanecer bloqueada pelos guardrails.
+- Fora desse caso especifico, continua valendo o fluxo normal `issue -> branch -> PR`.
+
 ## Regra de commit, push e merge
 
 - Nao deixe trabalho concluido apenas localmente.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,13 @@ Before changing any versioned file:
 11. Update the issue and relevant docs before considering the task complete.
 12. Commit validated checkpoints, push them promptly, and merge to `master` when the task is complete and checks are green unless the user explicitly says not to.
 
+### Jules-only exception
+
+- The only allowed `PR-first` exception is for pull requests published by Jules (Google Labs).
+- For a Jules PR, create the task after the PR opens, set `Workspace da task` to `jules://github/pr/<pr-number>`, apply `automation:jules`, and update the PR body with `Closes #<issue>`.
+- Until that retroactive task exists and is linked, the PR must remain blocked by governance checks.
+- This exception does not apply to humans, Codex, Claude, or any other agent.
+
 ## Publish and Merge Policy
 
 - Do not leave completed work only in the local worktree.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -7,7 +7,7 @@
 
 ---
 
-## Estado Atual (2026-04-09)
+## Estado Atual (2026-04-12)
 
 ### Dashboard
 - **3 abas renderizadas** em `dashboard/app.py`: `Visao Geral`, `Demonstracoes`, `Download`
@@ -72,6 +72,9 @@
   lane, mas ainda nao consumida pela lane solicitante
 - O fechamento da task passa a exigir checks verdes e merge confirmado; PR
   aberta nao conta como concluido
+- PRs do Jules (Google Labs) passam a ter uma excecao controlada `PR-first`,
+  com task retroativa, label `automation:jules` e workspace
+  `jules://github/pr/<numero>`
 - `docs/STUDENT_PACK_PLAN.md` deixa de espelhar task-by-task e passa a apontar para milestone + epics + filtros de issues
 - `docs/AGENTS.md` permanece apenas como estado atual e historico de sessoes
 
@@ -99,6 +102,16 @@
 ---
 
 ## Sessoes Recentes
+
+### Sessao 38 - 2026-04-12 (governanca retroativa para PRs do Jules)
+- Novo workflow dedicado para detectar PRs publicadas pelo Jules e orientar a
+  regularizacao da governanca
+- `PR Issue Guardrails` passa a aceitar `PR-first` somente quando a autoria for
+  do Jules e a issue retroativa estiver vinculada
+- Tasks retroativas do Jules passam a usar `Workspace da task` como
+  `jules://github/pr/<numero-da-pr>` e label `automation:jules`
+- `scripts/register_jules_pr.ps1` passa a criar a task retroativa, inferir
+  lane/risco e atualizar a PR com `Closes #<issue>`
 
 ### Sessao 37 - 2026-04-09 (child tasks formais entre lanes)
 - Delegacao entre lanes passa a exigir child task formal em GitHub Issue, nao

--- a/docs/governance/parallel-lanes.md
+++ b/docs/governance/parallel-lanes.md
@@ -70,6 +70,23 @@ child tasks. Nao use uma task gigante multi-lane.
    equivalente
 8. Remover a worktree da task
 
+## Excecao controlada para Jules
+
+PR-first so e permitido para PRs publicadas pelo Jules (Google Labs).
+
+### Regras
+
+- A task issue pode ser criada depois da abertura da PR apenas nesse caso.
+- A lane continua sendo unica e deve ser inferida/registrada normalmente.
+- O restante da governanca continua valendo: labels obrigatorios, `write-set`,
+  risco, validacao, merge unico e issue vinculada via `Closes #<issue>`.
+- A task retroativa do Jules usa `Workspace da task = jules://github/pr/<numero-da-pr>`.
+- O label `automation:jules` identifica a excecao nos guardrails e na
+  documentacao operacional.
+- A PR do Jules continua bloqueada enquanto a issue retroativa nao existir e
+  nao estiver vinculada.
+- Essa excecao nao autoriza PR-first para humanos ou para outras IAs.
+
 ## Handoff entre IAs ou humanos
 
 - Se outra pessoa ou IA assumir a task, atualize primeiro o `Owner atual`.

--- a/scripts/register_jules_pr.ps1
+++ b/scripts/register_jules_pr.ps1
@@ -1,0 +1,377 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [int]$Pr,
+
+  [string]$Repo = "",
+
+  [string]$Owner = "Jules (Google Labs)",
+
+  [ValidateSet("p0", "p1", "p2", "p3")]
+  [string]$Priority = "p1"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Normalize-PathValue {
+  param([string]$Value)
+
+  if ($null -eq $Value) {
+    return ""
+  }
+
+  return (($Value -replace "\\", "/").Trim())
+}
+
+function Convert-GlobToRegex {
+  param([string]$Pattern)
+
+  $normalized = Normalize-PathValue $Pattern
+  $builder = New-Object System.Text.StringBuilder
+  [void]$builder.Append("^")
+
+  for ($index = 0; $index -lt $normalized.Length; $index += 1) {
+    $current = $normalized[$index]
+    $next = if ($index + 1 -lt $normalized.Length) { $normalized[$index + 1] } else { [char]0 }
+
+    if ($current -eq "*" -and $next -eq "*") {
+      [void]$builder.Append(".*")
+      $index += 1
+      continue
+    }
+
+    if ($current -eq "*") {
+      [void]$builder.Append("[^/]*")
+      continue
+    }
+
+    if ($current -eq "?") {
+      [void]$builder.Append(".")
+      continue
+    }
+
+    [void]$builder.Append([regex]::Escape([string]$current))
+  }
+
+  [void]$builder.Append("$")
+  return $builder.ToString()
+}
+
+function Test-AnyPatternMatch {
+  param(
+    [string]$Path,
+    [object[]]$Patterns
+  )
+
+  $normalizedPath = Normalize-PathValue $Path
+  foreach ($pattern in $Patterns) {
+    if ($normalizedPath -match (Convert-GlobToRegex -Pattern ([string]$pattern))) {
+      return $true
+    }
+  }
+
+  return $false
+}
+
+function Ensure-Label {
+  param(
+    [string]$RepoName,
+    [string]$Name,
+    [string]$Color,
+    [string]$Description
+  )
+
+  gh label create $Name --repo $RepoName --color $Color --description $Description --force | Out-Null
+}
+
+function Test-IsJulesLogin {
+  param(
+    [string]$Login,
+    [string]$ConfiguredLogin
+  )
+
+  $normalized = Normalize-PathValue $Login
+  if (-not $normalized) {
+    return $false
+  }
+
+  $normalized = $normalized.ToLowerInvariant()
+  $configured = Normalize-PathValue $ConfiguredLogin
+
+  if ($configured) {
+    return $normalized -eq $configured.ToLowerInvariant()
+  }
+
+  return $normalized.Contains("jules") -and $normalized.EndsWith("[bot]")
+}
+
+function Get-RepoName {
+  param([string]$ExplicitRepo)
+
+  if ($ExplicitRepo) {
+    return $ExplicitRepo
+  }
+
+  $name = gh repo view --json nameWithOwner --jq .nameWithOwner
+  if (-not $name) {
+    throw "Nao foi possivel determinar o repositorio atual."
+  }
+
+  return $name.Trim()
+}
+
+function Get-AreaForLane {
+  param(
+    [string]$Lane,
+    [string[]]$Files
+  )
+
+  switch ($Lane) {
+    "frontend" { return "web" }
+    "ops-quality" { return "infra" }
+    "backend" {
+      if ($Files | Where-Object { $_ -like "apps/api/**" -or $_ -eq "docs/V2_API_CONTRACT.md" }) {
+        return "api"
+      }
+
+      return "core"
+    }
+  }
+
+  throw "Lane nao suportada para area: $Lane"
+}
+
+function Get-RiskRank {
+  param([string]$Risk)
+
+  switch ($Risk) {
+    "safe" { return 0 }
+    "shared" { return 1 }
+    "contract-sensitive" { return 2 }
+  }
+
+  throw "Risco nao suportado: $Risk"
+}
+
+function Get-HigherRisk {
+  param(
+    [string]$Current,
+    [string]$Candidate
+  )
+
+  if ((Get-RiskRank -Risk $Candidate) -gt (Get-RiskRank -Risk $Current)) {
+    return $Candidate
+  }
+
+  return $Current
+}
+
+$repoName = Get-RepoName -ExplicitRepo $Repo
+
+$labelDefinitions = @(
+  @{ Name = "kind:task"; Color = "0e8a16"; Description = "Executable task issue" }
+  @{ Name = "status:in-progress"; Color = "fbca04"; Description = "Work in progress" }
+  @{ Name = "priority:p0"; Color = "b60205"; Description = "Highest priority" }
+  @{ Name = "priority:p1"; Color = "d93f0b"; Description = "High priority" }
+  @{ Name = "priority:p2"; Color = "fbca04"; Description = "Medium priority" }
+  @{ Name = "priority:p3"; Color = "0e8a16"; Description = "Lower priority" }
+  @{ Name = "area:web"; Color = "1d76db"; Description = "Web app area" }
+  @{ Name = "area:api"; Color = "0052cc"; Description = "API area" }
+  @{ Name = "area:core"; Color = "5319e7"; Description = "Core Python area" }
+  @{ Name = "area:infra"; Color = "c2e0c6"; Description = "Infra and automation area" }
+  @{ Name = "risk:safe"; Color = "0e8a16"; Description = "Isolated write-set" }
+  @{ Name = "risk:shared"; Color = "fbca04"; Description = "Touches shared governance or critical files" }
+  @{ Name = "risk:contract-sensitive"; Color = "b60205"; Description = "Touches public contracts" }
+  @{ Name = "lane:frontend"; Color = "1d76db"; Description = "Frontend lane" }
+  @{ Name = "lane:backend"; Color = "5319e7"; Description = "Backend lane" }
+  @{ Name = "lane:ops-quality"; Color = "0052cc"; Description = "Ops-quality lane" }
+  @{ Name = "automation:jules"; Color = "7057ff"; Description = "Jules-specific governance and automation" }
+)
+
+foreach ($label in $labelDefinitions) {
+  Ensure-Label -RepoName $repoName -Name $label.Name -Color $label.Color -Description $label.Description
+}
+
+$prJson = gh pr view $Pr --repo $repoName --json number,title,body,url,author,files
+if (-not $prJson) {
+  throw "Nao foi possivel ler a PR #$Pr."
+}
+
+$prData = $prJson | ConvertFrom-Json
+$prBody = if ($null -eq $prData.body) { "" } else { [string]$prData.body }
+$configuredJulesLogin = ""
+$variableJson = gh api "repos/$repoName/actions/variables/JULES_GITHUB_LOGIN" 2>$null
+if ($LASTEXITCODE -eq 0 -and $variableJson) {
+  $variableData = $variableJson | ConvertFrom-Json
+  if ($null -ne $variableData.value) {
+    $configuredJulesLogin = [string]$variableData.value
+  }
+}
+
+$prAuthorLogin = ""
+if ($null -ne $prData.author -and $null -ne $prData.author.login) {
+  $prAuthorLogin = [string]$prData.author.login
+}
+
+if (-not (Test-IsJulesLogin -Login $prAuthorLogin -ConfiguredLogin $configuredJulesLogin)) {
+  throw "A PR #$Pr nao parece ter sido publicada pelo Jules. Autor encontrado: '$prAuthorLogin'."
+}
+
+$linkedIssueMatch = [regex]::Match($prBody, '(?im)\bCloses\s+#(\d+)\b')
+if ($linkedIssueMatch.Success) {
+  gh pr edit $Pr --repo $repoName --add-label "automation:jules" | Out-Null
+  Write-Output "PR #$Pr ja esta vinculada a issue #$($linkedIssueMatch.Groups[1].Value)."
+  exit 0
+}
+
+$policyPath = Join-Path $PSScriptRoot "..\\.github\\guardrails\\path-policy.json"
+$policy = Get-Content -Raw $policyPath | ConvertFrom-Json
+
+$files = @($prData.files | ForEach-Object { Normalize-PathValue $_.path }) | Where-Object { $_ }
+if (-not $files -or $files.Count -eq 0) {
+  throw "A PR #$Pr nao possui arquivos alterados."
+}
+
+$laneCandidates = @("frontend", "backend", "ops-quality")
+$ownerLaneHints = New-Object System.Collections.Generic.List[string]
+$minimumRisk = "safe"
+
+foreach ($file in $files) {
+  $matchedGroups = @($policy.criticalGroups | Where-Object { Test-AnyPatternMatch -Path $file -Patterns $_.patterns })
+  if ($matchedGroups.Count -gt 1) {
+    throw "O arquivo '$file' caiu em mais de um grupo critico."
+  }
+
+  if ($matchedGroups.Count -eq 1) {
+    $group = $matchedGroups[0]
+    $allowedLanes = @($group.allowedLanes)
+    $minimumRisk = Get-HigherRisk -Current $minimumRisk -Candidate $group.minimumRisk
+    $ownerLaneHints.Add($group.ownerLane) | Out-Null
+  } else {
+    $allowedLanes = @()
+    foreach ($laneProperty in $policy.laneAllowlists.PSObject.Properties) {
+      if (Test-AnyPatternMatch -Path $file -Patterns $laneProperty.Value) {
+        $allowedLanes += $laneProperty.Name
+      }
+    }
+
+    if ($allowedLanes.Count -eq 0) {
+      throw "O arquivo '$file' nao esta classificado em .github/guardrails/path-policy.json."
+    }
+
+    if ($allowedLanes.Count -eq 1) {
+      $ownerLaneHints.Add($allowedLanes[0]) | Out-Null
+    }
+  }
+
+  $laneCandidates = @($laneCandidates | Where-Object { $allowedLanes -contains $_ })
+  if ($laneCandidates.Count -eq 0) {
+    throw "Os arquivos alterados misturam lanes incompatíveis para a governanca atual."
+  }
+}
+
+if ($laneCandidates.Count -eq 1) {
+  $lane = $laneCandidates[0]
+} else {
+  $uniqueHints = @($ownerLaneHints | Sort-Object -Unique | Where-Object { $laneCandidates -contains $_ })
+  if ($uniqueHints.Count -eq 1) {
+    $lane = $uniqueHints[0]
+  } else {
+    throw "Nao foi possivel inferir uma unica lane para a PR #$Pr. Lanes candidatas: $($laneCandidates -join ', ')."
+  }
+}
+
+$area = Get-AreaForLane -Lane $lane -Files $files
+$workspace = "jules://github/pr/$Pr"
+$risk = $minimumRisk
+$issueTitle = "[Task] Register Jules PR #$Pr - $($prData.title)"
+$writeSetLines = ($files | Sort-Object | ForEach-Object { "- $_" }) -join "`n"
+
+$issueBody = @"
+## Epic pai
+n/a
+
+## Task mae
+n/a
+
+## Owner atual
+$Owner
+
+## Lane oficial
+$lane
+
+## Lane solicitante
+n/a
+
+## Workspace da task
+$workspace
+
+## Write-set esperado
+$writeSetLines
+
+## Classificacao de risco
+$risk
+
+## Dependencias ou write-sets concorrentes
+PR-first permitido apenas porque a autoria e do Jules.
+
+## Tasks filhas
+- nenhuma registrada
+
+## Criterio de consumo
+n/a
+
+## Contexto
+PR do Jules aberta em $($prData.url). Esta task retroativa formaliza a governanca exigida pelo repositorio depois que a PR ja existe.
+
+## Criterios de aceite
+- A PR do Jules fica vinculada a esta task com `Closes #<issue>`.
+- Lane, risco, workspace especial do Jules e write-set ficam registrados.
+- O restante da validacao e da revisao segue o fluxo padrao do repositorio.
+
+## Area principal
+$area
+
+## Prioridade
+$Priority
+
+## Checklist de execucao
+- [ ] Escopo confirmado
+- [ ] Owner, lane, workspace, write-set e risco revisados
+- [ ] Viculos de task mae/tasks filhas/consumo atualizados quando aplicavel
+- [ ] Implementacao concluida
+- [ ] Validacao executada
+- [ ] Issue/docs atualizados
+- [ ] PR mergeada e issue fechada
+
+## Validacao esperada
+- Revisar a PR do Jules.
+- Executar os checks relevantes para os arquivos alterados.
+- Confirmar que a PR referencia esta issue com `Closes #<issue>`.
+"@
+
+$issueUrl = gh issue create --repo $repoName --title $issueTitle --body $issueBody --label "kind:task" --label "status:in-progress" --label "priority:$Priority" --label "area:$area" --label "risk:$risk" --label "lane:$lane" --label "automation:jules"
+if (-not $issueUrl) {
+  throw "Nao foi possivel criar a task retroativa para a PR #$Pr."
+}
+
+$issueNumberMatch = [regex]::Match($issueUrl, '/issues/(\d+)$')
+if (-not $issueNumberMatch.Success) {
+  throw "Nao foi possivel extrair o numero da issue criada a partir de '$issueUrl'."
+}
+
+$issueNumber = $issueNumberMatch.Groups[1].Value
+$existingBody = $prBody
+$newBody = if ([string]::IsNullOrWhiteSpace($existingBody)) {
+  "Closes #$issueNumber"
+} else {
+  "Closes #$issueNumber`n`n$existingBody"
+}
+
+gh pr edit $Pr --repo $repoName --body $newBody --add-label "automation:jules" | Out-Null
+gh pr comment $Pr --repo $repoName --body "Task retroativa criada para esta PR do Jules: #$issueNumber. A governanca agora segue o fluxo normal do repositorio." | Out-Null
+
+Write-Output "ISSUE_URL=$issueUrl"
+Write-Output "ISSUE_NUMBER=$issueNumber"
+Write-Output "INFERRED_LANE=$lane"
+Write-Output "INFERRED_RISK=$risk"
+Write-Output "WORKSPACE=$workspace"


### PR DESCRIPTION
## Issue

Closes #1

## Resumo

- adiciona um workflow dedicado para PRs publicadas pelo Jules
- ajusta o guardrail para aceitar PR-first apenas para Jules, com task retroativa vinculada
- documenta o workspace especial `jules://github/pr/<numero>` e adiciona helper local para registrar a task retroativa
- sincroniza o write-set da issue com os templates e guardrails alterados nesta branch

## Paralelismo

- lane da task: `lane:ops-quality`
- worktree usada: `.claude/worktrees/ops-quality/1-jules-post-pr-governance/`
- esta e a unica PR oficial da task: `sim`
- risco da task: `risk:shared`
- task mae: `n/a`
- lane solicitante: `n/a`
- consumo registrado na task mae: `n/a`
- write-set principal:
  - `.github/workflows/**`
  - `.github/guardrails/**`
  - `.github/ISSUE_TEMPLATE/**`
  - `.github/PULL_REQUEST_TEMPLATE.md`
  - `AGENTS.md`, `CLAUDE.md`, `docs/AGENTS.md`, `docs/governance/parallel-lanes.md`
  - `scripts/register_jules_pr.ps1`
- coordenacao com outras tasks/PRs: nenhuma

## Compatibilidade

- politica aplicada: `additive-only`
- impacto em API, schema ou docs publicos: governanca e docs operacionais apenas

## Validacao

- [x] validacoes executadas e registradas abaixo

```text
[System.Management.Automation.Language.Parser]::ParseFile(scripts/register_jules_pr.ps1)
python -c "import yaml, pathlib; [yaml.safe_load(pathlib.Path(p).read_text(encoding='utf-8')) for p in ['.github/workflows/jules-pr-governance.yml','.github/workflows/pr-issue-guardrails.yml']]"
git diff --check
```

## Checklist

- [x] a branch segue `task/<issue-number>-<slug>`
- [x] a issue vinculada esta atualizada com checklist/status/evidencias
- [x] a issue vinculada registra owner atual, lane oficial, workspace da task, write-set esperado e `risk:*`
- [x] docs relevantes foram atualizados quando necessario
- [x] lane da task e worktree oficial foram registradas nesta PR
- [x] se a task for `risk:shared` ou `risk:contract-sensitive`, a PR abriu em draft
- [x] se a task for `risk:contract-sensitive`, a compatibilidade foi revisada e documentada
- [x] PR em draft apenas enquanto o trabalho ou as validacoes ainda estiverem incompletos
- [ ] checks obrigatorios verdes ou helper de conclusao acionado para aguardar
- [ ] pronto para `squash merge` em `master` quando os checks estiverem verdes
- [ ] nao considerar a task concluida ate confirmar merge, issue fechada e branch remota removida quando aplicavel