### PR TITLE
🧹 Remove unused import Path in desktop/ui.py

### DIFF
--- a/desktop/ui.py
+++ b/desktop/ui.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from datetime import datetime
-from pathlib import Path
 from typing import Any
 
 from PyQt6.QtCore import Qt, QStringListModel, pyqtSignal


### PR DESCRIPTION
Closes #16

🎯 **What:** Removed the unused import `Path` from `desktop/ui.py`.
💡 **Why:** Unused imports clutter the code and can lead to confusion. Removing them improves maintainability and readability.
✅ **Verification:** 
- Inspected `desktop/ui.py` to confirm `Path` is not used.
- Confirmed dependent files (`controller.py`, `cvm_pyqt_app.py`) have their own imports if they use `Path`.
- Verified the file still compiles successfully using `python3 -m py_compile`.
✨ **Result:** Cleaner and more maintainable code in `desktop/ui.py`.

---
*PR created automatically by Jules for task [1856347174140066991](https://jules.google.com/task/1856347174140066991) started by @joaosantossgp*