### PR TITLE
Fix standard names for Revenue in KPI calculation

### DIFF
--- a/scripts/calc_financial_kpis.py
+++ b/scripts/calc_financial_kpis.py
@@ -13,6 +13,7 @@ def load_data(db_path):
         'Receita de Venda de Bens e/ou Serviços',
         'Receitas das Operações',
         'Receitas de Intermediação Financeira',
+        'Receitas da Intermediação Financeira',
         'Resultado Bruto',
         'Lucro/Prejuízo Consolidado do Período',
         'Ativo Total',
@@ -34,6 +35,7 @@ def aggregate_annual(df):
     df['STANDARD_NAME'] = df['STANDARD_NAME'].replace({
         'Receitas das Operações': 'Receita',
         'Receitas de Intermediação Financeira': 'Receita',
+        'Receitas da Intermediação Financeira': 'Receita',
         'Receita de Venda de Bens e/ou Serviços': 'Receita'
     })
     


### PR DESCRIPTION
Closes #15

The task was to normalize revenue account names to a standard format 'Receita' in `scripts/calc_financial_kpis.py`. 

Upon analysis of `config/canonical_accounts.csv`, I identified that 'Receitas da Intermediação Financeira' was a valid standard name not fully covered in the script (which had 'Receitas de Intermediação Financeira').

I have updated `scripts/calc_financial_kpis.py` in two places:
1. `load_data`: Added 'Receitas da Intermediação Financeira' to the SQL `IN` clause to ensure these records are fetched.
2. `aggregate_annual`: Added the mapping from 'Receitas da Intermediação Financeira' to 'Receita' in the replacement dictionary.

I verified the logic by inspecting the code and running a verification script that checked for the presence of these mappings and SQL inclusions. Automated tests were skipped due to missing dependencies in the sandbox environment.

---
*PR created automatically by Jules for task [9516562330151192071](https://jules.google.com/task/9516562330151192071) started by @joaosantossgp*