### PR TITLE
Fix Jules intake workflow reprocessing

### DIFF
--- a/.github/workflows/jules-pr-governance.yml
+++ b/.github/workflows/jules-pr-governance.yml
@@ -28,5 +28,11 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const run = require('./.github/scripts/jules-pr-governance.cjs');
+            const path = require('path');
+            const run = require(
+              path.join(
+                process.env.GITHUB_WORKSPACE,
+                '.github/scripts/jules-pr-governance.cjs',
+              ),
+            );
             await run({ github, context, core });

--- a/.github/workflows/pr-issue-guardrails.yml
+++ b/.github/workflows/pr-issue-guardrails.yml
@@ -205,12 +205,7 @@ jobs:
               );
             }
 
-            const branch = context.payload.pull_request.head.ref;
-            const body = context.payload.pull_request.body || "";
             const prNumber = context.payload.pull_request.number;
-            const prLabels = context.payload.pull_request.labels.map((label) =>
-              typeof label === "string" ? label : label.name,
-            );
             const { data: policyFile } = await github.rest.repos.getContent({
               ...context.repo,
               path: ".github/guardrails/path-policy.json",
@@ -221,6 +216,15 @@ jobs:
               Buffer.from(policyFile.content, policyFile.encoding).toString("utf8"),
             );
             const julesConfig = policy.julesIntake || {};
+            const { data: currentPull } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: prNumber,
+            });
+            const branch = currentPull.head?.ref || context.payload.pull_request.head.ref;
+            const body = currentPull.body || context.payload.pull_request.body || "";
+            const prLabels = (currentPull.labels || context.payload.pull_request.labels || []).map(
+              (label) => (typeof label === "string" ? label : label.name),
+            );
             const isJulesPr =
               prLabels.includes(julesConfig.sourceLabel) ||
               hasJulesMarker(body, julesConfig.bodyMarkers);
@@ -652,7 +656,7 @@ jobs:
             if (
               ["opened", "reopened"].includes(context.payload.action) &&
               requiresDraft &&
-              !context.payload.pull_request.draft
+              !(currentPull.draft ?? context.payload.pull_request.draft)
             ) {
               core.setFailed(
                 `PRs que tocam paths criticos ou compartilhados devem abrir em draft.`,


### PR DESCRIPTION
## Issue

Closes #10

## Resumo

- corrige o carregamento do modulo do workflow do Jules no runner usando `GITHUB_WORKSPACE`
- faz o guardrail padrao consultar o estado atual da PR antes de decidir se ela e do Jules
- libera o reprocessamento das PRs abertas do Jules que falharam no primeiro backfill

## Paralelismo

- lane da task: `lane:ops-quality`
- worktree usada: `.claude/worktrees/ops-quality/10-fix-jules-retro-intake/`
- esta e a unica PR oficial da task: `sim`
- risco da task: `risk:shared`
- task mae: `n/a`
- lane solicitante: `n/a`
- consumo registrado na task mae: `n/a`
- write-set principal:
  - `.github/workflows/**`
  - `.github/scripts/**`
  - `.github/guardrails/**`
- coordenacao com outras tasks/PRs: `reprocessamento posterior das PRs #2, #4, #5, #6 e #8`

## Compatibilidade

- politica aplicada: `additive-only`
- impacto em API, schema ou docs publicos: nenhum; apenas governanca operacional do repositorio

## Validacao

- [x] validacoes executadas e registradas abaixo

```text
python + PyYAML: parse sintatico dos workflows
actions/github-script extraido e validado com node --check
require absoluto do modulo testado localmente com GITHUB_WORKSPACE apontando para a worktree
git diff --check
```

## Checklist

- [x] a branch segue `task/<issue-number>-<slug>` ou a PR foi publicada pelo Jules e a automacao ja vinculou a task retroativa
- [x] a issue vinculada esta atualizada com checklist/status/evidencias
- [x] a issue vinculada registra owner atual, lane oficial, workspace da task, write-set esperado e `risk:*`
- [ ] docs relevantes foram atualizados quando necessario
- [x] lane da task e worktree oficial foram registradas nesta PR
- [x] se a task for `risk:shared` ou `risk:contract-sensitive`, a PR abriu em draft
- [ ] se a task for `risk:contract-sensitive`, a compatibilidade foi revisada e documentada
- [x] PR em draft apenas enquanto o trabalho ou as validacoes ainda estiverem incompletos
- [ ] checks obrigatorios verdes ou helper de conclusao acionado para aguardar
- [ ] pronto para `squash merge` em `master` quando os checks estiverem verdes
- [ ] nao considerar a task concluida ate confirmar merge, issue fechada e branch remota removida quando aplicavel