### PR TITLE
[Task] Fix Jules intake against stale base refs

### DIFF
--- a/.github/scripts/jules-pr-governance.cjs
+++ b/.github/scripts/jules-pr-governance.cjs
@@ -564,10 +564,11 @@ module.exports = async function runJulesPrGovernance({ github, context, core }) 
 
   const pr = context.payload.pull_request;
   const prLabels = parseNames(pr.labels);
+  const policyRef = pr.base?.ref || pr.base?.sha;
   const { data: policyFile } = await github.rest.repos.getContent({
     ...context.repo,
     path: '.github/guardrails/path-policy.json',
-    ref: pr.base.sha,
+    ref: policyRef,
   });
   const policy = JSON.parse(
     Buffer.from(policyFile.content, policyFile.encoding).toString('utf8'),

--- a/.github/workflows/jules-pr-governance.yml
+++ b/.github/workflows/jules-pr-governance.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout base repository state
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: refs/heads/${{ github.event.pull_request.base.ref }}
           persist-credentials: false
 
       - name: Reconcile Jules PR-first intake

--- a/.github/workflows/pr-issue-guardrails.yml
+++ b/.github/workflows/pr-issue-guardrails.yml
@@ -209,7 +209,7 @@ jobs:
             const { data: policyFile } = await github.rest.repos.getContent({
               ...context.repo,
               path: ".github/guardrails/path-policy.json",
-              ref: context.payload.pull_request.base.sha,
+              ref: context.payload.pull_request.base.ref,
             });
 
             const policy = JSON.parse(
@@ -222,11 +222,12 @@ jobs:
             });
             const branch = currentPull.head?.ref || context.payload.pull_request.head.ref;
             const body = currentPull.body || context.payload.pull_request.body || "";
-            const prLabels = (currentPull.labels || context.payload.pull_request.labels || []).map(
-              (label) => (typeof label === "string" ? label : label.name),
+            const currentLabels = currentPull.labels || context.payload.pull_request.labels || [];
+            const currentLabelNames = currentLabels.map((label) =>
+              typeof label === "string" ? label : label.name,
             );
             const isJulesPr =
-              prLabels.includes(julesConfig.sourceLabel) ||
+              currentLabelNames.includes(julesConfig.sourceLabel) ||
               hasJulesMarker(body, julesConfig.bodyMarkers);
 
             if (isJulesPr) {


### PR DESCRIPTION
Closes #12

## Summary
- load Jules governance assets from the current base branch instead of the stale PR base SHA
- read the path policy from the current base branch in both governance workflows
- keep the guardrail Jules detection anchored to the current PR state when old PRs are reprocessed

## Validation
- python YAML parse for both workflows
- node --check .github/scripts/jules-pr-governance.cjs
- node --check on wrapped github-script extracts
- git diff --check