### PR TITLE
Fix temporal alignment issue in Excel exporter's GERAL tab

### DIFF
--- a/src/excel_exporter.py
+++ b/src/excel_exporter.py
@@ -410,7 +410,7 @@ class ExcelExporter:
             import re
             m_year = re.match(r"^20\d{2}$", p)
             if m_year:
-                return (int(p), 4, p)
+                return (int(p), 5, p)
             m_quarter = re.match(r"^([1-4])[QT](20\d{2}|\d{2})$", p)
             if m_quarter:
                 q = int(m_quarter.group(1))


### PR DESCRIPTION
Closes #28

This commit fixes an issue where periods for Balance Sheet (BPA/BPP) columns were misaligned relative to Income Statement (DRE) and Cash Flow (DFC) columns in the GERAL tab of the generated Excel reports. The issue was caused by an incorrect sorting behavior for annual periods (e.g. '2011') and Q4 periods (e.g. '4Q11') where annual periods were placed before Q4 periods due to lexicographical sorting. This has been resolved by mapping annual periods to a quarter index of 5 instead of 4, ensuring they correctly appear after the 4th quarter.

---
*PR created automatically by Jules for task [18147332852104146172](https://jules.google.com/task/18147332852104146172) started by @joaosantossgp*