### PR TITLE
chore(ops-quality): reduce agent startup context by 31%

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,32 @@
+# Data files — large raw inputs, databases, caches
+data/input/
+data/db/
+data/cache/
+data/metadata/
+
+# Output reports
+output/
+
+# Archived/dead scripts — do not explore
+archive/
+
+# Scratchpad and review artifacts — transient, not code
+.workflow/.scratchpad/
+
+# Reference documents — binary, for human reading only
+docs/references/
+
+# Python environment
+.venv/
+
+# Node.js
+apps/web/node_modules/
+apps/web/.next/
+
+# Binary and large files
+*.xlsx
+*.pdf
+*.zip
+*.db
+*.sqlite
+*.docx

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Hybrid Python project: a CLI scraper that extracts DFP/ITR financial reports from Brazil's CVM regulator and persists them to SQLite/PostgreSQL, plus a Streamlit analytics dashboard and a PyQt6 desktop app for 449+ public companies.
 
-> For business rules, pipeline details, and troubleshooting see `docs/CONTEXT.md`.
-> For the issue-first workflow required in this repo see `AGENTS.md`.
-> For current state and session history see `docs/AGENTS.md`.
+> For commands, architecture, and conventions: `docs/CLAUDE_REFERENCE.md` (read on demand).
+> For business rules and pipeline details: `docs/CONTEXT.md` (read before touching `src/`).
+> For issue-first workflow: `AGENTS.md`.
+> For current state and session history: `docs/AGENTS.md`.
 
 ## Required Workflow
 
@@ -102,160 +103,7 @@ Do not use `docs/AGENTS.md` as a backlog. The official backlog lives in GitHub I
 - Only the requester lane may mark the delivery as consumed and unblock the
   parent task.
 
-## Commands
-
-### Running the App
-
-```bash
-# Dashboard (Streamlit)
-streamlit run dashboard/app.py
-
-# Desktop GUI (PyQt6 — official; handles data refresh)
-python -m desktop.cvm_pyqt_app
-
-# CLI scraper
-python main.py --companies PETROBRAS --start_year 2021 --end_year 2025 --type consolidated
-```
-
-### Testing
-
-```bash
-pytest tests/ -v                         # all tests
-pytest tests/test_scraper.py -v          # single file
-pytest -k "test_normalize" -v            # by name pattern
-```
-
-Configuration lives in `pytest.ini` at the repo root.
-
-### Database Setup (after clone or migration)
-
-```bash
-python scripts/setup_db.py               # indices + companies/account_names tables
-python scripts/setup_companies_table.py  # populate companies with CVM metadata + tickers
-python scripts/expand_tickers.py --dry-run  # discover new B3 tickers
-```
-
-### Batch Data Collection
-
-```bash
-python scripts/batch_completo.py --dry-run           # preview
-python scripts/batch_completo.py --max-companies 450 --start-year 2022 --end-year 2025
-python scripts/atualizar_todos.py --anos 2024 2025   # update specific years only
-```
-
-### Activation
-
-```bash
-.venv\Scripts\activate.bat       # Windows CMD
-.\.venv\Scripts\Activate.ps1     # PowerShell
-```
-
-## Architecture
-
-### Data Pipeline
-
-CVM website → `src/scraper.py` (CVMScraper) → `src/standardizer.py` (AccountStandardizer) → `src/database.py` (CVMDatabase, SQLAlchemy) → SQLite or PostgreSQL → `dashboard/` (Streamlit) or `cvm_pyqt_app.py` (PyQt6)
-
-**`src/` module roles:**
-- `src/utils.py` — `normalize_account_name()` + `generate_line_id_base()` (used throughout)
-- `src/dictionary.py` — builds canonical account dictionary from CVM raw data
-- `src/db.py` — Streamlit-free `get_engine()` factory (2-tier: `DATABASE_URL` env → SQLite); safe to import from CLI scripts and PyQt6
-- `src/query_layer.py` — `CVMQueryLayer` class: all SQL queries for fetching statements (DRE, BPA, BPP, DFC, DVA, DMPL) by company/year/period. **Important**: `get_statement()` applies `fillna("")` on `STANDARD_NAME` before `pivot_table` — pandas silently drops NaN index rows.
-- `src/kpi_engine.py` — `compute_all_kpis()`, `compute_quarterly_kpis()`: 60+ financial indicators (ROE, ROA, margins, solvency, etc.). Outputs include `UNIDADE` column (`"%"` or `"x"`). Quarterly mode trims leading periods where LTM flow KPIs are not computable.
-- `src/ticker_map.py` — B3 ticker ↔ CVM code mapping utilities
-- `src/excel_exporter.py` — Excel report generation with QA logs and validations. KPI sheet has columns: INDICADOR, FÓRMULA, UNIDADE, [periods], Δ YoY, Tendência. Category headers use individual cell writes (no merge_range).
-- `src/statement_summary.py` — condensed multi-block statement builder (DRE, BPA, BPP, DFC). Filters to subtotal/summary `CD_CONTA` codes and optionally expands direct children. Used for high-level views without loading full pivot tables.
-
-### Database
-
-- **Local**: `data/db/cvm_financials.db` (SQLite, WAL mode); `data/cache/base_health_snapshot.json` stores the last base-health check result (committed to git, updated by PyQt6 app)
-- **Production**: PostgreSQL via `DATABASE_URL`
-- Connection fallback order: `DATABASE_URL` → SQLite (in `src/db.py`)
-- Write path lives in `src/database.py`; read/query path lives in `src/query_layer.py`
-- Core table: `financial_reports` (UPPER_CASE columns); metadata tables: `companies`, `account_names` (snake_case)
-- Key column: `LINE_ID_BASE` (never `LINE_ID`)
-
-### Dashboard Modules
-
-`dashboard/app.py` is the slim orchestrator. Current tab structure:
-
-- `dashboard/tabs/visao_geral.py` — KPI summary blocks and quarterly/period views
-- `dashboard/tabs/demonstracoes.py` — Financial statement pivot tables (BPA, BPP, DRE, DFC, DVA, DMPL)
-- `dashboard/tabs/download.py` — Excel export with KPIs
-
-`dashboard/components/search_bar.py` — `render_sidebar()`: company search + year selection widget
-
-**Data flow in app.py:**
-1. `render_sidebar()` → selected company + year range
-2. `CVMQueryLayer` → fetch statements from DB (cached `@st.cache_data` TTL 600s)
-3. `compute_all_kpis()` / `compute_quarterly_kpis()` → KPI DataFrames
-4. Tab renderers consume the precomputed data
-
-> The dashboard is **read-only** — data refresh is handled exclusively by `cvm_pyqt_app.py`. There is no update button in Streamlit.
-
-### PyQt6 Desktop App (`cvm_pyqt_app.py`)
-
-Operational updater GUI. Main moving parts:
-- `IntelligentSelectorService` ranks and prioritizes refresh work
-- `UpdateWorker` builds the company/year plan, runs `CVMScraper`, and syncs `company_refresh_status`
-- The UI exposes company search, year selection, progress tracking, and base-health summaries
-
-### Scraper Core (`src/scraper.py`)
-
-`CVMScraper` is the ingestion entrypoint for both CLI and PyQt flows. Key design choices:
-- Vectorized Pandas (Boolean masks, no row-by-row loops)
-- `ThreadPoolExecutor` for concurrent downloads (`max_workers=5` default)
-- SQLite WAL + `synchronous=OFF` for bulk inserts
-- retry + backoff around company-level DB write failures
-- DFC YTD→standalone conversion (`convert_dfc_ytd_to_standalone`)
-- BPA/BPP closing validation + QA logs per run
-
-### Scripts
-
-Active scripts in `scripts/`. Key ones:
-- `scripts/restaurar_historico.py` — restore historical data
-- `scripts/patch_database_sectors_v2.py` — sector metadata patching
-- `scripts/sync_docs_check.py` — warns when docs are out of sync with code changes
-- `scripts/validation/` — one-off diagnostic scripts (DFC standalone verification, missing quarters, trimestral checks); safe to run as read-only audits
-
-Dead/archived scripts are in `archive/` at the repo root — do not touch those.
-
-**Script convention**: prefer keeping user-tunable values near the top of executable scripts and avoid burying operational constants deep in the logic.
-
-## Critical Conventions
-
-**Numeric types**: Always `int(year)` before using as SQLite param — numpy `int64` causes silent failures.
-
-**yfinance `dividendYield`**: Already in % form — do NOT multiply by 100.
-
-**SQLAlchemy IN clauses**: Use `bindparam("x", expanding=True)` for list parameters.
-
-**B3 API**: `issuingCompany` = 4-letter base code (e.g., `"PETR"`); `codeCVM` = `cd_cvm` from DB.
-
-**`_upsert_company_metadata`**: Uses INSERT OR IGNORE + UPDATE (not REPLACE) to preserve existing CNPJ/ticker data.
-
-**Account normalization**: `normalize_account_name()` → lowercase, remove accents, collapse spaces. `generate_line_id_base()` creates stable IDs from `CD_CONTA` or `DS_CONTA_norm`.
-
-**Streamlit JS injection**: Use `st.components.v1.html()` to embed `<script>` tags — `st.markdown` does not execute JavaScript.
-
-**pandas `pivot_table` and NaN index**: `pd.pivot_table()` silently drops rows where any index column is NaN. Always `fillna("")` on index columns before pivoting. This caused DFC sub-accounts (82% of rows) to disappear when `STANDARD_NAME` was NULL.
-
-**Excel number formats**: Zeros display as `"-"`, negatives as `(1,234)` in red. Format string: `'#,##0;(#,##0);"-"'`. Applied to `subtotal_neg` and `neg_center` styles in `excel_exporter.py`.
-
-**KPI UNIDADE column**: Every KPI row includes `UNIDADE` (`"%"` for percentages, `"x"` for ratios). Propagated through kpi_engine → excel_exporter → dashboard meta_cols.
-
-## Deployment
-
-**Environment variable**: `DATABASE_URL=postgresql://...` (used by scraper, query layer, and dashboard).
-
-**Task Scheduler**: `CVM_Atualizar_Dados` task runs `scripts/atualizar_dados.ps1` every Sunday at 07:00.
-
-## Testing Conventions
-
-- Tests use `unittest.mock.patch` — no real CVM API calls or DB writes
-- Fixtures provide mocked `CVMScraper`, `CVMDatabase`, `AccountStandardizer`
-- `conftest.py` at repo root inserts the project root into `sys.path` (required for `cvm_pyqt_app` imports)
-- Test files: `test_scraper.py`, `test_cvm_pyqt_app.py`, `test_base_health_snapshot.py`, `test_database_portability.py`, `test_excel_exporter.py`, `test_statement_summary.py`, `test_utils.py`
+## Agent Behavior
 
 ### 1. Plan Mode Default
 - Enter plan mode for ANY non-trivial task (3+ steps or architectural decisions)
@@ -284,7 +132,7 @@ Dead/archived scripts are in `archive/` at the repo root — do not touch those.
 ### 5. Demand Elegance (Balanced)
 - For non-trivial changes: pause and ask "is there a more elegant way?"
 - If a fix feels hacky: "Knowing everything I know now, implement the elegant solution"
-- Skip this for simple, chvious fixes — don't over-engineer
+- Skip this for simple, obvious fixes — don't over-engineer
 - Challenge your own work before presenting it
 
 ### 6. Autonomous Bug Fixing
@@ -306,3 +154,12 @@ Dead/archived scripts are in `archive/` at the repo root — do not touch those.
 
 - **Simplicity First**: Make every change as simple as possible. Impact minimal code.
 - **No Laziness**: Find root causes. No temporary fixes. Senior developer standards.
+
+## Context Compaction
+
+When approaching context limits, compress `docs/AGENTS.md` session history: keep the
+"Estado Atual" section accurate and current; reduce fully-adopted governance sessions
+(where rules are already in CLAUDE.md/AGENTS.md) to a single changelog line each.
+Sessions describing active or recent work should remain in full. Binary files, `data/`,
+`archive/`, and `output/` are excluded via `.claudeignore` — do not read or explore them.
+`docs/AGENTS.md` must not exceed 150 lines — compress when it grows past that.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -4,6 +4,7 @@
 > Antes de modificar o codigo, leia `AGENTS.md`, este arquivo e `docs/CONTEXT.md`.
 > Apos concluir, atualize a secao "Estado Atual" e adicione uma entrada de sessao quando fizer sentido.
 > Backlog oficial: `GitHub Issues`. Este arquivo nao e uma lista viva de tarefas.
+> **Limite:** manter abaixo de 150 linhas; comprimir sessoes antigas quando necessario.
 
 ---
 
@@ -12,76 +13,35 @@
 ### Dashboard
 - **3 abas renderizadas** em `dashboard/app.py`: `Visao Geral`, `Demonstracoes`, `Download`
 - `dashboard/app.py` atua como orquestrador read-only
-- `dashboard/components/search_bar.py` controla busca de empresa e selecao de anos
-- `dashboard/tabs/visao_geral.py`, `dashboard/tabs/demonstracoes.py` e `dashboard/tabs/download.py` sao os tabs ativos
-- Atualizacao de dados nao acontece no Streamlit; ela pertence ao app PyQt6 e aos scripts
+- Atualizacao de dados nao acontece no Streamlit; pertence ao app PyQt6 e aos scripts
 
 ### Banco de Dados
 - **449 empresas**, 1,735,340 registros, 2022-2025 (last confirmed)
 - SQLite local: `data/db/cvm_financials.db` (WAL mode)
-- Ticker map central em `src/ticker_map.py`
 - Tabelas: `financial_reports` (UPPER_CASE), `companies`, `account_names` (snake_case)
 
 ### App Desktop
 - `cvm_pyqt_app.py` e a interface operacional principal
 - Ranking inteligente: 40% market cap + 60% liquidez, combinado com desatualizacao
-- Paralelismo configuravel 2-8 workers, barra de progresso total e bloco "Saude da Base"
+- Paralelismo configuravel 2-8 workers
 
 ### V2 Backend
-- `apps/api` existe como a Fase 1 da V2
-- API `FastAPI` read-only, thin wrapper sobre `src/read_service.py`
-- Endpoints iniciais: `health`, `companies`, `companies/filters`, `company detail`, `years`, `statements`, `kpis`, `refresh-status`, `base-health`
+- `apps/api`: API `FastAPI` read-only sobre `src/read_service.py`
+- Endpoints: `health`, `companies`, `companies/filters`, `company detail`, `years`, `statements`, `kpis`, `refresh-status`, `base-health`
 
 ### V2 Web
-- `apps/web` existe como o primeiro slice web da V2
-- Stack: `Next.js 16.2.2` + `App Router` + `TypeScript` + `Tailwind v4` + `@base-ui/react 1.3.0`
-- Sistema de icones: `Material Symbols Outlined` weight 200 (Google Fonts)
-- Biblioteca de componentes: 21st.dev via shadcn CLI (coss.com, reaviz, isaiahbjork, larsen66, moumensoliman)
-- Providers globais: `ThemeProvider` (next-themes) + `TooltipProvider` (radix) em `components/providers.tsx`
-- Rotas de produto: `/`, `/empresas`, `/empresas/[cd_cvm]`
-- Rota de tooling: `/design-system` — showcase de tokens e componentes (24 secoes)
-- Cores chart: OkLch com ~72° de espacamento, chroma real em light e dark mode
-- O frontend consome somente a API V2; nao acessa `src/` nem o banco diretamente
+- `apps/web`: `Next.js 16.2.2` + `App Router` + `TypeScript` + `Tailwind v4` + `@base-ui/react 1.3.0`
+- Icones: `Material Symbols Outlined` weight 200; componentes via 21st.dev shadcn CLI
+- Rotas: `/`, `/empresas`, `/empresas/[cd_cvm]`, `/design-system`
+- Cores chart: OkLch com ~72° espacamento; consome somente API V2
 
 ### Testes
-- `pytest tests/ -q` continua sendo a validacao mais confiavel da V1
-- `pytest apps/api/tests -q` cobre o contrato HTTP da Fase 1 da V2
-- `apps/web` valida com `npm run lint`, `npm run typecheck`, `npm run build` e `npm run test:e2e`
+- `pytest tests/ -q` — V1; `pytest apps/api/tests -q` — V2 API
+- `apps/web`: `npm run lint`, `npm run typecheck`, `npm run build`, `npm run test:e2e`
 
-### Governanca de Trabalho
-- `GitHub Issues` passa a ser a fonte oficial do backlog e do status do trabalho
-- `AGENTS.md` na raiz define o contrato operacional `issue -> branch -> PR -> merge`
-- O repositorio passa a operar com tres lanes oficiais:
-  `lane:frontend`, `lane:backend` e `lane:ops-quality`
-- O repo raiz permanece estavel em `master`; cada task executavel roda em
-  `.claude/worktrees/<lane>/<issue-number>-<slug>/`
-- A regra oficial passa a ser `1 task = 1 owner = 1 branch = 1 worktree = 1 PR`
-- Trabalho paralelo agora e regido por `owner atual`, `write-set esperado` e
-  classificacao `risk:*` declarados em cada task
-- `risk:shared` e `risk:contract-sensitive` exigem PR em draft na abertura
-- Paths sensiveis passam a ser governados por
-  `.github/guardrails/path-policy.json`
-- Interfaces publicas ficam `additive-only` por default durante execucao
-  simultanea
-- Delegacao entre lanes passa a exigir child task formal com `Task mae`,
-  `Lane solicitante`, `Tasks filhas` e `Criterio de consumo`
-- O inicio de cada chat executavel agora exige triagem de tasks abertas da
-  propria lane, child tasks recebidas/solicitadas e PRs abertas aguardando
-  consumo
-- `status:awaiting-consumption` passa a representar task mae entregue por outra
-  lane, mas ainda nao consumida pela lane solicitante
-- O fechamento da task passa a exigir checks verdes e merge confirmado; PR
-  aberta nao conta como concluido
-- PRs do Jules (Google Labs) passam a ter uma excecao controlada `PR-first`,
-  com task retroativa automatica, label `source:jules`, `Source PR` e workspace
-  `jules://github/pr/<numero>`
-- `docs/STUDENT_PACK_PLAN.md` deixa de espelhar task-by-task e passa a apontar para milestone + epics + filtros de issues
-- `docs/AGENTS.md` permanece apenas como estado atual e historico de sessoes
-
-### Pendencias Tecnicas Atuais
-- Validacao contra PostgreSQL real ainda depende de `DATABASE_URL` valido
-- Deploy de preview da V2 ainda nao foi iniciado
-- Streamlit Cloud deploy pendente
+### Pendencias Tecnicas
+- Validacao contra PostgreSQL real pendente (`DATABASE_URL` necessario)
+- Deploy de preview da V2 nao iniciado; Streamlit Cloud pendente
 - P10 (bancos financeiros: Itau, Bradesco) nao iniciado
 
 ---
@@ -95,7 +55,6 @@
 | SQLAlchemy IN clause: `bindparam("x", expanding=True)` | listas como params SQL |
 | `_upsert_company_metadata`: INSERT OR IGNORE + UPDATE | preserva CNPJ/ticker preenchidos por `setup_companies_table` |
 | `st.components.v1.html()` para JS | `st.markdown` nao executa `<script>` |
-| `archive/` na raiz | evita misturar scripts antigos com scripts ativos |
 | `fillna("")` antes de `pivot_table` | evita perda silenciosa de linhas com `STANDARD_NAME` nulo |
 | `apps/api` consome `src/read_service.py` | evita reimplementar SQL e KPI logic no adaptador HTTP |
 
@@ -104,168 +63,41 @@
 ## Sessoes Recentes
 
 ### Sessao 39 - 2026-04-12 (Jules-only intake automatica por GitHub Actions)
-- `jules-pr-governance.yml` deixa de apenas orientar e passa a criar ou
-  reconciliar automaticamente a task retroativa do Jules via `pull_request_target`
-- A identificacao do Jules passa a depender dos marcadores no corpo da PR,
-  com label persistente `source:jules`, sem depender apenas do autor
-- A task retroativa passa a registrar `Source PR`, lane/risco inferidos pelo
-  path policy e write-set reconciliado a cada `synchronize`
-- `PR Issue Guardrails` volta a ser estrito para PRs humanas e ignora PRs do
-  Jules porque a governanca desse caso fica centralizada no workflow dedicado
-- Casos ambiguos, domain mix proibido ou paths nao classificados agora falham
-  com pedido explicito de triagem humana e mantem a PR em draft
+- `jules-pr-governance.yml` passa a criar ou reconciliar automaticamente a task retroativa do Jules via `pull_request_target`
+- Identificacao do Jules depende dos marcadores no corpo da PR + label persistente `source:jules`
+- Task retroativa registra `Source PR`, lane/risco inferidos pelo path policy e write-set reconciliado a cada `synchronize`
+- `PR Issue Guardrails` volta a ser estrito para PRs humanas; ignora PRs do Jules (governanca centralizada no workflow dedicado)
+- Casos ambiguos, domain mix proibido ou paths nao classificados falham com pedido de triagem humana e mantem a PR em draft
 - `scripts/register_jules_pr.ps1` deixa de fazer parte do fluxo oficial
-- A configuracao de governanca passa a versionar o intake do Jules em
-  `.github/guardrails/path-policy.json`
+- Configuracao de governanca do Jules versionada em `.github/guardrails/path-policy.json`
 
 ### Sessao 38 - 2026-04-12 (governanca retroativa para PRs do Jules)
-- Novo workflow dedicado para detectar PRs publicadas pelo Jules e orientar a
-  regularizacao da governanca
-- `PR Issue Guardrails` passa a aceitar `PR-first` somente quando a autoria for
-  do Jules e a issue retroativa estiver vinculada
-- Tasks retroativas do Jules passam a usar `Workspace da task` como
-  `jules://github/pr/<numero-da-pr>` e label `automation:jules`
-- `scripts/register_jules_pr.ps1` passa a criar a task retroativa, inferir
-  lane/risco e atualizar a PR com `Closes #<issue>`
-
-### Sessao 37 - 2026-04-09 (child tasks formais entre lanes)
-- Delegacao entre lanes passa a exigir child task formal em GitHub Issue, nao
-  pedido informal no chat
-- `Task mae`, `Lane solicitante`, `Tasks filhas` e `Criterio de consumo`
-  passam a ser metadados operacionais da governanca
-- A task mae deve ficar `status:blocked` enquanto a child task estiver aberta e
-  `status:awaiting-consumption` ate a lane solicitante consumir a entrega
-- O inicio de cada chat executavel passa a exigir checagem de tasks abertas da
-  propria lane, child tasks recebidas/solicitadas e PRs abertas ligadas a essas
-  issues
-- O template de task e o guardrail da PR passam a suportar child tasks entre
-  lanes
-
-### Sessao 36 - 2026-04-08 (fechamento por checks verdes e merge confirmado)
-- `scripts/pr_complete.ps1` passa a ser o helper recomendado para concluir uma
-  task com PR
-- A governanca passa a exigir checks verdes, merge confirmado, issue fechada e
-  branch remota removida quando aplicavel
-- Templates de task e PR deixam explicito que PR aberta nao significa task
-  concluida
-
-### Sessao 35 - 2026-04-08 (fix no helper de remocao de worktree)
-- `scripts/worktree_remove.ps1` deixa de quebrar quando o merge-check local
-  retorna vazio
-- sem `-Force`, o helper agora orienta atualizar `master` local ou usar
-  `-Force` quando o clone ainda nao enxerga o merge remoto
-
-### Sessao 34 - 2026-04-08 (lanes oficiais, worktrees e critical paths)
-- O repositorio passa a operar com tres lanes oficiais:
-  `lane:frontend`, `lane:backend` e `lane:ops-quality`
-- Toda task executavel passa a exigir `Lane oficial` e `Workspace da task`
-- A regra de execucao vira `1 task = 1 owner = 1 branch = 1 worktree = 1 PR`
-- O repo raiz permanece em `master`; worktrees oficiais vivem em
-  `.claude/worktrees/<lane>/<issue-number>-<slug>/`
-- `.github/guardrails/path-policy.json` passa a versionar `shared-governance`,
-  `critical-bootstrap`, `critical-runtime` e `critical-contract`
-- O guardrail de PR passa a validar lane, workspace, paths criticos, risco
-  minimo, write-set coberto e unicidade de PR por task
-- Scripts `worktree_create.ps1`, `worktree_status.ps1` e
-  `worktree_remove.ps1` passam a apoiar o fluxo local
-
-### Sessao 33 - 2026-04-08 (smoke local da V1 e bootstrap do desktop)
-- `desktop/cvm_pyqt_app.py` passa a inserir a raiz do projeto em `sys.path`,
-  permitindo execucao tanto por `python -m desktop.cvm_pyqt_app` quanto por
-  `python desktop/cvm_pyqt_app.py`
-- `README.md`, `COMO_RODAR.md` e `CLAUDE.md` passam a preferir a execucao por
-  modulo para o app desktop
-- Smoke local revalidado com `runtime_doctor.py`, `smoke_validate.py`,
-  `db_portability_smoke.py --write-check`, desktop em modo offscreen e
-  Streamlit headless com resposta HTTP 200
-- SQLite local confirmado; PostgreSQL real continua pendente por ausencia de
-  `DATABASE_URL`
-
-### Sessao 32 - 2026-04-08 (protocolo de trabalho paralelo agnostico a IA)
-- Nova familia de labels `risk:*` criada no GitHub: `risk:safe`, `risk:shared`,
-  `risk:contract-sensitive`
-- Template de task passa a exigir `Owner atual`, `Write-set esperado` e
-  `Classificacao de risco`
-- PR template passa a registrar risco, write-set e politica de compatibilidade
-- Guardrail de PR passa a validar labels `status:*`, `priority:*`, `area:*`,
-  `risk:*` e a presenca de metadados de ownership/write-set na issue
-- PRs de tasks `risk:shared` e `risk:contract-sensitive` precisam abrir em draft
-- O protocolo passa a ser por task e write-set, nao por identidade da IA
-
-### Sessao 31 - 2026-04-08 (governanca issue-first no GitHub)
-- `AGENTS.md` criado na raiz como contrato operacional para agentes e contribuidores
-- `.github/ISSUE_TEMPLATE/` criado com forms de `epic` e `task`; blank issues desabilitadas
-- `.github/PULL_REQUEST_TEMPLATE.md` criado com referencia obrigatoria a issue
-- `.github/workflows/pr-issue-guardrails.yml` criado para validar branch `task/<issue-number>-<slug>`, `Closes #<issue>` e label `kind:task`
-- `CLAUDE.md` atualizado para abandonar `tasks/todo.md` e seguir fluxo issue-first
-- `docs/STUDENT_PACK_PLAN.md` atualizado para apontar para milestone/epics/tasks do GitHub em vez de espelhar backlog diario
-- Labels operacionais criadas no GitHub: `kind:*`, `status:*`, `priority:*`, `area:*`
-- Triage inicial aplicada aos issues `#2` a `#14`, com `#12` fechado como concluido por evidencia ja entregue
-
-### Sessao 30 - 2026-04-08 (design system + biblioteca de componentes V2 web)
-- `/design-system` criada como showcase de tokens e componentes (24 secoes, sidebar nav)
-- 20+ componentes instalados via 21st.dev shadcn CLI: coss.com (tabs, toolbar, field, textarea, checkbox, accordion, calendar), reaviz (charts), isaiahbjork (3 tabelas), larsen66 (tooltip, toggle-theme, feature-carousel), moumensoliman (delete-button), shadcnspace (switch), easemize (mobile-menu), Shatlyk1011 (animated-dropdown)
-- `@base-ui/react` confirmado como headless primitive; Radix coexiste sem conflito
-- `components/providers.tsx` criado: `ThemeProvider` (next-themes) + `TooltipProvider` (radix)
-- `suppressHydrationWarning` adicionado ao `<html>` para compatibilidade com next-themes SSR
-- Tokens de cor dos charts atualizados para OkLch com hues espacados ~72° e chroma real em dark mode
-- Footer sitemap reestruturado com 4 colunas e link "Design System" em Recursos
-- 8 erros TypeScript corrigidos nos componentes de terceiros instalados
-- Zero erros TypeScript; zero runtime errors no `/design-system`
-
-### Sessao 28 - 2026-04-08 (Fase 1 V2 backend-first)
-- `apps/api` criado como API `FastAPI` read-only em cima de `src/read_service.py`
-- Rotas de Fase 1 entregues: `health`, `companies`, `company detail`, `years`, `statements`, `kpis`, `refresh-status`, `base-health`
-- `apps/api/tests` adicionados para contratos HTTP e serializacao
-- `.github/workflows/ci.yml` criado para rodar V1 + API
-- `docs/V2_PHASE1_BACKEND.md` e `docs/V2_API_CONTRACT.md` criados
-- `docs/WEBAPP_TRANSFORMATION_PLAN.md` refinado para `backend-first`
-
-### Sessao 29 - 2026-04-08 (Fase 2 V2 web slice 1)
-- `apps/web` criado em `Next.js 16` com `App Router`, `TypeScript`, `Tailwind` e `shadcn`
-- Rotas entregues: `/`, `/empresas`, `/empresas/[cd_cvm]`
-- Home recebeu busca principal com autocomplete via route handler interno
-- Hub de empresas recebeu busca, filtro de setor e paginacao orientados por URL
-- Detalhe da empresa recebeu `Visao Geral` e `Demonstracoes` (`DRE`, `BPA`, `BPP`, `DFC`)
-- CI passou a incluir `lint`, `typecheck` e `build` do `apps/web`
-
-### Sessao 27 - 2026-04-07 (roadmap da transformacao web + aprendizado)
-- `docs/WEBAPP_TRANSFORMATION_PLAN.md` criado para registrar a execucao da V1 para a V2
-- O repo passa a registrar explicitamente proposito duplo: sistema operacional atual + trilha de aprendizado por construcao
-- Primeiro slice da V2 documentado como `Next.js` read-only consumindo API `FastAPI` read-only
-- Deploy inicial assumido como gerenciado e separado por camada; `Nginx` segue opcional e tardio
-- `README.md` e `docs/STUDENT_PACK_PLAN.md` atualizados para apontar para o roadmap da transformacao web
-
-### Sessao 26 - 2026-04-07 (ADR da stack V2 com Student Pack)
-- `docs/decisions/0002-student-pack-v2-stack.md` criado para congelar a recomendacao da V2
-- Stack recomendada registrada como `Next.js` + `FastAPI/Uvicorn` + `PostgreSQL` + `Ubuntu Linux`
-- `Nginx` registrado como opcional no inicio, apenas para self-hosting/reverse proxy
-- Correcao documental: evitar citar `Copilot Pro`; usar formulacao neutra `GitHub Copilot` e revalidar o beneficio vigente na pagina oficial
-- `docs/STUDENT_PACK_PLAN.md` atualizado para apontar para o ADR 0002
-
-### Sessao 25 - 2026-04-06 (docs cleanup)
-- `COMO_RODAR.md` e `docs/AGENTS.md` alinhados ao fluxo atual do repo
-- Fluxo principal reforcado como `setup_db.py` -> `setup_companies_table.py` -> `cvm_pyqt_app.py` -> `dashboard/app.py`
-- Estado atual mantido curto e orientado ao que esta realmente ativo hoje
-
-### Sessao 24 - 2026-04-05 (student pack roadmap)
-- `docs/STUDENT_PACK_PLAN.md` criado como documento-base para registrar beneficios do GitHub Student Pack e os proximos 60 dias
-- Roadmap consolidado em produtividade, cloud, observabilidade/qualidade e descoberta da V2
-- Backlog do GitHub planejado em torno de 4 epicos: ativacao do Pack, estabilizacao da stack atual, observabilidade/qualidade e descoberta da V2
-- Milestone `Student Pack 60 dias` criado no GitHub com issues `#2` a `#14` cobrindo epicos e fases do plano
-
-### Sessao 23 - 2026-04-05 (docs alinhados ao estado real)
-- `README.md`, `docs/CONTEXT.md` e `COMO_RODAR.md` atualizados para refletir o fluxo atual
-- `docs/AGENTS.md` atualizado para refletir o dashboard read-only de 3 abas
-- Fluxo principal documentado como `setup_db.py` -> `setup_companies_table.py` -> `cvm_pyqt_app.py` -> `dashboard/app.py`
-- Referencias antigas ao dashboard de 9 abas foram removidas do estado atual
-
-### Sessao 22 - 2026-04-01 (doc-architect overhaul)
-- Full audit + cleanup: ~41 scripts arquivados em `archive/`, `pytest.ini` criado, wrappers legados removidos
-- Docs reorganizados: `CONTEXT.md` consolidado em `docs/CONTEXT.md`; memoria/sessoes consolidadas em `docs/AGENTS.md`; `AUDIT.md` movido para `docs/`
-- Raiz limpa: apenas `README.md`, `CLAUDE.md`, `COMO_RODAR.md` como arquivos `.md` principais
-- `scripts/sync_docs_check.py` criado + lembretes de sincronizacao de docs
+- Workflow dedicado criado para detectar PRs do Jules e orientar regularizacao da governanca
+- `PR Issue Guardrails` aceita `PR-first` somente quando autoria for do Jules e issue retroativa estiver vinculada
+- Tasks retroativas usam `Workspace da task = jules://github/pr/<numero>` e label `automation:jules`
+- `scripts/register_jules_pr.ps1` criado para criar task retroativa e atualizar a PR
 
 ---
 
-> **Historico completo (sessoes 1-21):** consulte `git log --oneline` ou arquivos arquivados em `archive/` se existirem.
+## Changelog de Governanca (sessoes 22-37)
+
+- **S37** 2026-04-09 — child tasks formais entre lanes; `Task mae`, `Lane solicitante`, `Tasks filhas`, `Criterio de consumo`; `status:awaiting-consumption`
+- **S36** 2026-04-08 — `scripts/pr_complete.ps1`; fechamento exige checks verdes + merge confirmado + issue fechada + branch remota removida
+- **S35** 2026-04-08 — fix em `scripts/worktree_remove.ps1` (merge-check local vazio)
+- **S34** 2026-04-08 — tres lanes oficiais; `1 task = 1 owner = 1 branch = 1 worktree = 1 PR`; `path-policy.json`; guardrail de PR; scripts `worktree_*.ps1`
+- **S33** 2026-04-08 — smoke V1 revalidado; `desktop/cvm_pyqt_app.py` via `python -m desktop.cvm_pyqt_app`
+- **S32** 2026-04-08 — labels `risk:*`; template de task com `Owner atual`, `Write-set esperado`, `Classificacao de risco`; PRs `risk:shared`/`risk:contract-sensitive` abrem em draft
+- **S31** 2026-04-08 — `AGENTS.md` na raiz; issue templates; PR template; workflow `pr-issue-guardrails.yml`; labels `kind:*`, `status:*`, `priority:*`, `area:*`
+- **S30** 2026-04-08 — `/design-system` com 24 secoes; 20+ componentes 21st.dev; OkLch chart tokens; `components/providers.tsx`
+- **S29** 2026-04-08 — `apps/web` criado (Next.js 16, App Router, TypeScript, Tailwind, shadcn); rotas `/`, `/empresas`, `/empresas/[cd_cvm]`
+- **S28** 2026-04-08 — `apps/api` criado (FastAPI read-only sobre `src/read_service.py`); `docs/V2_API_CONTRACT.md`; CI atualizado
+- **S27** 2026-04-07 — `docs/WEBAPP_TRANSFORMATION_PLAN.md`; proposito duplo documentado (sistema operacional + trilha de aprendizado)
+- **S26** 2026-04-07 — ADR 0002 (stack V2: Next.js + FastAPI + PostgreSQL)
+- **S25** 2026-04-06 — docs cleanup; alinhamento ao fluxo atual
+- **S24** 2026-04-05 — `docs/STUDENT_PACK_PLAN.md`; milestone `Student Pack 60 dias`
+- **S23** 2026-04-05 — docs alinhados ao estado real; dashboard 3 abas confirmado
+- **S22** 2026-04-01 — doc-architect overhaul; ~41 scripts arquivados; docs reorganizados em `docs/`
+
+---
+
+> **Historico completo (sessoes 1-21):** consulte `git log --oneline`.

--- a/docs/CLAUDE_REFERENCE.md
+++ b/docs/CLAUDE_REFERENCE.md
@@ -1,0 +1,169 @@
+# CLAUDE_REFERENCE.md — On-demand reference for agents
+
+> Load this file when you need commands, architecture details, or conventions for
+> a specific area. It is NOT auto-loaded. Pointer from `CLAUDE.md`.
+
+---
+
+## Commands
+
+### Running the App
+
+```bash
+# Dashboard (Streamlit)
+streamlit run dashboard/app.py
+
+# Desktop GUI (PyQt6 — official; handles data refresh)
+python -m desktop.cvm_pyqt_app
+
+# CLI scraper
+python main.py --companies PETROBRAS --start_year 2021 --end_year 2025 --type consolidated
+```
+
+### Testing
+
+```bash
+pytest tests/ -v                         # all tests
+pytest tests/test_scraper.py -v          # single file
+pytest -k "test_normalize" -v            # by name pattern
+```
+
+Configuration lives in `pytest.ini` at the repo root.
+
+### Database Setup (after clone or migration)
+
+```bash
+python scripts/setup_db.py               # indices + companies/account_names tables
+python scripts/setup_companies_table.py  # populate companies with CVM metadata + tickers
+python scripts/expand_tickers.py --dry-run  # discover new B3 tickers
+```
+
+### Batch Data Collection
+
+```bash
+python scripts/batch_completo.py --dry-run           # preview
+python scripts/batch_completo.py --max-companies 450 --start-year 2022 --end-year 2025
+python scripts/atualizar_todos.py --anos 2024 2025   # update specific years only
+```
+
+### Activation
+
+```bash
+.venv\Scripts\activate.bat       # Windows CMD
+.\.venv\Scripts\Activate.ps1     # PowerShell
+```
+
+---
+
+## Architecture
+
+### Data Pipeline
+
+CVM website → `src/scraper.py` (CVMScraper) → `src/standardizer.py` (AccountStandardizer) → `src/database.py` (CVMDatabase, SQLAlchemy) → SQLite or PostgreSQL → `dashboard/` (Streamlit) or `cvm_pyqt_app.py` (PyQt6)
+
+**`src/` module roles:**
+- `src/utils.py` — `normalize_account_name()` + `generate_line_id_base()` (used throughout)
+- `src/dictionary.py` — builds canonical account dictionary from CVM raw data
+- `src/db.py` — Streamlit-free `get_engine()` factory (2-tier: `DATABASE_URL` env → SQLite); safe to import from CLI scripts and PyQt6
+- `src/query_layer.py` — `CVMQueryLayer` class: all SQL queries for fetching statements (DRE, BPA, BPP, DFC, DVA, DMPL) by company/year/period. **Important**: `get_statement()` applies `fillna("")` on `STANDARD_NAME` before `pivot_table` — pandas silently drops NaN index rows.
+- `src/kpi_engine.py` — `compute_all_kpis()`, `compute_quarterly_kpis()`: 60+ financial indicators (ROE, ROA, margins, solvency, etc.). Outputs include `UNIDADE` column (`"%"` or `"x"`). Quarterly mode trims leading periods where LTM flow KPIs are not computable.
+- `src/ticker_map.py` — B3 ticker ↔ CVM code mapping utilities
+- `src/excel_exporter.py` — Excel report generation with QA logs and validations. KPI sheet has columns: INDICADOR, FÓRMULA, UNIDADE, [periods], Δ YoY, Tendência. Category headers use individual cell writes (no merge_range).
+- `src/statement_summary.py` — condensed multi-block statement builder (DRE, BPA, BPP, DFC). Filters to subtotal/summary `CD_CONTA` codes and optionally expands direct children. Used for high-level views without loading full pivot tables.
+
+### Database
+
+- **Local**: `data/db/cvm_financials.db` (SQLite, WAL mode); `data/cache/base_health_snapshot.json` stores the last base-health check result (committed to git, updated by PyQt6 app)
+- **Production**: PostgreSQL via `DATABASE_URL`
+- Connection fallback order: `DATABASE_URL` → SQLite (in `src/db.py`)
+- Write path lives in `src/database.py`; read/query path lives in `src/query_layer.py`
+- Core table: `financial_reports` (UPPER_CASE columns); metadata tables: `companies`, `account_names` (snake_case)
+- Key column: `LINE_ID_BASE` (never `LINE_ID`)
+
+### Dashboard Modules
+
+`dashboard/app.py` is the slim orchestrator. Current tab structure:
+
+- `dashboard/tabs/visao_geral.py` — KPI summary blocks and quarterly/period views
+- `dashboard/tabs/demonstracoes.py` — Financial statement pivot tables (BPA, BPP, DRE, DFC, DVA, DMPL)
+- `dashboard/tabs/download.py` — Excel export with KPIs
+
+`dashboard/components/search_bar.py` — `render_sidebar()`: company search + year selection widget
+
+**Data flow in app.py:**
+1. `render_sidebar()` → selected company + year range
+2. `CVMQueryLayer` → fetch statements from DB (cached `@st.cache_data` TTL 600s)
+3. `compute_all_kpis()` / `compute_quarterly_kpis()` → KPI DataFrames
+4. Tab renderers consume the precomputed data
+
+> The dashboard is **read-only** — data refresh is handled exclusively by `cvm_pyqt_app.py`. There is no update button in Streamlit.
+
+### PyQt6 Desktop App (`cvm_pyqt_app.py`)
+
+Operational updater GUI. Main moving parts:
+- `IntelligentSelectorService` ranks and prioritizes refresh work
+- `UpdateWorker` builds the company/year plan, runs `CVMScraper`, and syncs `company_refresh_status`
+- The UI exposes company search, year selection, progress tracking, and base-health summaries
+
+### Scraper Core (`src/scraper.py`)
+
+`CVMScraper` is the ingestion entrypoint for both CLI and PyQt flows. Key design choices:
+- Vectorized Pandas (Boolean masks, no row-by-row loops)
+- `ThreadPoolExecutor` for concurrent downloads (`max_workers=5` default)
+- SQLite WAL + `synchronous=OFF` for bulk inserts
+- retry + backoff around company-level DB write failures
+- DFC YTD→standalone conversion (`convert_dfc_ytd_to_standalone`)
+- BPA/BPP closing validation + QA logs per run
+
+### Scripts
+
+Active scripts in `scripts/`. Key ones:
+- `scripts/restaurar_historico.py` — restore historical data
+- `scripts/patch_database_sectors_v2.py` — sector metadata patching
+- `scripts/sync_docs_check.py` — warns when docs are out of sync with code changes
+- `scripts/validation/` — one-off diagnostic scripts (DFC standalone verification, missing quarters, trimestral checks); safe to run as read-only audits
+
+Dead/archived scripts are in `archive/` at the repo root — do not touch those.
+
+**Script convention**: prefer keeping user-tunable values near the top of executable scripts and avoid burying operational constants deep in the logic.
+
+---
+
+## Critical Conventions
+
+**Numeric types**: Always `int(year)` before using as SQLite param — numpy `int64` causes silent failures.
+
+**yfinance `dividendYield`**: Already in % form — do NOT multiply by 100.
+
+**SQLAlchemy IN clauses**: Use `bindparam("x", expanding=True)` for list parameters.
+
+**B3 API**: `issuingCompany` = 4-letter base code (e.g., `"PETR"`); `codeCVM` = `cd_cvm` from DB.
+
+**`_upsert_company_metadata`**: Uses INSERT OR IGNORE + UPDATE (not REPLACE) to preserve existing CNPJ/ticker data.
+
+**Account normalization**: `normalize_account_name()` → lowercase, remove accents, collapse spaces. `generate_line_id_base()` creates stable IDs from `CD_CONTA` or `DS_CONTA_norm`.
+
+**Streamlit JS injection**: Use `st.components.v1.html()` to embed `<script>` tags — `st.markdown` does not execute JavaScript.
+
+**pandas `pivot_table` and NaN index**: `pd.pivot_table()` silently drops rows where any index column is NaN. Always `fillna("")` on index columns before pivoting. This caused DFC sub-accounts (82% of rows) to disappear when `STANDARD_NAME` was NULL.
+
+**Excel number formats**: Zeros display as `"-"`, negatives as `(1,234)` in red. Format string: `'#,##0;(#,##0);"-"'`. Applied to `subtotal_neg` and `neg_center` styles in `excel_exporter.py`.
+
+**KPI UNIDADE column**: Every KPI row includes `UNIDADE` (`"%"` for percentages, `"x"` for ratios). Propagated through kpi_engine → excel_exporter → dashboard meta_cols.
+
+---
+
+## Deployment
+
+**Environment variable**: `DATABASE_URL=postgresql://...` (used by scraper, query layer, and dashboard).
+
+**Task Scheduler**: `CVM_Atualizar_Dados` task runs `scripts/atualizar_dados.ps1` every Sunday at 07:00.
+
+---
+
+## Testing Conventions
+
+- Tests use `unittest.mock.patch` — no real CVM API calls or DB writes
+- Fixtures provide mocked `CVMScraper`, `CVMDatabase`, `AccountStandardizer`
+- `conftest.py` at repo root inserts the project root into `sys.path` (required for `cvm_pyqt_app` imports)
+- Test files: `test_scraper.py`, `test_cvm_pyqt_app.py`, `test_base_health_snapshot.py`, `test_database_portability.py`, `test_excel_exporter.py`, `test_statement_summary.py`, `test_utils.py`


### PR DESCRIPTION
## Summary

- Add `.claudeignore` — prevents agents from exploring `data/`, `archive/`, `output/`, `docs/references/`, and binary files
- Split `CLAUDE.md` 308→165 lines — Commands, Architecture, Conventions moved to `docs/CLAUDE_REFERENCE.md` (on-demand)
- Compress `docs/AGENTS.md` 271→103 lines — sessions 22–37 collapsed to single lines; 150-line cap enforced
- Add Context Compaction rule to `CLAUDE.md`

**Startup load: ~998 lines → ~687 lines (−31%)**

## Risk

`risk:shared` — touches `CLAUDE.md`, `docs/AGENTS.md` (shared-governance). No workflow rules changed; purely structural/size optimization.

## Write-set

`CLAUDE.md`, `docs/AGENTS.md`, `docs/CLAUDE_REFERENCE.md` (new), `.claudeignore` (new)

## Test plan

- [ ] Open a new Claude Code session and confirm `CLAUDE.md` + `AGENTS.md` load correctly
- [ ] Confirm `docs/CLAUDE_REFERENCE.md` is accessible on demand
- [ ] Confirm `.claudeignore` is picked up (agent does not explore `data/` or `archive/`)
- [ ] Confirm `docs/AGENTS.md` is under 150 lines

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)