### PR TITLE
fix(ci): correct branch master→main and wire deploy pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
       - "task/**"
   pull_request:
   merge_group:
@@ -71,7 +71,7 @@ jobs:
           path: coverage.xml
 
       - name: Upload coverage to Codecov
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: codecov/codecov-action@v5
         with:
           files: coverage.xml
@@ -108,22 +108,15 @@ jobs:
 
   deploy-api:
     needs: [test-python]
-    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
-    env:
-      RAILWAY_DEPLOY_HOOK: ${{ secrets.RAILWAY_DEPLOY_HOOK }}
     steps:
-      - name: Skip Railway deploy when hook is missing
-        if: env.RAILWAY_DEPLOY_HOOK == ''
-        run: echo "::warning::RAILWAY_DEPLOY_HOOK is not configured; skipping Railway deploy."
-
-      - name: Trigger Railway deploy
-        if: env.RAILWAY_DEPLOY_HOOK != ''
-        run: curl -fsSL -X POST "$RAILWAY_DEPLOY_HOOK"
+      - name: Railway deploys automatically via GitHub integration
+        run: echo "Railway is connected to this repo and deploys automatically after CI passes."
 
   deploy-web:
     needs: [test-web]
-    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     env:
       VERCEL_DEPLOY_HOOK: ${{ secrets.VERCEL_DEPLOY_HOOK }}

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -39,9 +39,13 @@
 - `pytest tests/ -q` — V1; `pytest apps/api/tests -q` — V2 API
 - `apps/web`: `npm run lint`, `npm run typecheck`, `npm run build`, `npm run test:e2e`
 
+### URLs Publicas
+- **API (Railway):** `https://analisys-production.up.railway.app`
+- **Web (Vercel):** `https://analisys-nine.vercel.app`
+
 ### Pendencias Tecnicas
 - Validacao contra PostgreSQL real pendente (`DATABASE_URL` necessario)
-- Deploy de preview da V2 nao iniciado; Streamlit Cloud pendente
+- Streamlit Cloud pendente
 - P10 (bancos financeiros: Itau, Bradesco) nao iniciado
 
 ---
@@ -108,6 +112,13 @@
 - Merge de 3 PRs do Jules (#23, #25, #29) focadas em performance.
 - Issues retroativas (#24, #26, #30) fechadas automaticamente pelo merge.
 - CI restaurado e validado apos os merges.
+
+### Sessao 46 - 2026-04-15 (deploy pipeline configurado)
+- CI corrigido: branch `master` → `main` em `.github/workflows/ci.yml` (4 ocorrencias).
+- Railway conectado ao GitHub (`main`, Wait for CI ON); `deploy-api` job simplificado.
+- Vercel criado (`analisys-nine.vercel.app`); `VERCEL_DEPLOY_HOOK` configurado no GitHub Secrets.
+- `docs/AGENTS.md` atualizado com URLs publicas da API e Web.
+- Issue #34 fechada via PR.
 
 ### Sessao 45 - 2026-04-15 (context optimizer + clone DB)
 - Agent context optimizer aplicado: startup load reduzido de ~998 para ~687 linhas (-31%).


### PR DESCRIPTION
## Summary
- Fix CI trigger branch: `master` → `main` (CI was never running on the default branch)
- Fix deploy job conditions: all `refs/heads/master` → `refs/heads/main`
- Simplify `deploy-api` job: Railway auto-deploys via GitHub integration (no hook needed)
- `VERCEL_DEPLOY_HOOK` secret configured; `deploy-web` job triggers Vercel on push to `main`
- Document public URLs in `docs/AGENTS.md`:
  - API: `https://analisys-production.up.railway.app`
  - Web: `https://analisys-nine.vercel.app`

## Test plan
- [ ] Push to `main` → CI runs (was silently skipped before)
- [ ] `deploy-api` job passes (Railway auto-deploys after CI)
- [ ] `deploy-web` job triggers Vercel deploy hook
- [ ] Railway and Vercel dashboards confirm deploy

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)