### PR TITLE
[frontend] Deploy Web V2 na Vercel + smoke first wave (#35)

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -76,6 +76,15 @@ npm run test:unit
 npm run test:e2e
 ```
 
+## Deploy remoto
+
+- **Web (Vercel):** https://analisys-nine.vercel.app
+- **API (Railway):** https://analisys-production.up.railway.app
+
+`API_BASE_URL` e definido como variavel de ambiente no projeto Vercel. O deploy
+automatico e acionado via `VERCEL_DEPLOY_HOOK` no CI (`.github/workflows/ci.yml`
+job `deploy-web`) a cada push no `main`.
+
 ## Observacoes
 
 - O app usa Server Components por padrao; `"use client"` fica restrito a interacao e URL state.

--- a/docs/decisions/0004-first-remote-runtime-railway-vercel.md
+++ b/docs/decisions/0004-first-remote-runtime-railway-vercel.md
@@ -72,22 +72,6 @@ Essa decisao deixa explicito o contrato operacional minimo entre as camadas:
 - O fechamento da task de deploy remoto exige URLs publicas, smoke funcional do
   slice web e evidencia de conexao com `PostgreSQL`.
 
-## URLs de producao
-
-| Camada | URL publica |
-|---|---|
-| API (Railway) | https://analisys-production.up.railway.app |
-| Web (Vercel) | https://analisys-nine.vercel.app |
-
-**Smoke confirmado — 2026-04-16**
-- `GET /health` → `{"status":"ok","database_dialect":"postgresql"}` ✅
-- `/` carrega ✅
-- `/empresas` lista empresas ✅
-- `/empresas/[cd_cvm]` abre detalhe ✅
-- Sem erros de CORS ✅
-- `ALLOWED_ORIGINS=https://analisys-nine.vercel.app` configurado no Railway ✅
-- CI secrets `RAILWAY_DEPLOY_HOOK` e `VERCEL_DEPLOY_HOOK` configurados ✅
-
 ## Referencias
 
 - [0002 - Stack recomendada para a V2 com GitHub Student Developer Pack](./0002-student-pack-v2-stack.md)

--- a/docs/decisions/0004-first-remote-runtime-railway-vercel.md
+++ b/docs/decisions/0004-first-remote-runtime-railway-vercel.md
@@ -72,6 +72,22 @@ Essa decisao deixa explicito o contrato operacional minimo entre as camadas:
 - O fechamento da task de deploy remoto exige URLs publicas, smoke funcional do
   slice web e evidencia de conexao com `PostgreSQL`.
 
+## URLs de producao
+
+| Camada | URL publica |
+|---|---|
+| API (Railway) | https://analisys-production.up.railway.app |
+| Web (Vercel) | https://analisys-nine.vercel.app |
+
+**Smoke confirmado — 2026-04-16**
+- `GET /health` → `{"status":"ok","database_dialect":"postgresql"}` ✅
+- `/` carrega ✅
+- `/empresas` lista empresas ✅
+- `/empresas/[cd_cvm]` abre detalhe ✅
+- Sem erros de CORS ✅
+- `ALLOWED_ORIGINS=https://analisys-nine.vercel.app` configurado no Railway ✅
+- CI secrets `RAILWAY_DEPLOY_HOOK` e `VERCEL_DEPLOY_HOOK` configurados ✅
+
 ## Referencias
 
 - [0002 - Stack recomendada para a V2 com GitHub Student Developer Pack](./0002-student-pack-v2-stack.md)


### PR DESCRIPTION
## Summary

- Registers production URLs in ADR 0004 after successful Vercel deployment
- Web: https://analisys-nine.vercel.app
- API: https://analisys-production.up.railway.app
- Smoke confirmed: `/`, `/empresas`, `/empresas/[cd_cvm]` live, no CORS errors
- CI secrets `RAILWAY_DEPLOY_HOOK` and `VERCEL_DEPLOY_HOOK` configured

## Evidence

- Build: `next build` passes cleanly (all 3 routes server-rendered)
- Railway health: `{"status":"ok","database_dialect":"postgresql"}`
- CORS: `ALLOWED_ORIGINS=https://analisys-nine.vercel.app` set on Railway
- Auto-deploy on push to `main` wired via deploy hooks

## Test plan

- [x] Build passes locally (`npm run build` — 0 errors)
- [x] Smoke: `/` loads
- [x] Smoke: `/empresas` lists companies
- [x] Smoke: `/empresas/[cd_cvm]` opens company detail
- [x] No CORS errors in browser console
- [x] ADR 0004 updated with both public URLs

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)