### PR TITLE
fix(ops): harden ingest automation — cron 2x/month, smoke hard-fail, env guard, refresh vars

### DIFF
--- a/.github/workflows/ingest.yml
+++ b/.github/workflows/ingest.yml
@@ -36,8 +36,8 @@ on:
           - "true"
 
   schedule:
-    # Runs on the 28th of every month at 02:00 UTC (covers all months)
-    - cron: "0 2 28 * *"
+    # Runs on the 1st and 15th of every month at 02:00 UTC
+    - cron: "0 2 1,15 * *"
 
 jobs:
   ingest:
@@ -49,6 +49,13 @@ jobs:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
 
     steps:
+      - name: Check DATABASE_URL
+        run: |
+          if [ -z "$DATABASE_URL" ]; then
+            echo "::error::DATABASE_URL secret is not set. Aborting ingestion to avoid writing to an unintended database."
+            exit 1
+          fi
+
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -63,7 +70,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
 
-      - name: Resolve end year
+      - name: Resolve years
         id: years
         run: |
           END_YEAR="${{ github.event.inputs.end_year }}"
@@ -71,6 +78,13 @@ jobs:
             END_YEAR=$(date +%Y)
           fi
           echo "end_year=$END_YEAR" >> "$GITHUB_OUTPUT"
+
+          # Scheduled runs use full history (2010–present); manual dispatch uses the input value
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            echo "start_year=2010" >> "$GITHUB_OUTPUT"
+          else
+            echo "start_year=${{ github.event.inputs.start_year || '2022' }}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Build flags
         id: flags
@@ -92,7 +106,7 @@ jobs:
         run: |
           python scripts/batch_completo.py \
             --max-companies "${{ github.event.inputs.max_companies || '150' }}" \
-            --start-year "${{ github.event.inputs.start_year || '2022' }}" \
+            --start-year "${{ steps.years.outputs.start_year }}" \
             --end-year "${{ steps.years.outputs.end_year }}" \
             ${{ steps.flags.outputs.flags }}
 
@@ -103,7 +117,8 @@ jobs:
             | python -c "import sys,json; print(json.load(sys.stdin)['pagination']['total_items'])")
           echo "companies_in_db=$TOTAL"
           if [ "$TOTAL" -eq 0 ]; then
-            echo "::warning::Ingestion completed but /companies still returns 0 items."
+            echo "::error::Ingestion completed but /companies still returns 0 items. Check DATABASE_URL and pipeline logs."
+            exit 1
           else
             echo "::notice::Database now has $TOTAL companies."
           fi

--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -33,10 +33,23 @@ jobs:
       - name: Criar tabelas (idempotente)
         run: python scripts/setup_db.py
 
+      - name: Resolver anos de refresh
+        id: anos
+        run: |
+          # Use repo variables if defined; fall back to current and previous year
+          CURR="${{ vars.REFRESH_YEAR_CURR }}"
+          PREV="${{ vars.REFRESH_YEAR_PREV }}"
+          if [ -z "$CURR" ]; then
+            CURR=$(date +%Y)
+          fi
+          if [ -z "$PREV" ]; then
+            PREV=$((CURR - 1))
+          fi
+          echo "curr=$CURR" >> "$GITHUB_OUTPUT"
+          echo "prev=$PREV" >> "$GITHUB_OUTPUT"
+
       - name: Executar refresh incremental
-        run: >
-          python scripts/atualizar_todos.py
-          --anos ${{ vars.REFRESH_YEAR_PREV }} ${{ vars.REFRESH_YEAR_CURR }}
+        run: python scripts/atualizar_todos.py --anos ${{ steps.anos.outputs.prev }} ${{ steps.anos.outputs.curr }}
 
       - name: Upload logs em caso de falha
         if: failure()


### PR DESCRIPTION
## Summary

- `ingest.yml`: cron changed to `0 2 1,15 * *` (1st and 15th monthly instead of 28th-only)
- `ingest.yml`: fail-fast step if `DATABASE_URL` secret is unset
- `ingest.yml`: smoke check uses `exit 1` + `::error::` instead of `::warning::` when DB returns 0 items
- `ingest.yml`: scheduled runs use `--start-year 2010` for full historical coverage
- `refresh.yml`: `REFRESH_YEAR_PREV`/`REFRESH_YEAR_CURR` now computed dynamically when repo vars are blank

## Test plan

- [ ] Verify `ingest.yml` cron reads `1,15` in the Actions tab
- [ ] Manually trigger `ingest.yml` workflow_dispatch → confirm it runs through
- [ ] Manually trigger `refresh.yml` workflow_dispatch → confirm year args are non-empty in logs
- [ ] CI tests pass (no schema changes)

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)