### PR TITLE
feat(web): add graceful no-data state for catalog companies

### DIFF
--- a/apps/web/app/empresas/[cd_cvm]/page.tsx
+++ b/apps/web/app/empresas/[cd_cvm]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 
 import { CompanyDetailTracker } from "@/components/company/company-detail-tracker";
 import { CompanyHeader } from "@/components/company/company-header";
+import { CompanyNoDataPage } from "@/components/company/company-no-data";
 import { CompanyOverview } from "@/components/company/company-overview";
 import { CompanyStatements } from "@/components/company/company-statements";
 import { CompanyUrlTabs } from "@/components/company/company-url-tabs";
@@ -127,7 +128,7 @@ export default async function EmpresaDetailPage({
   }
 
   if (availableYears.length === 0) {
-    notFound();
+    return <CompanyNoDataPage company={company} />;
   }
 
   const currentTab = coerceDetailTab(getFirstParam(resolvedSearchParams.aba));

--- a/apps/web/components/companies/company-directory-list.tsx
+++ b/apps/web/components/companies/company-directory-list.tsx
@@ -4,7 +4,7 @@ import { SurfaceCard } from "@/components/shared/design-system-recipes";
 import { Badge } from "@/components/ui/badge";
 import { buttonVariants } from "@/components/ui/button";
 import type { CompanyDirectoryItem } from "@/lib/api";
-import { formatYearsLabel } from "@/lib/formatters";
+import { formatInteger, formatYearsLabel } from "@/lib/formatters";
 import { cn } from "@/lib/utils";
 
 type CompanyDirectoryListProps = {
@@ -33,52 +33,81 @@ export function CompanyDirectoryList({ items }: CompanyDirectoryListProps) {
   return (
     <SurfaceCard tone="default" padding="none" className="overflow-hidden">
       <div className="divide-y divide-border/55">
-        {items.map((item) => (
-          <article
-            key={item.cd_cvm}
-            className="group grid gap-6 px-6 py-6 transition-colors hover:bg-muted/35 md:grid-cols-[minmax(0,1fr)_auto]"
-          >
-            <div className="space-y-4">
-              <div className="flex flex-wrap items-center gap-3">
-                <h2 className="font-heading text-[1.35rem] leading-tight text-foreground">
-                  {item.company_name}
-                </h2>
-                {item.ticker_b3 ? (
+        {items.map((item) => {
+          const hasFinancialData = item.has_financial_data !== false;
+
+          return (
+            <article
+              key={item.cd_cvm}
+              className={cn(
+                "grid gap-6 px-6 py-6 transition-colors md:grid-cols-[minmax(0,1fr)_auto]",
+                hasFinancialData ? "group hover:bg-muted/35" : "bg-background/35",
+              )}
+            >
+              <div className="space-y-4">
+                <div className="flex flex-wrap items-center gap-3">
+                  <h2 className="font-heading text-[1.35rem] leading-tight text-foreground">
+                    {item.company_name}
+                  </h2>
+                  {item.ticker_b3 ? (
+                    <Badge
+                      variant="outline"
+                      className="rounded-full border-border/75 bg-background/70 text-[0.68rem] uppercase tracking-[0.16em] text-muted-foreground"
+                    >
+                      {item.ticker_b3}
+                    </Badge>
+                  ) : null}
                   <Badge
                     variant="outline"
-                    className="rounded-full border-border/75 bg-background/70 text-[0.68rem] uppercase tracking-[0.16em] text-muted-foreground"
+                    className="rounded-full border-border/75 bg-secondary/35 text-[0.72rem] text-foreground"
                   >
-                    {item.ticker_b3}
+                    {item.sector_name}
                   </Badge>
-                ) : null}
-                <Badge
-                  variant="outline"
-                  className="rounded-full border-border/75 bg-secondary/35 text-[0.72rem] text-foreground"
-                >
-                  {item.sector_name}
-                </Badge>
+                  {!hasFinancialData ? (
+                    <Badge
+                      variant="secondary"
+                      className="rounded-full bg-muted text-[0.72rem] text-muted-foreground"
+                    >
+                      Sem dados
+                    </Badge>
+                  ) : null}
+                </div>
+
+                <div className="flex flex-wrap gap-x-5 gap-y-2 text-sm text-muted-foreground">
+                  <span>CVM {item.cd_cvm}</span>
+                  <span>{formatYearsLabel(item.anos_disponiveis)}</span>
+                  <span>
+                    {hasFinancialData ? `${formatInteger(item.total_rows)} linhas` : "-"}
+                  </span>
+                </div>
               </div>
 
-              <div className="flex flex-wrap gap-x-5 gap-y-2 text-sm text-muted-foreground">
-                <span>CVM {item.cd_cvm}</span>
-                <span>{formatYearsLabel(item.anos_disponiveis)}</span>
-                <span>{item.total_rows.toLocaleString("pt-BR")} linhas</span>
-              </div>
-            </div>
-
-            <div className="flex items-center md:justify-end">
-              <Link
-                href={`/empresas/${item.cd_cvm}`}
-                className={cn(
-                  buttonVariants({ variant: "outline", size: "lg" }),
-                  "rounded-full px-5 transition-transform group-hover:-translate-y-px",
+              <div className="flex items-center md:justify-end">
+                {hasFinancialData ? (
+                  <Link
+                    href={`/empresas/${item.cd_cvm}`}
+                    className={cn(
+                      buttonVariants({ variant: "outline", size: "lg" }),
+                      "rounded-full px-5 transition-transform group-hover:-translate-y-px",
+                    )}
+                  >
+                    Ver empresa
+                  </Link>
+                ) : (
+                  <span
+                    aria-disabled="true"
+                    className={cn(
+                      buttonVariants({ variant: "ghost", size: "lg" }),
+                      "pointer-events-none rounded-full px-5 text-muted-foreground opacity-70",
+                    )}
+                  >
+                    Ver empresa
+                  </span>
                 )}
-              >
-                Ver empresa
-              </Link>
-            </div>
-          </article>
-        ))}
+              </div>
+            </article>
+          );
+        })}
       </div>
     </SurfaceCard>
   );

--- a/apps/web/components/company/company-no-data.tsx
+++ b/apps/web/components/company/company-no-data.tsx
@@ -1,0 +1,117 @@
+import Link from "next/link";
+import { ChevronRightIcon } from "lucide-react";
+
+import {
+  InfoChip,
+  PageShell,
+  SectionHeading,
+  SurfaceCard,
+} from "@/components/shared/design-system-recipes";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button, buttonVariants } from "@/components/ui/button";
+import type { CompanyInfo } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+type CompanyNoDataPageProps = {
+  company: CompanyInfo;
+};
+
+type CompanyMetaCardProps = {
+  label: string;
+  value: string;
+};
+
+function CompanyMetaCard({ label, value }: CompanyMetaCardProps) {
+  return (
+    <SurfaceCard tone="inset" padding="md" className="flex flex-col gap-1.5">
+      <p className="text-xs uppercase tracking-[0.24em] text-muted-foreground">
+        {label}
+      </p>
+      <p className="text-sm font-medium text-foreground">{value}</p>
+    </SurfaceCard>
+  );
+}
+
+export function CompanyNoDataPage({ company }: CompanyNoDataPageProps) {
+  const sectorLabel =
+    company.sector_name || company.setor_analitico || company.setor_cvm || "Setor nao informado";
+
+  return (
+    <PageShell density="relaxed" className="max-w-5xl">
+      <div className="space-y-5">
+        <nav aria-label="breadcrumb">
+          <ol className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+            <li>
+              <Link href="/" className="hover:text-foreground">
+                Home
+              </Link>
+            </li>
+            <li className="flex items-center gap-2">
+              <ChevronRightIcon className="size-4" />
+              <Link href="/empresas" className="hover:text-foreground">
+                Empresas
+              </Link>
+            </li>
+            <li className="flex items-center gap-2 text-foreground">
+              <ChevronRightIcon className="size-4 text-muted-foreground" />
+              <span>{company.company_name}</span>
+            </li>
+          </ol>
+        </nav>
+
+        <SurfaceCard tone="hero" padding="hero" className="space-y-8">
+          <div className="flex flex-wrap items-center gap-3">
+            <InfoChip tone="brand">PG-03 - Detalhe da empresa</InfoChip>
+            <InfoChip>CVM {company.cd_cvm}</InfoChip>
+            {company.ticker_b3 ? <InfoChip tone="muted">{company.ticker_b3}</InfoChip> : null}
+          </div>
+
+          <SectionHeading
+            eyebrow="Dados historicos indisponiveis"
+            title={company.company_name}
+            titleAs="h1"
+            description="O cadastro desta companhia esta disponivel, mas ainda nao existem demonstracoes financeiras processadas para liberar a leitura detalhada."
+            descriptionClassName="max-w-3xl"
+          />
+
+          <div className="grid gap-4 md:grid-cols-3">
+            <CompanyMetaCard label="Setor" value={sectorLabel} />
+            <CompanyMetaCard label="CNPJ" value={company.cnpj ?? "Nao informado"} />
+            <CompanyMetaCard
+              label="Ticker B3"
+              value={company.ticker_b3 ?? "Sem ticker"}
+            />
+          </div>
+
+          <Alert className="rounded-[1.75rem] border border-border/70 bg-muted/28 px-5 py-5">
+            <AlertTitle>Dados historicos nao disponiveis</AlertTitle>
+            <AlertDescription>
+              Esta empresa ainda nao possui anos anuais processados para exibir
+              KPIs, demonstracoes financeiras ou exportacao em Excel nesta tela.
+            </AlertDescription>
+          </Alert>
+
+          <div className="flex flex-wrap gap-3">
+            <Button
+              variant="outline"
+              size="lg"
+              className="rounded-full px-5"
+              disabled
+            >
+              Solicitar dados financeiros
+            </Button>
+            <Link
+              href="/empresas"
+              className={cn(
+                buttonVariants({ variant: "ghost", size: "lg" }),
+                "rounded-full px-5",
+              )}
+            >
+              Voltar para o diretorio
+            </Link>
+          </div>
+        </SurfaceCard>
+      </div>
+    </PageShell>
+  );
+}

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -15,6 +15,8 @@ export type CompanyDirectoryItem = {
   setor_cvm: string | null;
   sector_name: string;
   sector_slug: string;
+  has_financial_data: boolean;
+  coverage_rank: number | null;
   anos_disponiveis: number[];
   total_rows: number;
 };


### PR DESCRIPTION
## What changed
- added `has_financial_data` and `coverage_rank` to the web directory item contract
- updated `/empresas` cards to distinguish catalog-only companies with a `Sem dados` badge and a non-navigable CTA
- replaced the company detail `notFound()` fallback with a dedicated `CompanyNoDataPage` when the company exists but has no available years
- added a server-side no-data state component with company metadata and a placeholder refresh CTA for FE-2

## Why
The frontend needs to keep catalog-only companies visible without crashing or routing users into a 404 when financial history has not been processed yet.

## Impact
- companies with data keep the current navigation flow
- catalog-only companies get a graceful no-data state instead of a hard failure
- FE-2 can now activate the placeholder CTA without redesigning this page shell

## Validation
- `npm run build`
- `npm run lint -- .` (warnings only, all pre-existing outside this write-set)

## Dependency note
- backend dependency `#54` is already merged into `main`

Closes #56