### PR TITLE
feat(backend): LEFT JOIN + has_financial_data flag — all companies visible in directory

### DIFF
--- a/apps/api/app/presenters.py
+++ b/apps/api/app/presenters.py
@@ -56,6 +56,8 @@ class CompanySearchResultPayload(BaseModel):
     sector_slug: str
     anos_disponiveis: list[int]
     total_rows: int
+    has_financial_data: bool
+    coverage_rank: int | None = None
 
 
 class CompanyInfoPayload(BaseModel):

--- a/apps/api/tests/test_api_contract.py
+++ b/apps/api/tests/test_api_contract.py
@@ -28,15 +28,19 @@ def test_companies_empty_search_returns_paginated_directory(client: TestClient):
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["pagination"]["total_items"] == 3
+    assert payload["pagination"]["total_items"] == 4
     assert payload["pagination"]["page"] == 1
     assert payload["pagination"]["page_size"] == 20
     assert payload["items"][0]["company_name"] == "PETROBRAS"
     assert payload["items"][0]["anos_disponiveis"] == [2023, 2024]
     assert payload["items"][0]["sector_name"] == "Energia"
     assert payload["items"][0]["sector_slug"] == "energia"
+    assert payload["items"][0]["has_financial_data"] is True
     returned_names = [item["company_name"] for item in payload["items"]]
-    assert "SEM DADOS" not in returned_names
+    assert "SEM DADOS" in returned_names
+    sem_dados = next(i for i in payload["items"] if i["company_name"] == "SEM DADOS")
+    assert sem_dados["has_financial_data"] is False
+    assert sem_dados["anos_disponiveis"] == []
 
 
 def test_companies_search_filters_results(client: TestClient):
@@ -57,8 +61,8 @@ def test_companies_pagination_respects_page_and_page_size(client: TestClient):
     assert payload["pagination"] == {
         "page": 2,
         "page_size": 1,
-        "total_items": 3,
-        "total_pages": 3,
+        "total_items": 4,
+        "total_pages": 4,
         "has_next": True,
         "has_previous": True,
     }
@@ -101,6 +105,7 @@ def test_companies_filters_returns_canonical_sector_options(client: TestClient):
     payload = response.json()
     assert payload["sectors"] == [
         {"sector_name": "Energia", "sector_slug": "energia", "company_count": 1},
+        {"sector_name": "Financeiro", "sector_slug": "financeiro", "company_count": 1},
         {"sector_name": "Materiais Basicos", "sector_slug": "materiais-basicos", "company_count": 1},
         {"sector_name": "Saneamento", "sector_slug": "saneamento", "company_count": 1},
     ]

--- a/apps/api/tests/test_presenters.py
+++ b/apps/api/tests/test_presenters.py
@@ -36,15 +36,17 @@ def test_presenters_serialize_dtos_without_raw_pandas_objects():
         [
             CompanySearchResult(
                 cd_cvm=9512,
-            company_name="PETROBRAS",
-            ticker_b3="PETR4",
-            setor_analitico="Energia",
-            setor_cvm="Energia",
-            sector_name="Energia",
-            sector_slug="energia",
-            anos_disponiveis=(2023, 2024),
-            total_rows=30,
-        )
+                company_name="PETROBRAS",
+                ticker_b3="PETR4",
+                setor_analitico="Energia",
+                setor_cvm="Energia",
+                sector_name="Energia",
+                sector_slug="energia",
+                anos_disponiveis=(2023, 2024),
+                total_rows=30,
+                has_financial_data=True,
+                coverage_rank=1,
+            )
         ]
     )[0]
     assert company_search.anos_disponiveis == [2023, 2024]
@@ -79,6 +81,8 @@ def test_presenters_serialize_dtos_without_raw_pandas_objects():
                     sector_slug="energia",
                     anos_disponiveis=(2023, 2024),
                     total_rows=30,
+                    has_financial_data=True,
+                    coverage_rank=1,
                 ),
             ),
             pagination=CompanyDirectoryPagination(

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -17,8 +17,6 @@ export type CompanyDirectoryItem = {
   sector_slug: string;
   anos_disponiveis: number[];
   total_rows: number;
-  has_financial_data: boolean;
-  coverage_rank: number | null;
 };
 
 export type CompanyDirectoryPage = {

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -17,6 +17,8 @@ export type CompanyDirectoryItem = {
   sector_slug: string;
   anos_disponiveis: number[];
   total_rows: number;
+  has_financial_data: boolean;
+  coverage_rank: number | null;
 };
 
 export type CompanyDirectoryPage = {

--- a/src/contracts.py
+++ b/src/contracts.py
@@ -148,6 +148,8 @@ class CompanySearchResult:
     sector_slug: str
     anos_disponiveis: tuple[int, ...]
     total_rows: int
+    has_financial_data: bool
+    coverage_rank: int | None
 
     def to_dict(self) -> dict[str, Any]:
         payload = asdict(self)

--- a/src/query_layer.py
+++ b/src/query_layer.py
@@ -102,7 +102,7 @@ class CVMQueryLayer:
             FROM (
                 SELECT c.cd_cvm
                 FROM companies c
-                JOIN financial_reports fr ON fr."CD_CVM" = c.cd_cvm
+                LEFT JOIN financial_reports fr ON fr."CD_CVM" = c.cd_cvm
                 WHERE {where_sql}
                 GROUP BY c.cd_cvm, c.company_name, c.ticker_b3, c.setor_analitico, c.setor_cvm
             ) company_rows
@@ -126,11 +126,13 @@ class CVMQueryLayer:
                 c.setor_analitico,
                 c.setor_cvm,
                 {_CANONICAL_SECTOR_SQL} AS sector_name,
-                COUNT(*) AS total_rows
+                COALESCE(COUNT(fr."CD_CVM"), 0) AS total_rows,
+                CASE WHEN COUNT(fr."CD_CVM") > 0 THEN 1 ELSE 0 END AS has_financial_data,
+                c.coverage_rank
             FROM companies c
-            JOIN financial_reports fr ON fr."CD_CVM" = c.cd_cvm
+            LEFT JOIN financial_reports fr ON fr."CD_CVM" = c.cd_cvm
             WHERE {where_sql}
-            GROUP BY c.cd_cvm, c.company_name, c.ticker_b3, c.setor_analitico, c.setor_cvm
+            GROUP BY c.cd_cvm, c.company_name, c.ticker_b3, c.setor_analitico, c.setor_cvm, c.coverage_rank
             ORDER BY c.company_name ASC
             {paging_sql}
             """
@@ -145,7 +147,7 @@ class CVMQueryLayer:
                 {_CANONICAL_SECTOR_SQL} AS sector_name,
                 COUNT(DISTINCT c.cd_cvm) AS company_count
             FROM companies c
-            JOIN financial_reports fr ON fr."CD_CVM" = c.cd_cvm
+            LEFT JOIN financial_reports fr ON fr."CD_CVM" = c.cd_cvm
             GROUP BY {_CANONICAL_SECTOR_SQL}
             ORDER BY sector_name ASC
             """

--- a/src/read_service.py
+++ b/src/read_service.py
@@ -182,6 +182,9 @@ class CVMReadService:
                 ]
                 snapshot_row = filtered.iloc[0] if not filtered.empty else None
 
+            if latest_year is None:
+                continue
+
             items.append(
                 SectorDirectoryItemDTO(
                     sector_name=sector_name,
@@ -486,6 +489,7 @@ class CVMReadService:
             setor_cvm = self._clean_optional_text(row.get("setor_cvm"))
             raw_sector_name = self._clean_optional_text(row.get("sector_name"))
             sector_name = raw_sector_name or canonical_sector_name(setor_analitico, setor_cvm)
+            raw_coverage_rank = row.get("coverage_rank")
             results.append(
                 CompanySearchResult(
                     cd_cvm=int(row["cd_cvm"]),
@@ -497,6 +501,8 @@ class CVMReadService:
                     sector_slug=sector_slugify(sector_name),
                     anos_disponiveis=_parse_years(row.get("anos_disponiveis")),
                     total_rows=int(row.get("total_rows") or 0),
+                    has_financial_data=bool(int(row.get("has_financial_data") or 0)),
+                    coverage_rank=int(raw_coverage_rank) if raw_coverage_rank is not None and str(raw_coverage_rank) != "nan" else None,
                 )
             )
         return results

--- a/tests/test_read_service.py
+++ b/tests/test_read_service.py
@@ -73,6 +73,7 @@ def _seed_sector_read_service(tmp_path):
                 setor_analitico TEXT,
                 company_type TEXT,
                 ticker_b3 TEXT,
+                coverage_rank INTEGER,
                 is_active INTEGER,
                 updated_at TEXT
             )
@@ -99,12 +100,12 @@ def _seed_sector_read_service(tmp_path):
             """
             INSERT INTO companies (
                 cd_cvm, company_name, nome_comercial, cnpj,
-                setor_cvm, setor_analitico, company_type, ticker_b3, is_active, updated_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                setor_cvm, setor_analitico, company_type, ticker_b3, coverage_rank, is_active, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             [
-                (9512, "PETROBRAS", "Petrobras", "33", "Energia", "Energia", "comercial", "PETR4", 1, "2026"),
-                (11223, "SABESP", "Sabesp", "43", "Saneamento", None, "comercial", "SBSP3", 1, "2026"),
+                (9512, "PETROBRAS", "Petrobras", "33", "Energia", "Energia", "comercial", "PETR4", 1, 1, "2026"),
+                (11223, "SABESP", "Sabesp", "43", "Saneamento", None, "comercial", "SBSP3", 3, 1, "2026"),
             ],
         )
         conn.executemany(


### PR DESCRIPTION
## Summary
- Switch `get_companies_directory_page()` and `get_available_company_sectors()` from INNER JOIN to LEFT JOIN on `financial_reports`, so all 600+ companies appear in the directory even without financial data
- Add `has_financial_data: bool` and `coverage_rank: int | None` to `CompanySearchResult`, `CompanySearchResultPayload`, and `CompanyDirectoryItem`
- `list_sectors()` skips sectors where no financial data exists, keeping the analysis view clean
- Update test fixtures and contract assertions to reflect the new behavior (SEM DADOS now appears; Financeiro sector appears in filters)

## Test plan
- [ ] `python -m pytest tests/ apps/api/tests/ -q` — 194 passed ✅
- [ ] `GET /companies` returns all 4 seed companies (incl. SEM DADOS with `has_financial_data: false`)
- [ ] `GET /companies/filters` returns 4 sectors (incl. Financeiro)
- [ ] `GET /sectors` still shows only 3 sectors (Financeiro excluded — no financial data)

## Compatibilidade
additive-only — novos campos opcionais adicionados ao payload existente; nenhuma campo removido ou renomeado.

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)