### PR TITLE
feat(web): add on-demand refresh polling for company no-data state

### DIFF
--- a/apps/web/app/api/refresh-status/[cd_cvm]/route.ts
+++ b/apps/web/app/api/refresh-status/[cd_cvm]/route.ts
@@ -1,0 +1,136 @@
+import { NextResponse } from "next/server";
+
+import { buildApiUrl } from "@/lib/api";
+
+type RefreshStatusRouteProps = {
+  params: Promise<{ cd_cvm: string }>;
+};
+
+type ProxyErrorPayload = {
+  error?: {
+    code?: string;
+    message?: string;
+  };
+  detail?:
+    | {
+        code?: string;
+        message?: string;
+      }
+    | string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function buildProxyErrorResponse(
+  status: number,
+  payload: ProxyErrorPayload | null,
+  fallbackMessage: string,
+) {
+  const detailCode =
+    isRecord(payload?.detail) && typeof payload.detail.code === "string"
+      ? payload.detail.code
+      : undefined;
+  const detailMessage =
+    isRecord(payload?.detail) && typeof payload.detail.message === "string"
+      ? payload.detail.message
+      : typeof payload?.detail === "string"
+        ? payload.detail
+        : undefined;
+  const code = payload?.error?.code ?? detailCode ?? "unknown_error";
+  const message = payload?.error?.message ?? detailMessage ?? fallbackMessage;
+
+  return NextResponse.json(
+    {
+      error: {
+        code,
+        message,
+      },
+    },
+    {
+      status,
+      headers: {
+        "cache-control": "no-store",
+      },
+    },
+  );
+}
+
+export async function GET(_: Request, { params }: RefreshStatusRouteProps) {
+  const { cd_cvm } = await params;
+
+  let upstream: Response;
+
+  try {
+    upstream = await fetch(
+      buildApiUrl(`/refresh-status?cd_cvm=${encodeURIComponent(cd_cvm)}`),
+      {
+        cache: "no-store",
+        headers: {
+          Accept: "application/json",
+        },
+      },
+    );
+  } catch {
+    return NextResponse.json(
+      {
+        error: {
+          code: "network_error",
+          message: "Nao foi possivel conectar a API da V2.",
+        },
+      },
+      {
+        status: 503,
+        headers: {
+          "cache-control": "no-store",
+        },
+      },
+    );
+  }
+
+  if (!upstream.ok) {
+    let payload: ProxyErrorPayload | null = null;
+
+    try {
+      payload = (await upstream.json()) as ProxyErrorPayload;
+    } catch {
+      payload = null;
+    }
+
+    const fallbackMessage =
+      upstream.status >= 500
+        ? "A API da V2 nao conseguiu consultar o status do refresh agora."
+        : "Nao foi possivel consultar o andamento desta solicitacao.";
+
+    return buildProxyErrorResponse(upstream.status, payload, fallbackMessage);
+  }
+
+  let payload: unknown;
+
+  try {
+    payload = await upstream.json();
+  } catch {
+    return NextResponse.json(
+      {
+        error: {
+          code: "invalid_response",
+          message: "A API da V2 retornou um corpo invalido para o status do refresh.",
+        },
+      },
+      {
+        status: 502,
+        headers: {
+          "cache-control": "no-store",
+        },
+      },
+    );
+  }
+
+  return NextResponse.json(payload, {
+    status: upstream.status,
+    headers: {
+      "cache-control": "no-store",
+    },
+  });
+}

--- a/apps/web/app/api/request-refresh/[cd_cvm]/route.ts
+++ b/apps/web/app/api/request-refresh/[cd_cvm]/route.ts
@@ -1,0 +1,136 @@
+import { NextResponse } from "next/server";
+
+import { buildApiUrl } from "@/lib/api";
+
+type RequestRefreshRouteProps = {
+  params: Promise<{ cd_cvm: string }>;
+};
+
+type ProxyErrorPayload = {
+  error?: {
+    code?: string;
+    message?: string;
+  };
+  detail?:
+    | {
+        code?: string;
+        message?: string;
+      }
+    | string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function buildProxyErrorResponse(
+  status: number,
+  payload: ProxyErrorPayload | null,
+  fallbackMessage: string,
+) {
+  const detailCode =
+    isRecord(payload?.detail) && typeof payload.detail.code === "string"
+      ? payload.detail.code
+      : undefined;
+  const detailMessage =
+    isRecord(payload?.detail) && typeof payload.detail.message === "string"
+      ? payload.detail.message
+      : typeof payload?.detail === "string"
+        ? payload.detail
+        : undefined;
+  const code = payload?.error?.code ?? detailCode ?? "unknown_error";
+  const message = payload?.error?.message ?? detailMessage ?? fallbackMessage;
+
+  return NextResponse.json(
+    {
+      error: {
+        code,
+        message,
+      },
+    },
+    {
+      status,
+      headers: {
+        "cache-control": "no-store",
+      },
+    },
+  );
+}
+
+export async function POST(_: Request, { params }: RequestRefreshRouteProps) {
+  const { cd_cvm } = await params;
+
+  let upstream: Response;
+
+  try {
+    upstream = await fetch(buildApiUrl(`/companies/${cd_cvm}/request-refresh`), {
+      method: "POST",
+      cache: "no-store",
+      headers: {
+        Accept: "application/json",
+      },
+    });
+  } catch {
+    return NextResponse.json(
+      {
+        error: {
+          code: "network_error",
+          message: "Nao foi possivel conectar a API da V2.",
+        },
+      },
+      {
+        status: 503,
+        headers: {
+          "cache-control": "no-store",
+        },
+      },
+    );
+  }
+
+  if (!upstream.ok) {
+    let payload: ProxyErrorPayload | null = null;
+
+    try {
+      payload = (await upstream.json()) as ProxyErrorPayload;
+    } catch {
+      payload = null;
+    }
+
+    const fallbackMessage =
+      upstream.status === 429
+        ? "Solicitacao ja em andamento."
+        : upstream.status >= 500
+          ? "A API da V2 nao conseguiu disparar o refresh agora."
+          : "Nao foi possivel solicitar os dados financeiros desta companhia.";
+
+    return buildProxyErrorResponse(upstream.status, payload, fallbackMessage);
+  }
+
+  let payload: unknown;
+
+  try {
+    payload = await upstream.json();
+  } catch {
+    return NextResponse.json(
+      {
+        error: {
+          code: "invalid_response",
+          message: "A API da V2 retornou um corpo invalido para o dispatch on-demand.",
+        },
+      },
+      {
+        status: 502,
+        headers: {
+          "cache-control": "no-store",
+        },
+      },
+    );
+  }
+
+  return NextResponse.json(payload, {
+    status: upstream.status,
+    headers: {
+      "cache-control": "no-store",
+    },
+  });
+}

--- a/apps/web/components/company/company-no-data.tsx
+++ b/apps/web/components/company/company-no-data.tsx
@@ -7,8 +7,9 @@ import {
   SectionHeading,
   SurfaceCard,
 } from "@/components/shared/design-system-recipes";
+import { CompanyRequestRefresh } from "@/components/company/company-request-refresh";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { Button, buttonVariants } from "@/components/ui/button";
+import { buttonVariants } from "@/components/ui/button";
 import type { CompanyInfo } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
@@ -91,15 +92,8 @@ export function CompanyNoDataPage({ company }: CompanyNoDataPageProps) {
             </AlertDescription>
           </Alert>
 
-          <div className="flex flex-wrap gap-3">
-            <Button
-              variant="outline"
-              size="lg"
-              className="rounded-full px-5"
-              disabled
-            >
-              Solicitar dados financeiros
-            </Button>
+          <div className="flex flex-wrap items-start gap-3">
+            <CompanyRequestRefresh cdCvm={company.cd_cvm} />
             <Link
               href="/empresas"
               className={cn(

--- a/apps/web/components/company/company-request-refresh.tsx
+++ b/apps/web/components/company/company-request-refresh.tsx
@@ -1,0 +1,292 @@
+"use client";
+
+import { LoaderCircleIcon, RotateCcwIcon } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import {
+  type RefreshStatusItem,
+  fetchRefreshStatus,
+  fetchRequestRefresh,
+  getUserFacingErrorMessage,
+  isApiClientError,
+} from "@/lib/api";
+
+type CompanyRequestRefreshProps = {
+  cdCvm: number;
+};
+
+type RefreshPhase =
+  | "idle"
+  | "submitting"
+  | "polling"
+  | "success"
+  | "error"
+  | "timeout";
+
+type RefreshState = {
+  phase: RefreshPhase;
+  message?: string;
+  detail?: string;
+  startedAt?: number;
+};
+
+const POLL_INTERVAL_MS = 10_000;
+const POLL_TIMEOUT_MS = 15 * 60 * 1_000;
+const RELOAD_DELAY_MS = 1_200;
+
+function getPollingCopy(item: RefreshStatusItem | undefined): {
+  message: string;
+  detail?: string;
+} {
+  switch (item?.last_status) {
+    case "queued":
+      return {
+        message: "Solicitacao enviada. Aguardando processamento...",
+        detail: "Acompanhando a fila atual da ingestao on-demand.",
+      };
+    case "running":
+      return {
+        message: "Atualizando demonstracoes financeiras...",
+        detail: "Os dados desta companhia estao sendo processados agora.",
+      };
+    default:
+      return {
+        message: "Acompanhando o processamento atual...",
+        detail: "A pagina sera recarregada assim que os dados ficarem disponiveis.",
+      };
+  }
+}
+
+export function CompanyRequestRefresh({
+  cdCvm,
+}: CompanyRequestRefreshProps) {
+  const [state, setState] = useState<RefreshState>({ phase: "idle" });
+  const reloadTimerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (reloadTimerRef.current !== null) {
+        window.clearTimeout(reloadTimerRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (state.phase !== "polling" || state.startedAt === undefined) {
+      return;
+    }
+
+    const pollingStartedAt = state.startedAt;
+    let active = true;
+
+    async function pollRefreshStatus() {
+      if (!active) {
+        return;
+      }
+
+      if (Date.now() - pollingStartedAt >= POLL_TIMEOUT_MS) {
+        setState({
+          phase: "timeout",
+          message: "O processamento ainda nao terminou.",
+          detail:
+            "Voce pode tentar novamente para reiniciar o acompanhamento desta empresa.",
+        });
+        return;
+      }
+
+      try {
+        const items = await fetchRefreshStatus(cdCvm);
+
+        if (!active) {
+          return;
+        }
+
+        const currentItem = items[0];
+        const currentStatus = currentItem?.last_status;
+
+        if (currentStatus === "success") {
+          setState({
+            phase: "success",
+            message: "Dados disponiveis! Recarregando...",
+            detail: "A leitura detalhada desta empresa sera atualizada agora.",
+          });
+          reloadTimerRef.current = window.setTimeout(() => {
+            window.location.reload();
+          }, RELOAD_DELAY_MS);
+          return;
+        }
+
+        if (currentStatus === "error" || currentStatus === "dispatch_failed") {
+          setState({
+            phase: "error",
+            message:
+              currentItem?.last_error ??
+              "Nao foi possivel concluir a atualizacao desta empresa.",
+            detail:
+              "A solicitacao foi encerrada com falha. Tente novamente em instantes.",
+          });
+          return;
+        }
+
+        const copy = getPollingCopy(currentItem);
+        setState((currentState) =>
+          currentState.phase === "polling"
+            ? {
+                ...currentState,
+                message: copy.message,
+                detail: copy.detail,
+              }
+            : currentState,
+        );
+      } catch (error) {
+        if (!active) {
+          return;
+        }
+
+        setState({
+          phase: "error",
+          message: getUserFacingErrorMessage(error),
+          detail:
+            "O acompanhamento do refresh foi interrompido. Tente novamente em instantes.",
+        });
+      }
+    }
+
+    void pollRefreshStatus();
+
+    const intervalId = window.setInterval(() => {
+      void pollRefreshStatus();
+    }, POLL_INTERVAL_MS);
+
+    return () => {
+      active = false;
+      window.clearInterval(intervalId);
+    };
+  }, [cdCvm, state.phase, state.startedAt]);
+
+  async function handleRequestRefresh() {
+    if (state.phase === "submitting" || state.phase === "polling" || state.phase === "success") {
+      return;
+    }
+
+    setState({
+      phase: "submitting",
+      message: "Solicitando atualizacao...",
+      detail: "Preparando o disparo on-demand desta companhia.",
+    });
+
+    try {
+      const payload = await fetchRequestRefresh(cdCvm);
+      setState({
+        phase: "polling",
+        startedAt: Date.now(),
+        message:
+          payload.status === "dispatch_failed"
+            ? "Dispatch registrado com falha. Acompanhando o status..."
+            : "Solicitacao enviada. Acompanhando processamento...",
+        detail:
+          payload.status === "dispatch_failed"
+            ? "O backend vai expor o status final desta tentativa na fila de refresh."
+            : "A pagina sera recarregada assim que os dados estiverem prontos.",
+      });
+    } catch (error) {
+      if (isApiClientError(error) && error.status === 429) {
+        setState({
+          phase: "polling",
+          startedAt: Date.now(),
+          message: "Solicitacao ja em andamento.",
+          detail: "Acompanhando o processamento atual desta companhia.",
+        });
+        return;
+      }
+
+      setState({
+        phase: "error",
+        message: getUserFacingErrorMessage(error),
+        detail: "Tente novamente em instantes.",
+      });
+    }
+  }
+
+  function handleReset() {
+    if (reloadTimerRef.current !== null) {
+      window.clearTimeout(reloadTimerRef.current);
+      reloadTimerRef.current = null;
+    }
+
+    setState({ phase: "idle" });
+  }
+
+  const isBusy =
+    state.phase === "submitting" ||
+    state.phase === "polling" ||
+    state.phase === "success";
+
+  const buttonLabel =
+    state.phase === "submitting"
+      ? "Solicitando..."
+      : state.phase === "polling"
+        ? "Atualizando..."
+        : state.phase === "success"
+          ? "Recarregando..."
+          : state.phase === "error" || state.phase === "timeout"
+            ? "Solicitar novamente"
+            : "Solicitar dados financeiros";
+
+  const showStatus = state.phase !== "idle";
+  const isDestructive = state.phase === "error" || state.phase === "timeout";
+
+  return (
+    <div className="flex min-w-[18rem] flex-col gap-3 sm:max-w-xl">
+      <Button
+        type="button"
+        variant="outline"
+        size="lg"
+        className="w-fit rounded-full px-5"
+        onClick={handleRequestRefresh}
+        disabled={isBusy}
+      >
+        {isBusy ? <LoaderCircleIcon className="animate-spin" /> : null}
+        {buttonLabel}
+      </Button>
+
+      {showStatus ? (
+        <Alert
+          className={
+            isDestructive
+              ? "rounded-[1.5rem] border border-destructive/25 bg-destructive/6 px-4 py-4"
+              : "rounded-[1.5rem] border border-border/70 bg-muted/28 px-4 py-4"
+          }
+        >
+          <AlertTitle>
+            {state.phase === "success"
+              ? "Atualizacao concluida"
+              : state.phase === "timeout"
+                ? "Tempo limite atingido"
+                : state.phase === "error"
+                  ? "Refresh indisponivel"
+                  : "Atualizacao em andamento"}
+          </AlertTitle>
+          <AlertDescription className="space-y-3">
+            <p>{state.message}</p>
+            {state.detail ? <p>{state.detail}</p> : null}
+            {state.phase === "timeout" ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="rounded-full px-3"
+                onClick={handleReset}
+              >
+                <RotateCcwIcon />
+                Tentar novamente
+              </Button>
+            ) : null}
+          </AlertDescription>
+        </Alert>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -60,6 +60,25 @@ export type CompanyInfo = {
   ticker_b3: string | null;
 };
 
+export type RefreshDispatchResponse = {
+  status: "dispatched" | "dispatch_failed";
+  cd_cvm: number;
+};
+
+export type RefreshStatusItem = {
+  cd_cvm: number;
+  company_name: string;
+  source_scope: string | null;
+  last_attempt_at: string | null;
+  last_success_at: string | null;
+  last_status: string | null;
+  last_error: string | null;
+  last_start_year: number | null;
+  last_end_year: number | null;
+  last_rows_inserted: number | null;
+  updated_at: string | null;
+};
+
 export type TabularDataRow = Record<string, string | number | boolean | null>;
 
 export type TabularData = {
@@ -131,6 +150,12 @@ type ApiErrorShape = {
     code?: string;
     message?: string;
   };
+  detail?:
+    | {
+        code?: string;
+        message?: string;
+      }
+    | string;
 };
 
 type ApiFetchOptions<T> = {
@@ -186,6 +211,10 @@ function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((item) => typeof item === "string");
 }
 
+function isNullableString(value: unknown): value is string | null {
+  return value === null || typeof value === "string";
+}
+
 function isTabularData(value: unknown): value is TabularData {
   return (
     isRecord(value) &&
@@ -238,6 +267,14 @@ function isCompanyInfo(value: unknown): value is CompanyInfo {
   );
 }
 
+function isRefreshDispatchResponse(value: unknown): value is RefreshDispatchResponse {
+  return (
+    isRecord(value) &&
+    typeof value.cd_cvm === "number" &&
+    (value.status === "dispatched" || value.status === "dispatch_failed")
+  );
+}
+
 function isKPIBundle(value: unknown): value is KPIBundle {
   return (
     isRecord(value) &&
@@ -261,6 +298,27 @@ function isStatementMatrix(value: unknown): value is StatementMatrix {
 
 function isNullableNumber(value: unknown): value is number | null {
   return value === null || typeof value === "number";
+}
+
+function isRefreshStatusItem(value: unknown): value is RefreshStatusItem {
+  return (
+    isRecord(value) &&
+    typeof value.cd_cvm === "number" &&
+    typeof value.company_name === "string" &&
+    isNullableString(value.source_scope) &&
+    isNullableString(value.last_attempt_at) &&
+    isNullableString(value.last_success_at) &&
+    isNullableString(value.last_status) &&
+    isNullableString(value.last_error) &&
+    isNullableNumber(value.last_start_year) &&
+    isNullableNumber(value.last_end_year) &&
+    isNullableNumber(value.last_rows_inserted) &&
+    isNullableString(value.updated_at)
+  );
+}
+
+function isRefreshStatusList(value: unknown): value is RefreshStatusItem[] {
+  return Array.isArray(value) && value.every((item) => isRefreshStatusItem(item));
 }
 
 function isSectorSnapshot(value: unknown): value is SectorSnapshot {
@@ -404,35 +462,55 @@ async function toApiError(response: Response): Promise<ApiClientError> {
 
   const rawCode = payload?.error?.code;
   const rawMessage = payload?.error?.message;
+  const detailCode =
+    isRecord(payload?.detail) && typeof payload.detail.code === "string"
+      ? payload.detail.code
+      : undefined;
+  const detailMessage =
+    isRecord(payload?.detail) && typeof payload.detail.message === "string"
+      ? payload.detail.message
+      : typeof payload?.detail === "string"
+        ? payload.detail
+        : undefined;
+  const code = rawCode ?? detailCode;
+  const message = rawMessage ?? detailMessage;
 
   if (response.status === 404) {
     return new ApiClientError(
-      rawMessage ?? "O recurso solicitado nao foi encontrado.",
+      message ?? "O recurso solicitado nao foi encontrado.",
       response.status,
-      rawCode ?? "not_found",
+      code ?? "not_found",
+    );
+  }
+
+  if (response.status === 429) {
+    return new ApiClientError(
+      message ?? "Solicitacao ja em andamento.",
+      response.status,
+      code ?? "refresh_already_queued",
     );
   }
 
   if (response.status === 422) {
     return new ApiClientError(
-      rawMessage ?? "A requisicao enviada para a API nao foi aceita.",
+      message ?? "A requisicao enviada para a API nao foi aceita.",
       response.status,
-      rawCode ?? "invalid_request",
+      code ?? "invalid_request",
     );
   }
 
   if (response.status >= 500) {
     return new ApiClientError(
-      rawMessage ?? "A API da V2 esta indisponivel no momento.",
+      message ?? "A API da V2 esta indisponivel no momento.",
       response.status,
       "upstream_unavailable",
     );
   }
 
   return new ApiClientError(
-    rawMessage ?? `Falha ao consultar a API (${response.status}).`,
+    message ?? `Falha ao consultar a API (${response.status}).`,
     response.status,
-    rawCode ?? "unknown_error",
+    code ?? "unknown_error",
   );
 }
 
@@ -482,6 +560,63 @@ async function apiFetch<T>(
   if (options?.validate && !options.validate(payload)) {
     throw new ApiClientError(
       options.invalidResponseMessage ?? "A API retornou um formato invalido.",
+      response.status,
+      "invalid_response",
+    );
+  }
+
+  return payload as T;
+}
+
+async function routeFetch<T>(
+  path: string,
+  init?: RequestInit,
+  options?: ApiFetchOptions<T>,
+): Promise<T | null> {
+  let response: Response;
+
+  try {
+    const headers = new Headers(init?.headers);
+    headers.set("Accept", "application/json");
+
+    response = await fetch(path, {
+      ...init,
+      cache: "no-store",
+      headers,
+    });
+  } catch (error) {
+    throw new ApiClientError(
+      isFetchFailureMessage(error instanceof Error ? error.message : undefined)
+        ? "Nao foi possivel conectar o frontend a rota de refresh."
+        : "A conexao com a rota de refresh falhou.",
+      503,
+      "network_error",
+    );
+  }
+
+  if (options?.allowNotFound && response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    throw await toApiError(response);
+  }
+
+  let payload: unknown;
+
+  try {
+    payload = await response.json();
+  } catch {
+    throw new ApiClientError(
+      options?.invalidResponseMessage ?? "A rota retornou um corpo invalido.",
+      response.status,
+      "invalid_response",
+    );
+  }
+
+  if (options?.validate && !options.validate(payload)) {
+    throw new ApiClientError(
+      options.invalidResponseMessage ?? "A rota retornou um formato invalido.",
       response.status,
       "invalid_response",
     );
@@ -619,4 +754,34 @@ export async function fetchCompanyStatement(
       invalidResponseMessage: "A API retornou uma demonstracao invalida para a empresa.",
     },
   )) as StatementMatrix;
+}
+
+export async function fetchRequestRefresh(
+  cdCvm: number,
+): Promise<RefreshDispatchResponse> {
+  return (await routeFetch<RefreshDispatchResponse>(
+    `/api/request-refresh/${cdCvm}`,
+    {
+      method: "POST",
+    },
+    {
+      validate: isRefreshDispatchResponse,
+      invalidResponseMessage:
+        "A rota interna retornou um payload invalido para o dispatch on-demand.",
+    },
+  )) as RefreshDispatchResponse;
+}
+
+export async function fetchRefreshStatus(
+  cdCvm: number,
+): Promise<RefreshStatusItem[]> {
+  return (await routeFetch<RefreshStatusItem[]>(
+    `/api/refresh-status/${cdCvm}`,
+    undefined,
+    {
+      validate: isRefreshStatusList,
+      invalidResponseMessage:
+        "A rota interna retornou um status invalido para o refresh on-demand.",
+    },
+  )) as RefreshStatusItem[];
 }


### PR DESCRIPTION
## What changed
- added a client-side refresh CTA for the no-data company state with polling, timeout and success/error feedback
- added Next.js proxy routes for on-demand dispatch and refresh status reads
- extended the web API client with typed helpers for request-refresh and refresh-status
- replaced the placeholder CTA in CompanyNoDataPage with the real interaction flow

## Why
The company no-data surface now needs to let users trigger the on-demand ingest flow exposed by the backend and stay informed until data becomes available.

## Validation
- 
pm run build
- 
pm run typecheck

Closes #57