### PR TITLE
feat(web): refresh company detail hero + quick wins (items 1-7)

### DIFF
--- a/apps/web/app/empresas/[cd_cvm]/page.tsx
+++ b/apps/web/app/empresas/[cd_cvm]/page.tsx
@@ -10,6 +10,7 @@ import { CompanyStatements } from "@/components/company/company-statements";
 import { CompanyUrlTabs } from "@/components/company/company-url-tabs";
 import { CompanyYearSelector } from "@/components/company/company-year-selector";
 import {
+  InfoChip,
   PageShell,
   SectionHeading,
   SurfaceCard,
@@ -48,15 +49,17 @@ function DetailPageError({
 }) {
   return (
     <PageShell density="relaxed" className="max-w-4xl">
-      <SurfaceCard tone="hero" padding="hero" className="space-y-6">
+      <SurfaceCard tone="default" padding="lg" className="space-y-6">
+        <div className="flex flex-wrap items-center gap-2">
+          <InfoChip tone="brand">Detalhe da companhia</InfoChip>
+        </div>
         <SectionHeading
-          eyebrow="PG-03 - Detalhe da empresa"
-          title="Leitura detalhada indisponivel"
+          title="Detalhes indisponiveis"
           titleAs="h1"
-          description="A superficie de detalhe nao conseguiu carregar os dados desta companhia agora."
+          description="Nao foi possivel carregar os dados desta companhia agora."
         />
         <Alert className="rounded-[1.75rem] border border-destructive/25 bg-destructive/6 px-5 py-5 text-left">
-          <AlertTitle>Falha controlada da leitura detalhada</AlertTitle>
+          <AlertTitle>Falha na leitura detalhada</AlertTitle>
           <AlertDescription>{message}</AlertDescription>
         </Alert>
         <Link
@@ -168,24 +171,16 @@ export default async function EmpresaDetailPage({
 
       <CompanyHeader company={company} selectedYears={selectedYears} />
 
-      <SurfaceCard tone="subtle" padding="md" className="space-y-4">
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-          <div className="space-y-2">
-            <p className="text-xs uppercase tracking-[0.26em] text-muted-foreground">
-              Filtro temporal
-            </p>
-            <p className="text-sm leading-7 text-muted-foreground">
-              Quando nenhum parametro e informado, a pagina usa os tres anos mais
-              recentes disponiveis.
-            </p>
-          </div>
-          <CompanyYearSelector
-            pathname={pathname}
-            availableYears={availableYears}
-            selectedYears={selectedYears}
-          />
-        </div>
-      </SurfaceCard>
+      <div className="flex flex-wrap items-center gap-3 px-1">
+        <span className="text-xs uppercase tracking-[0.24em] text-muted-foreground">
+          Periodo
+        </span>
+        <CompanyYearSelector
+          pathname={pathname}
+          availableYears={availableYears}
+          selectedYears={selectedYears}
+        />
+      </div>
 
       <CompanyUrlTabs
         pathname={pathname}
@@ -207,13 +202,13 @@ export default async function EmpresaDetailPage({
           </Alert>
         )
       ) : (
-        <div className="space-y-6">
-          <SurfaceCard tone="subtle" padding="md" className="space-y-4">
+        <SurfaceCard tone="default" padding="lg" className="space-y-5">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
             <SectionHeading
               eyebrow="Tipo de demonstracao"
-              title="Escolha a visao contabil disponivel"
+              title="Escolha a visao contabil"
               titleAs="h3"
-              description="A tabela abaixo respeita os anos selecionados e troca apenas a demonstracao ativa."
+              description="A tabela respeita os anos selecionados e troca apenas a demonstracao ativa."
               descriptionClassName="text-sm leading-7"
             />
             <CompanyUrlTabs
@@ -223,7 +218,7 @@ export default async function EmpresaDetailPage({
               options={Array.from(STATEMENT_OPTIONS)}
               eventName="company_statement_changed"
             />
-          </SurfaceCard>
+          </div>
           {statement ? (
             <CompanyStatements matrix={statement} />
           ) : (
@@ -235,7 +230,7 @@ export default async function EmpresaDetailPage({
               </AlertDescription>
             </Alert>
           )}
-        </div>
+        </SurfaceCard>
       )}
     </PageShell>
   );

--- a/apps/web/components/company/company-header.tsx
+++ b/apps/web/components/company/company-header.tsx
@@ -27,12 +27,20 @@ export function CompanyHeader({
   }
   const compareHref = `/comparar?${compareParams.toString()}`;
   const latestSelectedYear = selectedYears[selectedYears.length - 1] ?? null;
+  const earliestSelectedYear = selectedYears[0] ?? null;
   const sectorHref =
     company.sector_slug && latestSelectedYear
       ? `/setores/${company.sector_slug}?ano=${latestSelectedYear}`
       : company.sector_slug
         ? `/setores/${company.sector_slug}`
         : null;
+
+  const freshnessLabel =
+    earliestSelectedYear && latestSelectedYear
+      ? earliestSelectedYear === latestSelectedYear
+        ? `Dados ${latestSelectedYear}`
+        : `Dados ${earliestSelectedYear}\u2013${latestSelectedYear}`
+      : "Fonte CVM";
 
   return (
     <div className="space-y-5">
@@ -56,27 +64,28 @@ export function CompanyHeader({
         </ol>
       </nav>
 
-      <SurfaceCard tone="default" padding="lg">
-        <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+      <SurfaceCard tone="hero" padding="hero">
+        <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
           <div className="space-y-4">
-            <div className="flex flex-wrap items-center gap-3">
-              <InfoChip tone="brand">PG-03 - Detalhe da empresa</InfoChip>
+            <div className="flex flex-wrap items-center gap-2">
+              <InfoChip tone="brand">Detalhe da companhia</InfoChip>
               <InfoChip>CVM {company.cd_cvm}</InfoChip>
+              <InfoChip tone="muted">Fonte CVM &middot; {freshnessLabel}</InfoChip>
             </div>
 
             <div className="space-y-3">
               <h1 className="font-heading text-4xl tracking-[-0.05em] text-foreground sm:text-5xl">
                 {company.company_name}
               </h1>
-              <div className="flex flex-wrap gap-3 text-sm text-muted-foreground">
+              <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
                 <span>{company.ticker_b3 ?? "Sem ticker"}</span>
+                <span aria-hidden="true">&middot;</span>
                 <span>{company.sector_name}</span>
-                <span>{selectedYears.join(", ")}</span>
               </div>
             </div>
           </div>
 
-          <div className="flex flex-wrap gap-3">
+          <div className="flex flex-wrap items-center gap-2">
             <ExcelDownloadButton
               endpoint={`/api/companies/${company.cd_cvm}/excel`}
               fallbackFilename={`${company.ticker_b3 ?? `cvm${company.cd_cvm}`}.xlsx`}
@@ -94,17 +103,17 @@ export function CompanyHeader({
               <Link
                 href={sectorHref}
                 className={cn(
-                  buttonVariants({ variant: "outline", size: "lg" }),
-                  "rounded-full px-5",
+                  buttonVariants({ variant: "ghost", size: "lg" }),
+                  "rounded-full px-4",
                 )}
               >
                 Ver setor
               </Link>
             ) : (
               <Button
-                variant="outline"
+                variant="ghost"
                 size="lg"
-                className="rounded-full px-5"
+                className="rounded-full px-4"
                 disabled
               >
                 Setor indisponivel
@@ -113,11 +122,11 @@ export function CompanyHeader({
             <Link
               href={compareHref}
               className={cn(
-                buttonVariants({ variant: "outline", size: "lg" }),
-                "rounded-full px-5",
+                buttonVariants({ variant: "ghost", size: "lg" }),
+                "rounded-full px-4",
               )}
             >
-              Comparar empresa
+              Comparar
             </Link>
           </div>
         </div>

--- a/apps/web/components/company/company-no-data.tsx
+++ b/apps/web/components/company/company-no-data.tsx
@@ -62,7 +62,7 @@ export function CompanyNoDataPage({ company }: CompanyNoDataPageProps) {
 
         <SurfaceCard tone="hero" padding="hero" className="space-y-8">
           <div className="flex flex-wrap items-center gap-3">
-            <InfoChip tone="brand">PG-03 - Detalhe da empresa</InfoChip>
+            <InfoChip tone="brand">Detalhe da companhia</InfoChip>
             <InfoChip>CVM {company.cd_cvm}</InfoChip>
             {company.ticker_b3 ? <InfoChip tone="muted">{company.ticker_b3}</InfoChip> : null}
           </div>


### PR DESCRIPTION
## Summary

Ships roadmap items 1-7 of the enterprise hero restructure for `/empresas/[cd_cvm]` — all composition-only, zero new primitives, within the approved Design System.

- **Hero header.** `CompanyHeader` now wraps in `SurfaceCard tone="hero" padding="hero"`; action cluster ranked (primary `Baixar Excel`, ghost `Ver setor` / `Comparar`); added freshness `InfoChip` built from the selected year range (`Dados 2022-2024` or `Dados 2024`).
- **Eyebrow cleanup.** Replaced `"PG-03 - Detalhe da empresa"` with brand chip `"Detalhe da companhia"` across `CompanyHeader`, `DetailPageError`, and `CompanyNoDataPage`.
- **Year filter collapsed.** Removed the `SurfaceCard tone="subtle"` wrapper and its two-sentence explainer; `CompanyYearSelector` now sits in a minimal inline toolbar row (temporary until the hero chart lands in follow-up).
- **Statements tab unified.** Collapsed the two stacked `SurfaceCard`s (statement-type selector + matrix) into a single `tone="default" padding="lg"` card with an inline toolbar row.
- **Error state demoted.** `DetailPageError` dropped from `tone="hero"` to `tone="default"`, titled tightened to `"Detalhes indisponiveis"` / `"Falha na leitura detalhada"`.

Items 8-13 (two-column grid, primary chart, `SparklineChip`, freshness card CTA, period presets) follow in a separate task.

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `eslint` on touched files — clean
- [ ] Manual smoke at `/empresas/9512` (Petrobras) — hero renders, year selector toolbar works, tabs switch
- [ ] Responsive check (sm / md / lg / xl) — hero action cluster wraps, toolbar reflows
- [ ] Dark mode toggle — new chips and surfaces look correct
- [ ] Error path — force a fetch failure and confirm `DetailPageError` renders with `tone="default"` + destructive alert

Closes #70