### PR TITLE
chore(ci): drop legacy Railway deploy hook job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,21 +106,7 @@ jobs:
       - name: Run web build
         run: npm run build
 
-  deploy-api:
-    needs: [test-python]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    runs-on: ubuntu-latest
-    env:
-      RAILWAY_DEPLOY_HOOK: ${{ secrets.RAILWAY_DEPLOY_HOOK }}
-    steps:
-      - name: Skip Railway deploy when hook is missing
-        if: env.RAILWAY_DEPLOY_HOOK == ''
-        run: echo "::warning::RAILWAY_DEPLOY_HOOK is not configured; skipping Railway deploy."
-
-      - name: Trigger Railway deploy
-        if: env.RAILWAY_DEPLOY_HOOK != ''
-        run: curl -fsSL -X POST "$RAILWAY_DEPLOY_HOOK"
-
+  # The API deploys from Railway's native GitHub autodeploy on pushes to main.
   deploy-web:
     needs: [test-web]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'


### PR DESCRIPTION
## Issue

Closes #75

## Resumo

- remover o job `deploy-api` que tentava usar `RAILWAY_DEPLOY_HOOK`
- alinhar o workflow `CI` ao autodeploy nativo da Railway em `main`
- manter no arquivo uma nota curta explicando que o deploy da API nao e disparado por hook do GitHub Actions

## Paralelismo

- lane da task: `lane:ops-quality`
- worktree usada: `.claude/worktrees/ops-quality/75-ci-railway-autodeploy/`
- esta e a unica PR oficial da task: `sim`
- risco da task: `risk:shared`
- task mae: `n/a`
- lane solicitante: `n/a`
- consumo registrado na task mae: `n/a`
- write-set principal:
  - `.github/workflows/ci.yml`
- coordenacao com outras tasks/PRs: nenhuma

## Compatibilidade

- politica aplicada: `n/a`
- impacto em API, schema ou docs publicos: nenhum; a mudanca so remove um caminho legado de automacao que nao era a via real de deploy da API

## Validacao

- [x] validacoes executadas e registradas abaixo

```text
git diff --check
railway deployment list --service analisys --json
```

## Checklist

- [x] a branch segue `task/<issue-number>-<slug>` ou a PR foi publicada pelo Jules e a automacao ja vinculou a task retroativa
- [x] a issue vinculada esta atualizada com checklist/status/evidencias
- [x] a issue vinculada registra owner atual, lane oficial, workspace da task, write-set esperado e `risk:*`
- [x] docs relevantes foram atualizados quando necessario
- [x] lane da task e worktree oficial foram registradas nesta PR
- [x] se a task for `risk:shared` ou `risk:contract-sensitive`, a PR abriu em draft
- [x] PR em draft apenas enquanto o trabalho ou as validacoes ainda estiverem incompletos
- [ ] checks obrigatorios verdes ou helper de conclusao acionado para aguardar
- [ ] pronto para `squash merge` em `main` quando os checks estiverem verdes
- [ ] nao considerar a task concluida ate confirmar merge, issue fechada e branch remota removida quando aplicavel
