### PR TITLE
chore(ops): expand coverage seed and monthly delta refresh

### DIFF
--- a/.github/workflows/ingest.yml
+++ b/.github/workflows/ingest.yml
@@ -27,17 +27,13 @@ on:
           - "false"
           - "true"
       dry_run:
-        description: "Dry run — show plan without downloading"
+        description: "Dry run - show plan without downloading"
         required: false
         default: "false"
         type: choice
         options:
           - "false"
           - "true"
-
-  schedule:
-    # Runs on the 1st and 15th of every month at 02:00 UTC
-    - cron: "0 2 1,15 * *"
 
 jobs:
   ingest:
@@ -78,13 +74,7 @@ jobs:
             END_YEAR=$(date +%Y)
           fi
           echo "end_year=$END_YEAR" >> "$GITHUB_OUTPUT"
-
-          # Scheduled runs use full history (2010–present); manual dispatch uses the input value
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-            echo "start_year=2010" >> "$GITHUB_OUTPUT"
-          else
-            echo "start_year=${{ github.event.inputs.start_year || '2022' }}" >> "$GITHUB_OUTPUT"
-          fi
+          echo "start_year=${{ github.event.inputs.start_year || '2022' }}" >> "$GITHUB_OUTPUT"
 
       - name: Build flags
         id: flags
@@ -96,10 +86,6 @@ jobs:
           if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
             FLAGS="$FLAGS --dry-run"
           fi
-          # Scheduled runs always skip yfinance to keep runtime under limits
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-            FLAGS="$FLAGS --skip-yfinance"
-          fi
           echo "flags=$FLAGS" >> "$GITHUB_OUTPUT"
 
       - name: Run batch ingestion
@@ -110,7 +96,7 @@ jobs:
             --end-year "${{ steps.years.outputs.end_year }}" \
             ${{ steps.flags.outputs.flags }}
 
-      - name: Smoke check — verify API responds with data
+      - name: Smoke check - verify API responds with data
         if: github.event.inputs.dry_run != 'true'
         run: |
           TOTAL=$(curl -sf "https://analisys-production.up.railway.app/companies?page=1&page_size=1" \

--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -1,9 +1,9 @@
-name: Atualizacao Semanal CVM
+name: Atualizacao Mensal CVM
 
 on:
   schedule:
-    - cron: "0 9 * * 0"   # Domingos 09h UTC (06h BRT)
-  workflow_dispatch:        # trigger manual para testes
+    - cron: "0 9 1 * *"   # Dia 1 de cada mes, 09h UTC (06h BRT)
+  workflow_dispatch:
 
 jobs:
   refresh:
@@ -36,7 +36,7 @@ jobs:
       - name: Resolver anos de refresh
         id: anos
         run: |
-          # Use repo variables if defined; fall back to current and previous year
+          # Usa repo vars se definidas; caso contrario, verifica apenas ano atual e anterior.
           CURR="${{ vars.REFRESH_YEAR_CURR }}"
           PREV="${{ vars.REFRESH_YEAR_PREV }}"
           if [ -z "$CURR" ]; then

--- a/.github/workflows/seed_catalog.yml
+++ b/.github/workflows/seed_catalog.yml
@@ -64,13 +64,13 @@ jobs:
                   )
               ).scalars().all()
 
-          expected_ranks = list(range(1, 81))
+          expected_ranks = list(range(1, 121))
           if total < 600:
               print(f"::error::Expected at least 600 companies after seed, got {total}.")
               sys.exit(1)
           if coverage_ranks != expected_ranks:
               print(
-                  "::error::Expected coverage_rank sequence 1..80 with no gaps; "
+                  "::error::Expected coverage_rank sequence 1..120 with no gaps; "
                   f"got {len(coverage_ranks)} ranked rows and sequence {coverage_ranks[:10]}..."
               )
               sys.exit(1)

--- a/scripts/seed_catalog.py
+++ b/scripts/seed_catalog.py
@@ -5,7 +5,7 @@ Seed idempotente da tabela `companies` a partir do cadastro CVM.
 - Insere ou atualiza todas as empresas ativas do catalogo.
 - Mantem ticker_b3 e company_type ja existentes quando o catalogo nao traz
   informacao melhor.
-- Atribui coverage_rank de 1 a 80 para os primeiros cd_cvm definidos em
+- Atribui coverage_rank de 1 a 120 para os primeiros cd_cvm definidos em
   src.ticker_map.TICKER_MAP.
 """
 from __future__ import annotations
@@ -41,7 +41,7 @@ log = logging.getLogger(__name__)
 
 CVM_MASTER_URL = "https://dados.cvm.gov.br/dados/CIA_ABERTA/CAD/DADOS/cad_cia_aberta.csv"
 ACTIVE_STATUS_VALUES = {"ATIVO", "A"}
-TOP_COVERAGE_CODES = tuple(list(TICKER_MAP)[:80])
+TOP_COVERAGE_CODES = tuple(list(TICKER_MAP)[:120])
 
 
 def _clean_text(value: object) -> str | None:

--- a/scripts/test_seed_catalog.py
+++ b/scripts/test_seed_catalog.py
@@ -5,7 +5,7 @@ import math
 
 import pandas as pd
 
-from scripts.seed_catalog import build_upsert_records
+from scripts.seed_catalog import TOP_COVERAGE_CODES, build_upsert_records
 
 
 def test_build_upsert_records_normalizes_nullable_fields_to_none():
@@ -43,3 +43,8 @@ def test_build_upsert_records_normalizes_nullable_fields_to_none():
             "updated_at": "2026-04-17T00:00:00",
         }
     ]
+
+
+def test_top_coverage_codes_expanded_to_120_without_duplicates():
+    assert len(TOP_COVERAGE_CODES) == 120
+    assert len(set(TOP_COVERAGE_CODES)) == 120


### PR DESCRIPTION
## Issue

Closes #77

## Resumo

- expandir o seed de `coverage_rank` para os primeiros 120 codigos do mapa canonico
- ajustar a validacao automatica do seed para exigir a sequencia `1..120`
- remover o cron historico de `ingest.yml`, deixando esse workflow apenas para backfill manual
- mover a rotina automatica mensal para `refresh.yml`, executando apenas refresh incremental de ano atual + anterior

## Paralelismo

- lane da task: `lane:ops-quality`
- worktree usada: `.claude/worktrees/ops-quality/77-seed-top120-monthly-delta/`
- esta e a unica PR oficial da task: `sim`
- risco da task: `risk:shared`
- task mae: `n/a`
- lane solicitante: `n/a`
- consumo registrado na task mae: `n/a`
- write-set principal:
  - `.github/workflows/ingest.yml`
  - `.github/workflows/refresh.yml`
  - `.github/workflows/seed_catalog.yml`
  - `scripts/seed_catalog.py`
  - `scripts/test_seed_catalog.py`
- coordenacao com outras tasks/PRs: nenhuma

## Compatibilidade

- politica aplicada: `n/a`
- impacto em API, schema ou docs publicos: nenhum contrato publico muda; a alteracao e apenas de priorizacao operacional do catalogo e do agendamento automatico de refresh

## Validacao

- [x] validacoes executadas e registradas abaixo

```text
python -m pytest scripts/test_seed_catalog.py -q
```

## Checklist

- [x] a branch segue `task/<issue-number>-<slug>` ou a PR foi publicada pelo Jules e a automacao ja vinculou a task retroativa
- [x] a issue vinculada esta atualizada com checklist/status/evidencias
- [x] a issue vinculada registra owner atual, lane oficial, workspace da task, write-set esperado e `risk:*`
- [x] docs relevantes foram atualizados quando necessario
- [x] lane da task e worktree oficial foram registradas nesta PR
- [x] se a task for `risk:shared` ou `risk:contract-sensitive`, a PR abriu em draft
- [x] PR em draft apenas enquanto o trabalho ou as validacoes ainda estiverem incompletos
- [ ] checks obrigatorios verdes ou helper de conclusao acionado para aguardar
- [ ] pronto para `squash merge` em `main` quando os checks estiverem verdes
- [ ] nao considerar a task concluida ate confirmar merge, issue fechada e branch remota removida quando aplicavel
