### PR TITLE
feat(web): foundation tokens — teal primary, paleta de setores e escala tipográfica

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -53,6 +53,17 @@
   --component-bg: var(--component-bg);
   --component-inactive-color: var(--component-inactive-color);
 
+  /* Escala tipográfica */
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-base: 0.95rem;
+  --text-lg: 1.0625rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.75rem;
+  --text-3xl: 2.5rem;
+  --text-eyebrow-size: 0.7rem;
+  --text-eyebrow-tracking: 0.15em;
+
   @keyframes iconBounce {
     0%,
     100% {
@@ -80,7 +91,7 @@
   --card-foreground: oklch(0.23 0.021 93.58);
   --popover: oklch(0.99 0.005 95.73);
   --popover-foreground: oklch(0.23 0.021 93.58);
-  --primary: oklch(0.37 0.065 161.56);
+  --primary: oklch(0.65 0.14 178);
   --primary-foreground: oklch(0.985 0.005 110.31);
   --secondary: oklch(0.89 0.03 67.39);
   --secondary-foreground: oklch(0.28 0.022 76.96);
@@ -91,7 +102,7 @@
   --destructive: oklch(0.61 0.219 26.44);
   --border: oklch(0.88 0.01 90.56);
   --input: oklch(0.88 0.01 90.56);
-  --ring: oklch(0.59 0.065 161.56);
+  --ring: oklch(0.65 0.14 178);
   --chart-1: oklch(0.62 0.13 161.56); /* teal - primaria */
   --chart-2: oklch(0.65 0.14 29); /* amber - contraste complementar */
   --chart-3: oklch(0.6 0.12 258); /* blue-violet */
@@ -100,7 +111,7 @@
   --radius: 0.875rem;
   --sidebar: oklch(0.985 0.006 94.78);
   --sidebar-foreground: oklch(0.23 0.021 93.58);
-  --sidebar-primary: oklch(0.37 0.065 161.56);
+  --sidebar-primary: oklch(0.65 0.14 178);
   --sidebar-primary-foreground: oklch(0.985 0.005 110.31);
   --sidebar-accent: oklch(0.94 0.008 92.11);
   --sidebar-accent-foreground: oklch(0.23 0.021 93.58);
@@ -121,8 +132,8 @@
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.205 0 0);
   --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
+  --primary: oklch(0.72 0.14 178);
+  --primary-foreground: oklch(0.985 0 0);
   --secondary: oklch(0.269 0 0);
   --secondary-foreground: oklch(0.985 0 0);
   --muted: oklch(0.269 0 0);
@@ -132,7 +143,7 @@
   --destructive: oklch(0.704 0.191 22.216);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
+  --ring: oklch(0.72 0.14 178);
   --chart-1: oklch(0.72 0.15 161.56); /* teal */
   --chart-2: oklch(0.75 0.16 29); /* amber */
   --chart-3: oklch(0.7 0.13 258); /* blue-violet */
@@ -152,6 +163,21 @@
   --component-active-bg: var(--secondary);
   --component-line-inactive-color: var(--muted-foreground);
   --component-active-color-default: var(--accent-foreground);
+}
+
+@layer utilities {
+  .eyebrow {
+    font-size: var(--text-eyebrow-size);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: var(--text-eyebrow-tracking);
+    color: var(--muted-foreground);
+  }
+
+  .tnum {
+    font-variant-numeric: tabular-nums;
+    font-feature-settings: 'tnum';
+  }
 }
 
 @layer base {

--- a/apps/web/lib/constants.ts
+++ b/apps/web/lib/constants.ts
@@ -1,3 +1,21 @@
+export const SECTOR_COLOR: Record<string, string> = {
+  Financeiro:   '#1E88E5',
+  Tecnologia:   '#D32F2F',
+  'Saúde':      '#43A047',
+  Industrial:   '#FFB300',
+  Varejo:       '#E91E63',
+  Utilidades:   '#00897B',
+  Energia:      '#FF6F00',
+  'Mineração':  '#8D6E63',
+  'Agronegócio':'#558B2F',
+  'Imobiliário':'#7B1FA2',
+};
+
+export function getSectorColor(sector: string | null | undefined): string {
+  if (!sector) return '#64748B';
+  return SECTOR_COLOR[sector] ?? '#64748B';
+}
+
 export const HOME_QUICK_LINKS = [
   {
     label: "Comparar",


### PR DESCRIPTION
## Issue

Closes #79

## Resumo

- `--primary` atualizado para teal (`oklch(0.65 0.14 178)`) em light e dark mode
- `--ring` e `--sidebar-primary` alinhados com a nova cor primária
- Escala tipográfica adicionada ao `@theme inline` (`--text-xs` até `--text-3xl`, eyebrow, tracking)
- Classes utilitárias `.eyebrow` e `.tnum` disponíveis globalmente
- `SECTOR_COLOR` (map de 10 setores → hex) e `getSectorColor()` exportados de `constants.ts`

## Paralelismo

- lane da task: `lane:frontend`
- worktree usada: `.claude/worktrees/frontend/79-foundation-tokens/`
- risco: `risk:safe`
- write-set: `apps/web/app/globals.css`, `apps/web/lib/constants.ts`

## Validação

- [x] `constants.ts` sem erros TypeScript
- [x] Erros de TS pré-existentes (node_modules incompleto) não foram introduzidos por esta PR
- [ ] CI build verde

## Checklist

- [x] branch segue `task/<issue>-<slug>`
- [x] issue vinculada atualizada
- [x] write-set declarado
- [x] risk:safe (CSS vars + constantes isoladas)
- [ ] checks obrigatórios verdes
- [ ] pronto para squash merge em main