### PR TITLE
feat(web): home redesenhada — hero centralizado, discovery tabs e trust strip

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,88 +1,33 @@
-import { ArrowUpRightIcon } from "lucide-react";
-
 import { CompanySearchHero } from "@/components/home/company-search-hero";
-import { FutureDomainGrid } from "@/components/home/future-domain-grid";
+import { DiscoverySection } from "@/components/home/discovery-section";
 import { TrustStrip } from "@/components/home/trust-strip";
-import {
-  InfoChip,
-  PageShell,
-  SectionHeading,
-  SurfaceCard,
-} from "@/components/shared/design-system-recipes";
+import { PageShell } from "@/components/shared/design-system-recipes";
 import { fetchCompanies, safeFetchHealth } from "@/lib/api";
-import { formatCompactInteger } from "@/lib/formatters";
 
 export const dynamic = "force-dynamic";
 
 export default async function HomePage() {
-  const [health, companySnapshot] = await Promise.all([
+  const [health, companySnapshot, topCompaniesResult] = await Promise.all([
     safeFetchHealth(),
     fetchCompanies({ page: 1, pageSize: 1 }).catch(() => null),
+    fetchCompanies({ page: 1, pageSize: 6 }).catch(() => null),
   ]);
 
   const totalCompanies = companySnapshot?.pagination.total_items ?? null;
+  const topCompanies = topCompaniesResult?.items ?? [];
 
   return (
     <>
-      <PageShell density="relaxed" className="pb-18">
-        <div className="grid gap-8 xl:grid-cols-[minmax(0,1.15fr)_22rem]">
-          <div className="space-y-6">
-            <div className="flex flex-wrap items-center gap-3">
-              <InfoChip tone="brand">V2 web - slice publico</InfoChip>
-              <InfoChip>Home - Empresas - Empresa</InfoChip>
-            </div>
+      <PageShell
+        density="relaxed"
+        className="pb-18 flex flex-col items-center text-center gap-12"
+      >
+        <CompanySearchHero
+          apiAvailable={health?.status === "ok"}
+          totalCompanies={totalCompanies}
+        />
 
-            <CompanySearchHero
-              apiAvailable={health?.status === "ok"}
-              totalCompanies={totalCompanies}
-            />
-          </div>
-
-          <SurfaceCard
-            tone="subtle"
-            padding="lg"
-            className="flex flex-col justify-between gap-8"
-          >
-            <div className="space-y-4">
-              <SectionHeading
-                eyebrow="Leitura orientada a descoberta"
-                title="Menos friccao para encontrar a empresa certa."
-                titleAs="h2"
-                description="A fase atual evita dashboards genericos e entra pela tarefa principal: descobrir, abrir e analisar uma companhia em poucos passos."
-                bodyClassName="max-w-none"
-                descriptionClassName="text-base leading-7"
-              />
-              <p className="text-sm leading-7 text-muted-foreground">
-                O backend ja sustenta busca, diretorio paginado, filtros
-                canonicos, detalhe rico, KPIs e demonstracoes.
-              </p>
-            </div>
-
-            <div className="space-y-5 border-t border-border/55 pt-5">
-              <div className="grid gap-3">
-                <p className="flex items-center justify-between text-sm text-muted-foreground">
-                  <span>Empresas com dados</span>
-                  <span className="font-medium text-foreground">
-                    {formatCompactInteger(totalCompanies)}
-                  </span>
-                </p>
-                <p className="flex items-center justify-between text-sm text-muted-foreground">
-                  <span>Status da API</span>
-                  <span className="font-medium text-foreground">
-                    {health?.status === "ok" ? "Pronta" : "Indisponivel"}
-                  </span>
-                </p>
-              </div>
-
-              <div className="flex items-center gap-2 text-xs uppercase tracking-[0.24em] text-muted-foreground">
-                Proximas superficies
-                <ArrowUpRightIcon className="size-3.5" />
-              </div>
-            </div>
-          </SurfaceCard>
-        </div>
-
-        <FutureDomainGrid />
+        <DiscoverySection topCompanies={topCompanies} />
       </PageShell>
 
       <TrustStrip health={health} totalCompanies={totalCompanies} />

--- a/apps/web/components/home/company-search-hero.tsx
+++ b/apps/web/components/home/company-search-hero.tsx
@@ -7,7 +7,6 @@ import { useRouter } from "next/navigation";
 
 import {
   InfoChip,
-  SurfaceCard,
   surfaceVariants,
 } from "@/components/shared/design-system-recipes";
 import { buttonVariants } from "@/components/ui/button";
@@ -122,129 +121,118 @@ export function CompanySearchHero({
   }
 
   return (
-    <SurfaceCard
-      tone="hero"
-      padding="hero"
-      className="relative overflow-visible"
-    >
-      <div className="pointer-events-none absolute inset-0 rounded-[inherit] bg-[radial-gradient(circle_at_top_left,_rgba(183,110,44,0.14),_transparent_34%),radial-gradient(circle_at_bottom_right,_rgba(25,78,55,0.1),_transparent_32%)]" />
-
-      <div className="relative space-y-7">
-        <div className="space-y-4">
-          <InfoChip tone="secondary">Descoberta orientada a analise</InfoChip>
-          <div className="space-y-4">
-            <h1 className="max-w-4xl font-heading text-4xl leading-[1.02] tracking-[-0.05em] text-foreground sm:text-5xl lg:text-6xl">
-              Entre por empresa e va direto ao historico que importa.
-            </h1>
-            <p className="max-w-2xl text-base leading-8 text-muted-foreground sm:text-lg">
-              Busque companhias abertas pelo nome, ticker ou codigo CVM e caia
-              direto em uma leitura publica, rapida e rastreavel dos numeros.
-            </p>
-          </div>
-        </div>
-
-        <form
-          action="/empresas"
-          className="space-y-4"
-          method="get"
-          onSubmit={handleSubmit}
-        >
-          <div className="relative">
-            <div className="flex flex-col gap-3 rounded-[1.5rem] border border-border/70 bg-background/92 p-3 shadow-[0_18px_45px_-40px_rgba(16,30,24,0.22)] sm:flex-row sm:items-center">
-              <div className="flex flex-1 items-center gap-3 rounded-[1.2rem] border border-border/60 bg-muted/55 px-4 py-3">
-                <SearchIcon className="size-4.5 text-muted-foreground" />
-                <Input
-                  name="busca"
-                  type="search"
-                  value={query}
-                  placeholder="PETROBRAS, VALE3 ou 9512"
-                  className="h-auto border-0 bg-transparent p-0 text-base shadow-none ring-0 focus-visible:ring-0"
-                  onChange={(event) => setQuery(event.target.value)}
-                  aria-label="Buscar empresa"
-                />
-              </div>
-              <div className="flex flex-col gap-3 sm:flex-row">
-                <button
-                  type="submit"
-                  className={cn(
-                    buttonVariants({ size: "lg" }),
-                    "rounded-full px-5",
-                  )}
-                  disabled={isPending}
-                >
-                  Buscar empresa
-                  <ArrowRightIcon data-icon="inline-end" />
-                </button>
-                <Link
-                  href="/empresas"
-                  className={cn(
-                    buttonVariants({ variant: "outline", size: "lg" }),
-                    "rounded-full px-5",
-                  )}
-                >
-                  Ir para empresas
-                </Link>
-              </div>
-            </div>
-
-            {apiAvailable &&
-            (loadingSuggestions || suggestions.length > 0 || suggestionError) ? (
-              <div
-                className={cn(
-                  surfaceVariants({ tone: "default", padding: "none" }),
-                  "absolute inset-x-0 top-[calc(100%+0.75rem)] z-20 overflow-hidden",
-                )}
-              >
-                {loadingSuggestions ? (
-                  <p className="px-5 py-4 text-sm text-muted-foreground">
-                    Buscando sugestoes...
-                  </p>
-                ) : suggestionError ? (
-                  <p className="px-5 py-4 text-sm text-destructive">
-                    {suggestionError}
-                  </p>
-                ) : (
-                  <ul className="divide-y divide-border/50">
-                    {suggestions.map((item) => (
-                      <li key={item.cd_cvm}>
-                        <button
-                          type="button"
-                          className="flex w-full items-start justify-between gap-4 px-5 py-4 text-left transition-colors hover:bg-muted/45"
-                          onClick={() => handleSuggestionSelection(item)}
-                        >
-                          <div className="space-y-1.5">
-                            <p className="font-medium text-foreground">
-                              {item.company_name}
-                            </p>
-                            <p className="text-sm text-muted-foreground">
-                              {item.ticker_b3 ?? "Sem ticker"} - CVM {item.cd_cvm}
-                            </p>
-                          </div>
-                          <div className="space-y-1 text-right">
-                            <p className="text-sm text-foreground">
-                              {item.sector_name}
-                            </p>
-                            <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
-                              {formatYearsLabel(item.anos_disponiveis)}
-                            </p>
-                          </div>
-                        </button>
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </div>
-            ) : null}
-          </div>
-        </form>
-
-        <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
-          <InfoChip>{apiAvailable ? "API pronta para busca" : "API indisponivel"}</InfoChip>
-          {totalCompanies !== null ? (
-            <InfoChip>{formatCompactInteger(totalCompanies)} empresas com dados</InfoChip>
-          ) : null}
-        </div>
+    <div className="w-full max-w-[680px] mx-auto space-y-7 text-center">
+      <div className="space-y-5">
+        <h1 className="font-heading text-[clamp(2.5rem,5.5vw,4.25rem)] leading-[1.02] tracking-[-0.045em] text-foreground">
+          Análise financeira<br />
+          <span className="text-muted-foreground italic font-normal">
+            de quem está na bolsa.
+          </span>
+        </h1>
+        <p className="max-w-[560px] mx-auto text-[1.0625rem] leading-[1.55] text-muted-foreground">
+          Pesquise qualquer companhia aberta brasileira. Leia DRE, balanço e KPIs com 10+ anos de histórico, direto da CVM.
+        </p>
       </div>
-    </SurfaceCard>
+
+      <form
+        action="/empresas"
+        method="get"
+        onSubmit={handleSubmit}
+        className="relative"
+      >
+        <div className="flex flex-col gap-3 rounded-[1.5rem] border border-border/70 bg-background/92 p-3 shadow-[0_18px_45px_-40px_rgba(16,30,24,0.22)] sm:flex-row sm:items-center">
+          <div className="flex flex-1 items-center gap-3 rounded-[1.2rem] border border-border/60 bg-muted/55 px-4 py-3">
+            <SearchIcon className="size-4.5 text-muted-foreground" />
+            <Input
+              name="busca"
+              type="search"
+              value={query}
+              placeholder="PETROBRAS, VALE3 ou 9512"
+              className="h-auto border-0 bg-transparent p-0 text-base shadow-none ring-0 focus-visible:ring-0"
+              onChange={(event) => setQuery(event.target.value)}
+              aria-label="Buscar empresa"
+            />
+          </div>
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <button
+              type="submit"
+              className={cn(
+                buttonVariants({ size: "lg" }),
+                "rounded-full px-5",
+              )}
+              disabled={isPending}
+            >
+              Buscar empresa
+              <ArrowRightIcon data-icon="inline-end" />
+            </button>
+            <Link
+              href="/empresas"
+              className={cn(
+                buttonVariants({ variant: "outline", size: "lg" }),
+                "rounded-full px-5",
+              )}
+            >
+              Ir para empresas
+            </Link>
+          </div>
+        </div>
+
+        {apiAvailable &&
+        (loadingSuggestions || suggestions.length > 0 || suggestionError) ? (
+          <div
+            className={cn(
+              surfaceVariants({ tone: "default", padding: "none" }),
+              "absolute inset-x-0 top-[calc(100%+0.75rem)] z-20 overflow-hidden text-left",
+            )}
+          >
+            {loadingSuggestions ? (
+              <p className="px-5 py-4 text-sm text-muted-foreground">
+                Buscando sugestoes...
+              </p>
+            ) : suggestionError ? (
+              <p className="px-5 py-4 text-sm text-destructive">
+                {suggestionError}
+              </p>
+            ) : (
+              <ul className="divide-y divide-border/50">
+                {suggestions.map((item) => (
+                  <li key={item.cd_cvm}>
+                    <button
+                      type="button"
+                      className="flex w-full items-start justify-between gap-4 px-5 py-4 text-left transition-colors hover:bg-muted/45"
+                      onClick={() => handleSuggestionSelection(item)}
+                    >
+                      <div className="space-y-1.5">
+                        <p className="font-medium text-foreground">
+                          {item.company_name}
+                        </p>
+                        <p className="text-sm text-muted-foreground">
+                          {item.ticker_b3 ?? "Sem ticker"} - CVM {item.cd_cvm}
+                        </p>
+                      </div>
+                      <div className="space-y-1 text-right">
+                        <p className="text-sm text-foreground">
+                          {item.sector_name}
+                        </p>
+                        <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+                          {formatYearsLabel(item.anos_disponiveis)}
+                        </p>
+                      </div>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        ) : null}
+      </form>
+
+      <div className="flex flex-wrap justify-center items-center gap-3 text-sm text-muted-foreground">
+        <InfoChip>{apiAvailable ? "API pronta para busca" : "API indisponivel"}</InfoChip>
+        {totalCompanies !== null ? (
+          <InfoChip>{formatCompactInteger(totalCompanies)} empresas com dados</InfoChip>
+        ) : null}
+      </div>
+    </div>
   );
 }

--- a/apps/web/components/home/discovery-section.tsx
+++ b/apps/web/components/home/discovery-section.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { ArrowUpRightIcon } from "lucide-react";
+
+import type { CompanyDirectoryItem } from "@/lib/api";
+import { SECTOR_COLOR } from "@/lib/constants";
+import { cn } from "@/lib/utils";
+
+type Tab = "populares" | "destaque" | "setores";
+
+const TABS: { id: Tab; label: string }[] = [
+  { id: "populares", label: "Populares" },
+  { id: "destaque", label: "Em destaque" },
+  { id: "setores", label: "Setores" },
+];
+
+type DiscoverySectionProps = {
+  topCompanies: CompanyDirectoryItem[];
+};
+
+export function DiscoverySection({ topCompanies }: DiscoverySectionProps) {
+  const [activeTab, setActiveTab] = useState<Tab>("populares");
+
+  return (
+    <section className="w-full max-w-4xl mx-auto space-y-6">
+      <div className="flex items-center gap-1 border-b border-border/60">
+        {TABS.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            onClick={() => setActiveTab(tab.id)}
+            className={cn(
+              "px-5 py-2.5 text-sm font-medium transition-colors border-b-2 -mb-px",
+              activeTab === tab.id
+                ? "border-primary text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === "populares" && (
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+          {topCompanies.slice(0, 6).map((co) => (
+            <Link
+              key={co.cd_cvm}
+              href={`/empresas/${co.cd_cvm}`}
+              className="group flex flex-col gap-1 rounded-xl border border-border/60 bg-muted/30 px-4 py-3.5 transition-colors hover:bg-muted/60 hover:border-border"
+            >
+              <span className="font-medium text-sm text-foreground group-hover:text-primary transition-colors">
+                {co.ticker_b3 ?? co.company_name}
+              </span>
+              <span className="text-xs text-muted-foreground line-clamp-1">
+                {co.company_name}
+              </span>
+              {co.sector_name ? (
+                <span className="mt-1 text-[0.7rem] uppercase tracking-[0.12em] text-muted-foreground">
+                  {co.sector_name}
+                </span>
+              ) : null}
+            </Link>
+          ))}
+        </div>
+      )}
+
+      {activeTab === "destaque" && (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          {topCompanies.slice(0, 4).map((co) => {
+            const color =
+              co.sector_name
+                ? (SECTOR_COLOR[co.sector_name] ?? "#64748B")
+                : "#64748B";
+            return (
+              <Link
+                key={co.cd_cvm}
+                href={`/empresas/${co.cd_cvm}`}
+                className="group relative flex flex-col justify-between gap-4 overflow-hidden rounded-xl border border-border/60 bg-muted/30 px-5 py-4 transition-colors hover:border-border"
+                style={{ borderLeftColor: color, borderLeftWidth: 3 }}
+              >
+                <div>
+                  <p className="font-heading text-lg text-foreground">
+                    {co.company_name}
+                  </p>
+                  {co.sector_name ? (
+                    <p className="text-sm text-muted-foreground">
+                      {co.sector_name}
+                    </p>
+                  ) : null}
+                </div>
+                <div className="flex items-center justify-between">
+                  <span
+                    className="font-mono text-sm font-medium"
+                    style={{ color }}
+                  >
+                    {co.ticker_b3 ?? `CVM ${co.cd_cvm}`}
+                  </span>
+                  <ArrowUpRightIcon className="size-4 text-muted-foreground group-hover:text-primary transition-colors" />
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+      )}
+
+      {activeTab === "setores" && (
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4">
+          {Object.entries(SECTOR_COLOR).map(([sector, color]) => (
+            <Link
+              key={sector}
+              href="/setores"
+              className="flex flex-col gap-2.5 rounded-xl border border-border/60 bg-muted/30 px-4 py-3.5 transition-colors hover:bg-muted/60 hover:border-border"
+            >
+              <div
+                className="size-3 rounded-full"
+                style={{ backgroundColor: color }}
+              />
+              <span className="text-sm font-medium text-foreground">
+                {sector}
+              </span>
+            </Link>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/components/home/trust-strip.tsx
+++ b/apps/web/components/home/trust-strip.tsx
@@ -1,6 +1,8 @@
-import { InfoChip } from "@/components/shared/design-system-recipes";
+import { Building2, FileText, BarChart3, RefreshCw } from "lucide-react";
+
 import type { HealthResponse } from "@/lib/api";
 import { formatCompactInteger } from "@/lib/formatters";
+import { cn } from "@/lib/utils";
 
 type TrustStripProps = {
   health: HealthResponse | null;
@@ -8,28 +10,54 @@ type TrustStripProps = {
 };
 
 export function TrustStrip({ health, totalCompanies }: TrustStripProps) {
-  const statusLabel = health?.status === "ok" ? "API online" : "API indisponivel";
-  const dialectLabel = health?.database_dialect
-    ? health.database_dialect.toUpperCase()
-    : "N/A";
+  const isOnline = health?.status === "ok";
+
+  const metrics = [
+    {
+      icon: Building2,
+      label: "Companhias",
+      value: formatCompactInteger(totalCompanies),
+      pulse: false,
+    },
+    {
+      icon: FileText,
+      label: "Demonstrações",
+      value: "1,7 M",
+      pulse: false,
+    },
+    {
+      icon: BarChart3,
+      label: "KPIs",
+      value: "60+",
+      pulse: false,
+    },
+    {
+      icon: RefreshCw,
+      label: "Atualizado",
+      value: isOnline ? "Agora" : "Indisponível",
+      pulse: isOnline,
+    },
+  ] as const;
 
   return (
     <div className="border-y border-border/60 bg-background/72 backdrop-blur-sm">
-      <div className="mx-auto flex w-full max-w-7xl flex-col gap-5 px-4 py-4 text-sm text-muted-foreground sm:px-6 lg:px-10 xl:flex-row xl:items-center xl:justify-between">
-        <div className="flex flex-wrap items-center gap-2.5">
-          <InfoChip tone="brand">Fonte CVM</InfoChip>
-          <InfoChip>{statusLabel}</InfoChip>
-          <InfoChip>Banco {dialectLabel}</InfoChip>
-          <InfoChip>
-            {totalCompanies !== null
-              ? `${formatCompactInteger(totalCompanies)} empresas com dados`
-              : "Diretorio publico em leitura"}
-          </InfoChip>
-        </div>
-        <p className="max-w-2xl text-sm leading-7">
-          Fluxo inicial focado em descoberta por empresa, leitura historica e
-          navegacao rasa antes das areas de comparacao e contexto setorial.
-        </p>
+      <div className="mx-auto flex w-full max-w-7xl flex-wrap items-center justify-center gap-8 px-4 py-5 sm:px-6 lg:px-10 xl:justify-between">
+        {metrics.map(({ icon: Icon, label, value, pulse }) => (
+          <div key={label} className="flex items-center gap-3">
+            <Icon
+              className={cn(
+                "size-4 text-muted-foreground",
+                pulse && "animate-spin",
+              )}
+            />
+            <div className="space-y-0.5">
+              <p className="text-xs uppercase tracking-[0.14em] text-muted-foreground">
+                {label}
+              </p>
+              <p className="text-sm font-medium text-foreground">{value}</p>
+            </div>
+          </div>
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- **CompanySearchHero**: remove wrapper SurfaceCard, h1 com clamp tipográfico + italic span, subtítulo descritivo; busca com autocomplete sem regressão
- **DiscoverySection** (novo arquivo): 3 abas client-side — Populares (6 empresas em grid), Em destaque (4 cards com cor de setor), Setores (10 cards de setor com dot colorido)
- **TrustStrip**: 4 métricas com ícones lucide (Companhias, Demonstrações, KPIs, Atualizado com `animate-spin` quando online)
- **page.tsx**: layout centrado sem grid 2-col, fetcha `topCompanies` em paralelo, remove SurfaceCard de descrição e `FutureDomainGrid`

## Test plan

- [ ] Home carrega sem erro de runtime
- [ ] Hero search centralizado, h1 com font clamp visível
- [ ] Busca com autocomplete funciona (digitar 2+ chars retorna sugestões)
- [ ] DiscoverySection renderiza 3 abas; trocar aba funciona
- [ ] TrustStrip mostra 4 métricas com ícones
- [ ] Mobile: layout colapsa corretamente
- [ ] CI: lint + type-check passam

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)