### PR TITLE
feat(web): directory redesenhado — left rail, view toggle e company row/card

### DIFF
--- a/apps/web/app/empresas/page.tsx
+++ b/apps/web/app/empresas/page.tsx
@@ -5,16 +5,15 @@ import { CompanyDirectoryFilters } from "@/components/companies/company-director
 import { CompanyDirectoryList } from "@/components/companies/company-directory-list";
 import { DirectoryPagination } from "@/components/companies/directory-pagination";
 import {
-  InfoChip,
   PageShell,
-  SectionHeading,
   SurfaceCard,
+  SectionHeading,
 } from "@/components/shared/design-system-recipes";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { buttonVariants } from "@/components/ui/button";
 import { formatCompactInteger } from "@/lib/formatters";
 import { loadCompaniesPageData } from "@/lib/companies-page-data";
-import { coercePositiveInt, getFirstParam } from "@/lib/search-params";
+import { coercePositiveInt, getFirstParam, mergeSearchParams } from "@/lib/search-params";
 import { cn } from "@/lib/utils";
 
 export const metadata: Metadata = {
@@ -25,13 +24,13 @@ export const metadata: Metadata = {
 
 export const dynamic = "force-dynamic";
 
+const PAGE_SIZE = 20;
+
 type EmpresasPageProps = {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 };
 
-export default async function EmpresasPage({
-  searchParams,
-}: EmpresasPageProps) {
+export default async function EmpresasPage({ searchParams }: EmpresasPageProps) {
   const resolvedSearchParams = await searchParams;
   const currentSearch = getFirstParam(resolvedSearchParams.busca) ?? "";
   const currentSector = getFirstParam(resolvedSearchParams.setor) ?? null;
@@ -39,16 +38,13 @@ export default async function EmpresasPage({
     getFirstParam(resolvedSearchParams.pagina),
     1,
   );
+  const rawView = getFirstParam(resolvedSearchParams.view);
+  const viewMode: "rows" | "cards" = rawView === "cards" ? "cards" : "rows";
+
   const retryParams = new URLSearchParams();
-  if (currentSearch) {
-    retryParams.set("busca", currentSearch);
-  }
-  if (currentSector) {
-    retryParams.set("setor", currentSector);
-  }
-  if (currentPage > 1) {
-    retryParams.set("pagina", String(currentPage));
-  }
+  if (currentSearch) retryParams.set("busca", currentSearch);
+  if (currentSector) retryParams.set("setor", currentSector);
+  if (currentPage > 1) retryParams.set("pagina", String(currentPage));
   const retryQuery = retryParams.toString();
   const retryHref = retryQuery ? `/empresas?${retryQuery}` : "/empresas";
 
@@ -57,7 +53,7 @@ export default async function EmpresasPage({
       search: currentSearch,
       sector: currentSector,
       page: currentPage,
-      pageSize: 20,
+      pageSize: PAGE_SIZE,
     });
 
   if (!directory) {
@@ -65,16 +61,16 @@ export default async function EmpresasPage({
       <PageShell density="relaxed" className="max-w-4xl">
         <SurfaceCard tone="hero" padding="hero" className="space-y-6">
           <SectionHeading
-            eyebrow="PG-02 - Hub de empresas"
-            title="Diretorio temporariamente indisponivel"
+            eyebrow="Empresas"
+            title="Diretório temporariamente indisponível"
             titleAs="h1"
-            description="A listagem de empresas nao respondeu agora. O fluxo de busca e navegacao pode ser retomado assim que a API voltar a responder."
+            description="A listagem de empresas não respondeu agora. O fluxo de busca e navegação pode ser retomado assim que a API voltar a responder."
           />
           <Alert className="rounded-[1.75rem] border border-destructive/25 bg-destructive/6 px-5 py-5 text-left">
             <AlertTitle>Falha controlada da listagem</AlertTitle>
             <AlertDescription>
               {directoryError ??
-                "Nao foi possivel carregar o diretorio de empresas agora. Tente novamente em instantes."}
+                "Não foi possível carregar o diretório de empresas agora. Tente novamente em instantes."}
             </AlertDescription>
           </Alert>
           <div className="flex flex-wrap gap-3">
@@ -99,46 +95,73 @@ export default async function EmpresasPage({
     );
   }
 
+  const currentParamsStr = mergeSearchParams("", {
+    busca: currentSearch || null,
+    setor: currentSector,
+    pagina: currentPage > 1 ? currentPage : null,
+  });
+  const viewRowsHref = mergeSearchParams(currentParamsStr, { view: null })
+    ? `/empresas?${mergeSearchParams(currentParamsStr, { view: null })}`
+    : "/empresas";
+  const viewCardsHref = `/empresas?${mergeSearchParams(currentParamsStr, { view: "cards" }) || "view=cards"}`;
+  const clearHref = viewMode === "cards" ? "/empresas?view=cards" : "/empresas";
+
   return (
     <PageShell density="default">
-      <SectionHeading
-        eyebrow="PG-02 - Hub de empresas"
-        title="Diretorio publico de empresas"
-        titleAs="h1"
-        description="Use busca, setor canonico e paginacao para cair na companhia certa sem depender de navegacao lateral ou filtros client-side opacos."
-        meta={
-          <InfoChip tone="muted">
-            {formatCompactInteger(directory.pagination.total_items)} resultados
-          </InfoChip>
-        }
-      />
+      <div className="flex flex-col gap-2">
+        <h1 className="font-heading text-2xl text-foreground">
+          Diretório de empresas
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          {formatCompactInteger(directory.pagination.total_items)} resultados
+          {currentSearch ? ` para "${currentSearch}"` : ""}
+          {currentSector ? ` · ${currentSector}` : ""}
+        </p>
+      </div>
 
       {filtersError ? (
         <Alert className="rounded-[1.75rem] border border-border/70 bg-background/85 px-5 py-4">
-          <AlertTitle>Filtro setorial indisponivel</AlertTitle>
+          <AlertTitle>Filtro setorial indisponível</AlertTitle>
           <AlertDescription>
-            {filtersError} A busca livre e a paginacao continuam disponiveis.
+            {filtersError} A busca livre e a paginação continuam disponíveis.
           </AlertDescription>
         </Alert>
       ) : null}
 
-      <CompanyDirectoryFilters
-        currentSearch={currentSearch}
-        currentSector={currentSector}
-        sectors={filters?.sectors ?? []}
-        sectorFilterUnavailable={Boolean(filtersError)}
-      />
+      <div className="grid gap-8 lg:grid-cols-[280px_1fr]">
+        <aside className="lg:sticky lg:top-24 lg:self-start">
+          <div className="rounded-xl border border-border/60 bg-card p-5">
+            <CompanyDirectoryFilters
+              currentSearch={currentSearch}
+              currentSector={currentSector}
+              sectors={filters?.sectors ?? []}
+              sectorFilterUnavailable={Boolean(filtersError)}
+            />
+          </div>
+        </aside>
 
-      <CompanyDirectoryList items={directory.items} />
+        <div className="space-y-6">
+          <CompanyDirectoryList
+            items={directory.items}
+            viewMode={viewMode}
+            viewRowsHref={viewRowsHref}
+            viewCardsHref={viewCardsHref}
+            hasActiveFilters={Boolean(currentSearch || currentSector)}
+            clearHref={clearHref}
+          />
 
-      <DirectoryPagination
-        currentPage={directory.pagination.page}
-        totalPages={directory.pagination.total_pages}
-        hasNext={directory.pagination.has_next}
-        hasPrevious={directory.pagination.has_previous}
-        currentSearch={currentSearch}
-        currentSector={Boolean(filtersError) ? null : currentSector}
-      />
+          <DirectoryPagination
+            currentPage={directory.pagination.page}
+            totalPages={directory.pagination.total_pages}
+            totalItems={directory.pagination.total_items}
+            pageSize={PAGE_SIZE}
+            hasNext={directory.pagination.has_next}
+            hasPrevious={directory.pagination.has_previous}
+            currentSearch={currentSearch}
+            currentSector={Boolean(filtersError) ? null : currentSector}
+          />
+        </div>
+      </div>
     </PageShell>
   );
 }

--- a/apps/web/components/companies/company-card.tsx
+++ b/apps/web/components/companies/company-card.tsx
@@ -1,0 +1,48 @@
+import Link from "next/link";
+import { ArrowUpRightIcon } from "lucide-react";
+
+import type { CompanyDirectoryItem } from "@/lib/api";
+import { getSectorColor } from "@/lib/constants";
+import { formatYearsLabel } from "@/lib/formatters";
+import { cn } from "@/lib/utils";
+
+type CompanyCardProps = {
+  item: CompanyDirectoryItem;
+};
+
+export function CompanyCard({ item }: CompanyCardProps) {
+  const sectorColor = getSectorColor(item.sector_name);
+  const hasData = item.has_financial_data !== false;
+
+  return (
+    <Link
+      href={hasData ? `/empresas/${item.cd_cvm}` : "#"}
+      aria-disabled={!hasData}
+      className={cn(
+        "group flex flex-col justify-between gap-4 overflow-hidden rounded-xl border border-border/60 bg-card px-5 py-4 transition-colors",
+        hasData ? "hover:border-border hover:bg-muted/30" : "pointer-events-none opacity-50",
+      )}
+      style={{ borderLeftColor: sectorColor, borderLeftWidth: 3 }}
+    >
+      <div className="space-y-1.5">
+        <div className="flex items-center justify-between gap-2">
+          <span
+            className="flex h-6 items-center rounded-full px-2 text-[0.65rem] font-semibold uppercase tracking-[0.12em] text-white"
+            style={{ backgroundColor: sectorColor }}
+          >
+            {item.ticker_b3 ?? "—"}
+          </span>
+          <ArrowUpRightIcon className="size-3.5 shrink-0 text-muted-foreground transition-colors group-hover:text-primary" />
+        </div>
+        <p className="font-heading text-base font-medium text-foreground leading-tight line-clamp-2">
+          {item.company_name}
+        </p>
+        <p className="text-xs text-muted-foreground">{item.sector_name}</p>
+      </div>
+
+      <p className="text-xs text-muted-foreground">
+        {formatYearsLabel(item.anos_disponiveis)}
+      </p>
+    </Link>
+  );
+}

--- a/apps/web/components/companies/company-directory-filters.tsx
+++ b/apps/web/components/companies/company-directory-filters.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { SearchIcon } from "lucide-react";
+import { SearchIcon, XIcon } from "lucide-react";
 import { startTransition, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 
-import { SurfaceCard } from "@/components/shared/design-system-recipes";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -35,6 +34,7 @@ export function CompanyDirectoryFilters({
   const router = useRouter();
   const searchParams = useSearchParams();
   const [search, setSearch] = useState(currentSearch);
+
   const hasCurrentSector = sectors.some(
     (sector) => sector.sector_slug === currentSector,
   );
@@ -43,7 +43,11 @@ export function CompanyDirectoryFilters({
       ? "all"
       : currentSector ?? "all";
 
-  function pushFilters(updates: Record<string, string | number | null | undefined>) {
+  const hasActiveFilters = Boolean(currentSearch || currentSector);
+
+  function pushFilters(
+    updates: Record<string, string | number | null | undefined>,
+  ) {
     const query = mergeSearchParams(searchParams.toString(), updates);
     const href = query ? `/empresas?${query}` : "/empresas";
 
@@ -70,68 +74,85 @@ export function CompanyDirectoryFilters({
     });
   }
 
+  function handleClear() {
+    setSearch("");
+    pushFilters({ busca: null, setor: null, pagina: null });
+  }
+
   return (
-    <SurfaceCard tone="subtle" padding="md">
-      <form
-        onSubmit={handleSubmit}
-        className="flex flex-col gap-3 lg:flex-row lg:items-center"
-      >
-        <div className="flex flex-1 items-center gap-3 rounded-[1.15rem] border border-border/65 bg-muted/55 px-4 py-3">
-          <SearchIcon className="size-4 text-muted-foreground" />
+    <form onSubmit={handleSubmit} className="space-y-5">
+      <p className="eyebrow text-muted-foreground">Filtros</p>
+
+      <div className="space-y-1.5">
+        <label className="text-xs font-medium text-foreground">Busca</label>
+        <div className="flex items-center gap-2 rounded-[1rem] border border-border/65 bg-muted/55 px-3 py-2.5">
+          <SearchIcon className="size-3.5 shrink-0 text-muted-foreground" />
           <Input
             type="search"
             value={search}
             onChange={(event) => setSearch(event.target.value)}
-            placeholder="Buscar por nome, ticker ou codigo CVM"
-            className="h-auto border-0 bg-transparent p-0 shadow-none focus-visible:ring-0"
+            placeholder="Nome, ticker ou CVM"
+            className="h-auto border-0 bg-transparent p-0 text-sm shadow-none focus-visible:ring-0"
           />
         </div>
+      </div>
 
-        <div className="flex flex-col gap-3 sm:flex-row lg:w-auto">
-          <Select
-            value={selectValue}
-            disabled={sectorFilterUnavailable}
-            onValueChange={(value) => {
-              const nextSector = value === "all" ? null : value;
-              track("companies_filter_changed", {
-                search,
-                sector: nextSector,
-                source: "sector",
-              });
-              pushFilters({
-                setor: nextSector,
-                pagina: null,
-              });
-            }}
-          >
-            <SelectTrigger className="h-11 min-w-56 rounded-[1.15rem] bg-background px-4">
-              <SelectValue
-                placeholder={
-                  sectorFilterUnavailable
-                    ? "Filtro setorial indisponivel"
-                    : "Todos os setores"
-                }
-              />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectGroup>
-                <SelectItem value="all">Todos os setores</SelectItem>
-                {!sectorFilterUnavailable
-                  ? sectors.map((sector) => (
-                      <SelectItem key={sector.sector_slug} value={sector.sector_slug}>
-                        {sector.sector_name} - {sector.company_count}
-                      </SelectItem>
-                    ))
-                  : null}
-              </SelectGroup>
-            </SelectContent>
-          </Select>
+      <div className="space-y-1.5">
+        <label className="text-xs font-medium text-foreground">Setor</label>
+        <Select
+          value={selectValue}
+          disabled={sectorFilterUnavailable}
+          onValueChange={(value) => {
+            const nextSector = value === "all" ? null : value;
+            track("companies_filter_changed", {
+              search,
+              sector: nextSector,
+              source: "sector",
+            });
+            pushFilters({ setor: nextSector, pagina: null });
+          }}
+        >
+          <SelectTrigger className="h-10 w-full rounded-[1rem] bg-background px-3 text-sm">
+            <SelectValue
+              placeholder={
+                sectorFilterUnavailable
+                  ? "Filtro indisponível"
+                  : "Todos os setores"
+              }
+            />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              <SelectItem value="all">Todos os setores</SelectItem>
+              {!sectorFilterUnavailable
+                ? sectors.map((sector) => (
+                    <SelectItem
+                      key={sector.sector_slug}
+                      value={sector.sector_slug}
+                    >
+                      {sector.sector_name} · {sector.company_count}
+                    </SelectItem>
+                  ))
+                : null}
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+      </div>
 
-          <Button type="submit" size="lg" className="h-11 rounded-full px-5">
-            Aplicar filtros
-          </Button>
-        </div>
-      </form>
-    </SurfaceCard>
+      <Button type="submit" size="sm" className="w-full rounded-full">
+        Aplicar filtros
+      </Button>
+
+      {hasActiveFilters ? (
+        <button
+          type="button"
+          onClick={handleClear}
+          className="flex w-full items-center justify-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <XIcon className="size-3" />
+          Limpar filtros
+        </button>
+      ) : null}
+    </form>
   );
 }

--- a/apps/web/components/companies/company-directory-list.tsx
+++ b/apps/web/components/companies/company-directory-list.tsx
@@ -1,114 +1,105 @@
 import Link from "next/link";
+import { InboxIcon } from "lucide-react";
 
+import { CompanyCard } from "@/components/companies/company-card";
+import { CompanyRow } from "@/components/companies/company-row";
 import { SurfaceCard } from "@/components/shared/design-system-recipes";
-import { Badge } from "@/components/ui/badge";
 import { buttonVariants } from "@/components/ui/button";
 import type { CompanyDirectoryItem } from "@/lib/api";
-import { formatInteger, formatYearsLabel } from "@/lib/formatters";
 import { cn } from "@/lib/utils";
 
 type CompanyDirectoryListProps = {
   items: CompanyDirectoryItem[];
+  viewMode: "rows" | "cards";
+  viewRowsHref: string;
+  viewCardsHref: string;
+  hasActiveFilters: boolean;
+  clearHref: string;
 };
 
-export function CompanyDirectoryList({ items }: CompanyDirectoryListProps) {
-  if (items.length === 0) {
-    return (
-      <SurfaceCard
-        tone="muted"
-        padding="hero"
-        className="items-center text-center"
-      >
-        <p className="font-heading text-2xl text-foreground">
-          Nenhuma empresa encontrada.
-        </p>
-        <p className="max-w-2xl text-sm leading-7 text-muted-foreground">
-          Ajuste o termo de busca ou remova o filtro setorial para ampliar o
-          diretorio disponivel.
-        </p>
-      </SurfaceCard>
-    );
-  }
+export function CompanyDirectoryList({
+  items,
+  viewMode,
+  viewRowsHref,
+  viewCardsHref,
+  hasActiveFilters,
+  clearHref,
+}: CompanyDirectoryListProps) {
+  const toggleBase =
+    "flex h-8 w-8 items-center justify-center rounded-lg border transition-colors text-sm";
 
   return (
-    <SurfaceCard tone="default" padding="none" className="overflow-hidden">
-      <div className="divide-y divide-border/55">
-        {items.map((item) => {
-          const hasFinancialData = item.has_financial_data !== false;
-
-          return (
-            <article
-              key={item.cd_cvm}
-              className={cn(
-                "grid gap-6 px-6 py-6 transition-colors md:grid-cols-[minmax(0,1fr)_auto]",
-                hasFinancialData ? "group hover:bg-muted/35" : "bg-background/35",
-              )}
-            >
-              <div className="space-y-4">
-                <div className="flex flex-wrap items-center gap-3">
-                  <h2 className="font-heading text-[1.35rem] leading-tight text-foreground">
-                    {item.company_name}
-                  </h2>
-                  {item.ticker_b3 ? (
-                    <Badge
-                      variant="outline"
-                      className="rounded-full border-border/75 bg-background/70 text-[0.68rem] uppercase tracking-[0.16em] text-muted-foreground"
-                    >
-                      {item.ticker_b3}
-                    </Badge>
-                  ) : null}
-                  <Badge
-                    variant="outline"
-                    className="rounded-full border-border/75 bg-secondary/35 text-[0.72rem] text-foreground"
-                  >
-                    {item.sector_name}
-                  </Badge>
-                  {!hasFinancialData ? (
-                    <Badge
-                      variant="secondary"
-                      className="rounded-full bg-muted text-[0.72rem] text-muted-foreground"
-                    >
-                      Sem dados
-                    </Badge>
-                  ) : null}
-                </div>
-
-                <div className="flex flex-wrap gap-x-5 gap-y-2 text-sm text-muted-foreground">
-                  <span>CVM {item.cd_cvm}</span>
-                  <span>{formatYearsLabel(item.anos_disponiveis)}</span>
-                  <span>
-                    {hasFinancialData ? `${formatInteger(item.total_rows)} linhas` : "-"}
-                  </span>
-                </div>
-              </div>
-
-              <div className="flex items-center md:justify-end">
-                {hasFinancialData ? (
-                  <Link
-                    href={`/empresas/${item.cd_cvm}`}
-                    className={cn(
-                      buttonVariants({ variant: "outline", size: "lg" }),
-                      "rounded-full px-5 transition-transform group-hover:-translate-y-px",
-                    )}
-                  >
-                    Ver empresa
-                  </Link>
-                ) : (
-                  <span
-                    aria-disabled="true"
-                    className={cn(
-                      buttonVariants({ variant: "ghost", size: "lg" }),
-                      "pointer-events-none rounded-full px-5 text-muted-foreground opacity-70",
-                    )}
-                  >
-                    Ver empresa
-                  </span>
-                )}
-              </div>
-            </article>
-          );
-        })}
+    <div className="space-y-4">
+      <div className="flex items-center justify-end gap-1.5">
+        <Link
+          href={viewRowsHref}
+          title="Ver em linhas"
+          className={cn(
+            toggleBase,
+            viewMode === "rows"
+              ? "border-border bg-muted text-foreground"
+              : "border-border/40 text-muted-foreground hover:border-border hover:text-foreground",
+          )}
+        >
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden>
+            <rect x="1" y="2" width="12" height="2" rx="0.5" fill="currentColor" />
+            <rect x="1" y="6" width="12" height="2" rx="0.5" fill="currentColor" />
+            <rect x="1" y="10" width="12" height="2" rx="0.5" fill="currentColor" />
+          </svg>
+        </Link>
+        <Link
+          href={viewCardsHref}
+          title="Ver em cards"
+          className={cn(
+            toggleBase,
+            viewMode === "cards"
+              ? "border-border bg-muted text-foreground"
+              : "border-border/40 text-muted-foreground hover:border-border hover:text-foreground",
+          )}
+        >
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden>
+            <rect x="1" y="1" width="5" height="5" rx="1" fill="currentColor" />
+            <rect x="8" y="1" width="5" height="5" rx="1" fill="currentColor" />
+            <rect x="1" y="8" width="5" height="5" rx="1" fill="currentColor" />
+            <rect x="8" y="8" width="5" height="5" rx="1" fill="currentColor" />
+          </svg>
+        </Link>
       </div>
-    </SurfaceCard>
+
+      {items.length === 0 ? (
+        <SurfaceCard tone="muted" padding="hero" className="items-center text-center">
+          <InboxIcon className="size-10 text-muted-foreground/50" />
+          <p className="font-heading text-xl text-foreground">
+            Nenhuma empresa encontrada.
+          </p>
+          <p className="max-w-sm text-sm leading-7 text-muted-foreground">
+            Ajuste o termo de busca ou remova o filtro setorial para ampliar o
+            diretório disponível.
+          </p>
+          {hasActiveFilters ? (
+            <Link
+              href={clearHref}
+              className={cn(buttonVariants({ variant: "outline", size: "sm" }), "rounded-full")}
+            >
+              Limpar filtros
+            </Link>
+          ) : null}
+        </SurfaceCard>
+      ) : viewMode === "cards" ? (
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+          {items.map((item) => (
+            <CompanyCard key={item.cd_cvm} item={item} />
+          ))}
+        </div>
+      ) : (
+        <SurfaceCard tone="default" padding="none" className="overflow-hidden">
+          <div className="divide-y divide-border/45">
+            {items.map((item) => (
+              <CompanyRow key={item.cd_cvm} item={item} />
+            ))}
+          </div>
+        </SurfaceCard>
+      )}
+    </div>
   );
 }

--- a/apps/web/components/companies/company-row.tsx
+++ b/apps/web/components/companies/company-row.tsx
@@ -1,0 +1,89 @@
+import Link from "next/link";
+import { ChevronRightIcon } from "lucide-react";
+
+import type { CompanyDirectoryItem } from "@/lib/api";
+import { getSectorColor } from "@/lib/constants";
+import { formatYearsLabel } from "@/lib/formatters";
+import { cn } from "@/lib/utils";
+
+function buildSparklinePoints(anos: number[]): string {
+  if (anos.length === 0) return "";
+  const sorted = [...anos].sort((a, b) => a - b);
+  const min = sorted[0]!;
+  const max = sorted[sorted.length - 1]!;
+  const rangeYears = max - min || 1;
+  const W = 48;
+  const H = 16;
+
+  return sorted
+    .map((year, i) => {
+      const x = ((year - min) / rangeYears) * W;
+      const y = H - (i / Math.max(sorted.length - 1, 1)) * (H * 0.75) - 2;
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+}
+
+type CompanyRowProps = {
+  item: CompanyDirectoryItem;
+};
+
+export function CompanyRow({ item }: CompanyRowProps) {
+  const sectorColor = getSectorColor(item.sector_name);
+  const hasData = item.has_financial_data !== false;
+  const sparkPoints = buildSparklinePoints(item.anos_disponiveis);
+
+  return (
+    <Link
+      href={hasData ? `/empresas/${item.cd_cvm}` : "#"}
+      aria-disabled={!hasData}
+      className={cn(
+        "group flex h-[54px] items-center gap-4 px-5 transition-colors",
+        hasData
+          ? "hover:bg-muted/40 cursor-pointer"
+          : "pointer-events-none opacity-50",
+      )}
+    >
+      <span
+        className="flex h-7 min-w-[3.25rem] items-center justify-center rounded-full px-2 text-[0.68rem] font-semibold uppercase tracking-[0.12em] text-white"
+        style={{ backgroundColor: sectorColor }}
+      >
+        {item.ticker_b3 ?? "—"}
+      </span>
+
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium text-foreground">
+          {item.company_name}
+        </p>
+        <p className="truncate text-xs text-muted-foreground">
+          {item.sector_name}
+        </p>
+      </div>
+
+      {sparkPoints ? (
+        <svg
+          width={48}
+          height={16}
+          viewBox="0 0 48 16"
+          className="hidden shrink-0 text-primary sm:block"
+          aria-hidden
+        >
+          <polyline
+            points={sparkPoints}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      ) : null}
+
+      <span className="hidden w-20 text-right text-xs text-muted-foreground sm:block">
+        {formatYearsLabel(item.anos_disponiveis)}
+      </span>
+
+      <ChevronRightIcon className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+    </Link>
+  );
+}

--- a/apps/web/components/companies/directory-pagination.tsx
+++ b/apps/web/components/companies/directory-pagination.tsx
@@ -2,22 +2,17 @@
 
 import { startTransition } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
 
-import {
-  Pagination,
-  PaginationContent,
-  PaginationEllipsis,
-  PaginationItem,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
-} from "@/components/ui/pagination";
 import { mergeSearchParams } from "@/lib/search-params";
 import { track } from "@/lib/track";
+import { cn } from "@/lib/utils";
 
 type DirectoryPaginationProps = {
   currentPage: number;
   totalPages: number;
+  totalItems: number;
+  pageSize: number;
   hasNext: boolean;
   hasPrevious: boolean;
   currentSearch: string;
@@ -25,16 +20,24 @@ type DirectoryPaginationProps = {
 };
 
 function getVisiblePages(currentPage: number, totalPages: number): number[] {
-  const pages = new Set([1, totalPages, currentPage - 1, currentPage, currentPage + 1]);
+  const pages = new Set([
+    1,
+    totalPages,
+    currentPage - 1,
+    currentPage,
+    currentPage + 1,
+  ]);
 
   return Array.from(pages)
     .filter((page) => page >= 1 && page <= totalPages)
-    .sort((left, right) => left - right);
+    .sort((a, b) => a - b);
 }
 
 export function DirectoryPagination({
   currentPage,
   totalPages,
+  totalItems,
+  pageSize,
   hasNext,
   hasPrevious,
   currentSearch,
@@ -46,6 +49,9 @@ export function DirectoryPagination({
   if (totalPages <= 1) {
     return null;
   }
+
+  const rangeStart = (currentPage - 1) * pageSize + 1;
+  const rangeEnd = Math.min(currentPage * pageSize, totalItems);
 
   function goTo(page: number) {
     const query = mergeSearchParams(searchParams.toString(), {
@@ -66,61 +72,74 @@ export function DirectoryPagination({
   }
 
   const visiblePages = getVisiblePages(currentPage, totalPages);
+  const pillBase =
+    "flex h-8 min-w-8 items-center justify-center rounded-full px-2.5 text-sm transition-colors";
 
   return (
-    <Pagination className="justify-start">
-      <PaginationContent>
-        <PaginationItem>
-          <PaginationPrevious
-            href="#"
-            text="Anterior"
-            aria-disabled={!hasPrevious}
-            className={!hasPrevious ? "pointer-events-none opacity-40" : ""}
-            onClick={(event) => {
-              event.preventDefault();
-              if (hasPrevious) {
-                goTo(currentPage - 1);
-              }
-            }}
-          />
-        </PaginationItem>
+    <div className="flex flex-col items-center gap-4 sm:flex-row sm:justify-between">
+      <p className="text-xs text-muted-foreground">
+        Mostrando {rangeStart}–{rangeEnd} de {totalItems}
+      </p>
+
+      <div className="flex items-center gap-1">
+        <button
+          type="button"
+          disabled={!hasPrevious}
+          onClick={() => hasPrevious && goTo(currentPage - 1)}
+          className={cn(
+            pillBase,
+            "border border-border/60",
+            hasPrevious
+              ? "hover:border-border hover:text-foreground text-muted-foreground"
+              : "pointer-events-none opacity-35",
+          )}
+          aria-label="Página anterior"
+        >
+          <ChevronLeftIcon className="size-4" />
+        </button>
 
         {visiblePages.map((page, index) => {
-          const previous = visiblePages[index - 1];
-          const showEllipsis = previous && page - previous > 1;
+          const prev = visiblePages[index - 1];
+          const showEllipsis = prev !== undefined && page - prev > 1;
 
           return (
-            <PaginationItem key={page}>
-              {showEllipsis ? <PaginationEllipsis /> : null}
-              <PaginationLink
-                href="#"
-                isActive={page === currentPage}
-                onClick={(event) => {
-                  event.preventDefault();
-                  goTo(page);
-                }}
+            <span key={page} className="flex items-center gap-1">
+              {showEllipsis ? (
+                <span className={cn(pillBase, "text-muted-foreground")}>…</span>
+              ) : null}
+              <button
+                type="button"
+                onClick={() => goTo(page)}
+                className={cn(
+                  pillBase,
+                  "border",
+                  page === currentPage
+                    ? "border-primary bg-primary text-primary-foreground font-medium"
+                    : "border-border/60 text-muted-foreground hover:border-border hover:text-foreground",
+                )}
               >
                 {page}
-              </PaginationLink>
-            </PaginationItem>
+              </button>
+            </span>
           );
         })}
 
-        <PaginationItem>
-          <PaginationNext
-            href="#"
-            text="Proxima"
-            aria-disabled={!hasNext}
-            className={!hasNext ? "pointer-events-none opacity-40" : ""}
-            onClick={(event) => {
-              event.preventDefault();
-              if (hasNext) {
-                goTo(currentPage + 1);
-              }
-            }}
-          />
-        </PaginationItem>
-      </PaginationContent>
-    </Pagination>
+        <button
+          type="button"
+          disabled={!hasNext}
+          onClick={() => hasNext && goTo(currentPage + 1)}
+          className={cn(
+            pillBase,
+            "border border-border/60",
+            hasNext
+              ? "hover:border-border hover:text-foreground text-muted-foreground"
+              : "pointer-events-none opacity-35",
+          )}
+          aria-label="Próxima página"
+        >
+          <ChevronRightIcon className="size-4" />
+        </button>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

- **empresas/page.tsx**: grid `lg:grid-cols-[280px_1fr]` com left rail sticky; lê `?view=rows|cards` dos searchParams; computa URLs de toggle preservando filtros ativos
- **CompanyDirectoryFilters**: layout vertical (stack) com eyebrow "Filtros", search input, select de setor e botão "Limpar filtros" (visível só quando há filtro ativo)
- **CompanyDirectoryList**: aceita `viewMode: 'rows' | 'cards'`; toggle de view via links server-rendered; empty state com `InboxIcon` + botão limpar
- **CompanyRow** (novo): altura 54px, ticker badge colorido via `getSectorColor`, sparkline SVG 48×16 gerado dos anos disponíveis, `formatYearsLabel`, chevron de navegação
- **CompanyCard** (novo): `border-left` colorida por setor, ticker badge, nome com clamp, setor, anos disponíveis
- **DirectoryPagination**: range "Mostrando X–Y de Z", pills numerados com `ChevronLeft/Right`, remove dependência do `<Pagination>` do shadcn

## Test plan

- [ ] `/empresas` carrega com left rail à esquerda (lg+) e colapsa em mobile
- [ ] Busca e filtro de setor funcionam sem regressão
- [ ] Botão "Limpar filtros" aparece só quando há filtro ativo
- [ ] Toggle rows/cards persiste no URL e muda a view
- [ ] View rows: ticker badge colorido, sparkline e anos disponíveis visíveis
- [ ] View cards: grid 2/3 colunas responsivo com border-left colorida
- [ ] Paginação mostra range e pills numerados
- [ ] CI: guardrail + tests passam

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)