### PR TITLE
feat(web): company cockpit — hero gradiente, KPI row, hero chart e right rail

### DIFF
--- a/apps/web/app/empresas/[cd_cvm]/page.tsx
+++ b/apps/web/app/empresas/[cd_cvm]/page.tsx
@@ -191,7 +191,7 @@ export default async function EmpresaDetailPage({
 
       {currentTab === "visao-geral" ? (
         bundle ? (
-          <CompanyOverview bundle={bundle} />
+          <CompanyOverview bundle={bundle} cdCvm={cdCvm} />
         ) : (
           <Alert className="rounded-[1.75rem] border border-destructive/25 bg-destructive/6 px-5 py-5 text-left">
             <AlertTitle>Visao geral indisponivel</AlertTitle>

--- a/apps/web/components/company/company-freshness-card.tsx
+++ b/apps/web/components/company/company-freshness-card.tsx
@@ -1,0 +1,15 @@
+import { CompanyRequestRefresh } from "@/components/company/company-request-refresh";
+import { SurfaceCard } from "@/components/shared/design-system-recipes";
+
+type CompanyFreshnessCardProps = {
+  cdCvm: number;
+};
+
+export function CompanyFreshnessCard({ cdCvm }: CompanyFreshnessCardProps) {
+  return (
+    <SurfaceCard tone="inset" padding="md">
+      <p className="eyebrow mb-3 text-muted-foreground">Atualização</p>
+      <CompanyRequestRefresh cdCvm={cdCvm} />
+    </SurfaceCard>
+  );
+}

--- a/apps/web/components/company/company-header.tsx
+++ b/apps/web/components/company/company-header.tsx
@@ -1,13 +1,11 @@
 import Link from "next/link";
 import { ChevronRightIcon } from "lucide-react";
 
-import {
-  InfoChip,
-  SurfaceCard,
-} from "@/components/shared/design-system-recipes";
+import { InfoChip } from "@/components/shared/design-system-recipes";
 import { ExcelDownloadButton } from "@/components/shared/excel-download-button";
 import { Button, buttonVariants } from "@/components/ui/button";
 import type { CompanyInfo } from "@/lib/api";
+import { getSectorColor } from "@/lib/constants";
 import { cn } from "@/lib/utils";
 
 type CompanyHeaderProps = {
@@ -15,19 +13,26 @@ type CompanyHeaderProps = {
   selectedYears: number[];
 };
 
-export function CompanyHeader({
-  company,
-  selectedYears,
-}: CompanyHeaderProps) {
-  const compareParams = new URLSearchParams({
-    ids: String(company.cd_cvm),
-  });
+function getInitials(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((word) => word[0]!.toUpperCase())
+    .join("");
+}
+
+export function CompanyHeader({ company, selectedYears }: CompanyHeaderProps) {
+  const sectorColor = getSectorColor(company.sector_name);
+  const initials = getInitials(company.company_name);
+
+  const compareParams = new URLSearchParams({ ids: String(company.cd_cvm) });
   if (selectedYears.length > 0) {
     compareParams.set("anos", selectedYears.join(","));
   }
   const compareHref = `/comparar?${compareParams.toString()}`;
+
   const latestSelectedYear = selectedYears[selectedYears.length - 1] ?? null;
-  const earliestSelectedYear = selectedYears[0] ?? null;
   const sectorHref =
     company.sector_slug && latestSelectedYear
       ? `/setores/${company.sector_slug}?ano=${latestSelectedYear}`
@@ -35,15 +40,8 @@ export function CompanyHeader({
         ? `/setores/${company.sector_slug}`
         : null;
 
-  const freshnessLabel =
-    earliestSelectedYear && latestSelectedYear
-      ? earliestSelectedYear === latestSelectedYear
-        ? `Dados ${latestSelectedYear}`
-        : `Dados ${earliestSelectedYear}\u2013${latestSelectedYear}`
-      : "Fonte CVM";
-
   return (
-    <div className="space-y-5">
+    <div className="space-y-4">
       <nav aria-label="breadcrumb">
         <ol className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
           <li>
@@ -64,65 +62,73 @@ export function CompanyHeader({
         </ol>
       </nav>
 
-      <SurfaceCard tone="hero" padding="hero">
+      <div
+        className="overflow-hidden rounded-2xl border border-border/60 px-6 py-6 lg:px-8 lg:py-8"
+        style={{
+          background: `linear-gradient(135deg, color-mix(in oklch, ${sectorColor} 10%, var(--card)) 0%, var(--card) 70%)`,
+        }}
+      >
         <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
-          <div className="space-y-4">
-            <div className="flex flex-wrap items-center gap-2">
-              <InfoChip tone="brand">Detalhe da companhia</InfoChip>
-              <InfoChip>CVM {company.cd_cvm}</InfoChip>
-              <InfoChip tone="muted">Fonte CVM &middot; {freshnessLabel}</InfoChip>
+          <div className="flex flex-col gap-5 sm:flex-row sm:items-start">
+            <div
+              className="flex size-[88px] shrink-0 items-center justify-center rounded-[20px]"
+              style={{ backgroundColor: `${sectorColor}26` }}
+            >
+              <span
+                className="font-heading text-[1.6rem] font-bold leading-none"
+                style={{ color: sectorColor }}
+              >
+                {initials}
+              </span>
             </div>
 
             <div className="space-y-3">
-              <h1 className="font-heading text-4xl tracking-[-0.05em] text-foreground sm:text-5xl">
+              <div className="flex flex-wrap items-center gap-2">
+                {company.ticker_b3 ? (
+                  <InfoChip tone="brand">{company.ticker_b3}</InfoChip>
+                ) : null}
+                <InfoChip>CVM {company.cd_cvm}</InfoChip>
+              </div>
+              <h1 className="font-heading text-[clamp(1.8rem,3.5vw,2.5rem)] leading-[1.05] tracking-[-0.04em] text-foreground">
                 {company.company_name}
               </h1>
-              <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-                <span>{company.ticker_b3 ?? "Sem ticker"}</span>
-                <span aria-hidden="true">&middot;</span>
-                <span>{company.sector_name}</span>
-              </div>
+              <p className="text-sm text-muted-foreground">{company.sector_name}</p>
             </div>
           </div>
 
-          <div className="flex flex-wrap items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2 lg:shrink-0">
             <ExcelDownloadButton
               endpoint={`/api/companies/${company.cd_cvm}/excel`}
               fallbackFilename={`${company.ticker_b3 ?? `cvm${company.cd_cvm}`}.xlsx`}
-              buttonLabel="Baixar Excel"
-              pendingLabel="Preparando Excel..."
+              buttonLabel="Excel"
+              pendingLabel="Preparando..."
               trackingEvent="company_excel_download_clicked"
               failureTrackingEvent="company_excel_download_failed"
               trackingPayload={{
                 cd_cvm: company.cd_cvm,
                 company_name: company.company_name,
               }}
-              className="rounded-full px-5"
+              className="rounded-full px-4"
             />
             {sectorHref ? (
               <Link
                 href={sectorHref}
                 className={cn(
-                  buttonVariants({ variant: "ghost", size: "lg" }),
+                  buttonVariants({ variant: "outline", size: "sm" }),
                   "rounded-full px-4",
                 )}
               >
                 Ver setor
               </Link>
             ) : (
-              <Button
-                variant="ghost"
-                size="lg"
-                className="rounded-full px-4"
-                disabled
-              >
-                Setor indisponivel
+              <Button variant="outline" size="sm" className="rounded-full px-4" disabled>
+                Setor indisponível
               </Button>
             )}
             <Link
               href={compareHref}
               className={cn(
-                buttonVariants({ variant: "ghost", size: "lg" }),
+                buttonVariants({ variant: "outline", size: "sm" }),
                 "rounded-full px-4",
               )}
             >
@@ -130,7 +136,7 @@ export function CompanyHeader({
             </Link>
           </div>
         </div>
-      </SurfaceCard>
+      </div>
     </div>
   );
 }

--- a/apps/web/components/company/company-hero-chart.tsx
+++ b/apps/web/components/company/company-hero-chart.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useState } from "react";
+
+import {
+  SectionHeading,
+  SurfaceCard,
+} from "@/components/shared/design-system-recipes";
+import { cn } from "@/lib/utils";
+
+type ChartPoint = { year: number; value: number };
+
+type HeroChartSeries = {
+  label: string;
+  points: ChartPoint[];
+  formatSuffix?: string;
+};
+
+type CompanyHeroChartProps = {
+  series: HeroChartSeries[];
+};
+
+const PERIODS: { id: string; label: string; years: number }[] = [
+  { id: "3a", label: "3A", years: 3 },
+  { id: "5a", label: "5A", years: 5 },
+  { id: "all", label: "Todos", years: Infinity },
+];
+
+function SvgAreaChart({ points }: { points: ChartPoint[] }) {
+  if (points.length < 2) {
+    return (
+      <div className="flex h-[140px] items-center justify-center text-sm text-muted-foreground">
+        Dados insuficientes para o gráfico.
+      </div>
+    );
+  }
+
+  const W = 600;
+  const H = 140;
+  const PAD = { top: 12, right: 8, bottom: 20, left: 8 };
+  const innerW = W - PAD.left - PAD.right;
+  const innerH = H - PAD.top - PAD.bottom;
+
+  const values = points.map((p) => p.value);
+  const minVal = Math.min(...values);
+  const maxVal = Math.max(...values);
+  const range = maxVal - minVal || 1;
+
+  const toX = (i: number) =>
+    PAD.left + (i / (points.length - 1)) * innerW;
+  const toY = (v: number) =>
+    PAD.top + innerH - ((v - minVal) / range) * innerH;
+
+  const linePts = points
+    .map((p, i) => `${toX(i).toFixed(1)},${toY(p.value).toFixed(1)}`)
+    .join(" ");
+
+  const areaPath = [
+    `M ${toX(0).toFixed(1)} ${(PAD.top + innerH).toFixed(1)}`,
+    points
+      .map((p, i) => `L ${toX(i).toFixed(1)} ${toY(p.value).toFixed(1)}`)
+      .join(" "),
+    `L ${toX(points.length - 1).toFixed(1)} ${(PAD.top + innerH).toFixed(1)} Z`,
+  ].join(" ");
+
+  return (
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      className="w-full text-primary"
+      aria-hidden
+      preserveAspectRatio="none"
+    >
+      <defs>
+        <linearGradient id="hero-chart-grad" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="currentColor" stopOpacity="0.18" />
+          <stop offset="100%" stopColor="currentColor" stopOpacity="0.01" />
+        </linearGradient>
+      </defs>
+      <path d={areaPath} fill="url(#hero-chart-grad)" />
+      <polyline
+        points={linePts}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {points.map((p, i) => (
+        <text
+          key={p.year}
+          x={toX(i).toFixed(1)}
+          y={H - 4}
+          textAnchor="middle"
+          className="fill-muted-foreground text-[10px]"
+          fontSize={10}
+        >
+          {p.year}
+        </text>
+      ))}
+    </svg>
+  );
+}
+
+export function CompanyHeroChart({ series }: CompanyHeroChartProps) {
+  const [activeMetric, setActiveMetric] = useState(series[0]?.label ?? "");
+  const [activePeriod, setActivePeriod] = useState("all");
+
+  const currentSeries = series.find((s) => s.label === activeMetric) ?? series[0];
+  const periodYears =
+    PERIODS.find((p) => p.id === activePeriod)?.years ?? Infinity;
+  const filteredPoints = (currentSeries?.points ?? []).filter((p, _, arr) => {
+    const maxYear = Math.max(...arr.map((a) => a.year));
+    return p.year > maxYear - periodYears;
+  });
+
+  const pillBase =
+    "rounded-full border px-3 py-1 text-xs font-medium transition-colors";
+
+  if (series.length === 0 || !currentSeries) {
+    return null;
+  }
+
+  return (
+    <SurfaceCard tone="default" padding="lg">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <SectionHeading
+          title={activeMetric}
+          titleAs="h2"
+          eyebrow="Histórico"
+          bodyClassName="gap-0"
+        />
+        <div className="flex flex-wrap gap-2">
+          {series.map((s) => (
+            <button
+              key={s.label}
+              type="button"
+              onClick={() => setActiveMetric(s.label)}
+              className={cn(
+                pillBase,
+                s.label === activeMetric
+                  ? "border-primary bg-primary text-primary-foreground"
+                  : "border-border/60 text-muted-foreground hover:border-border hover:text-foreground",
+              )}
+            >
+              {s.label}
+            </button>
+          ))}
+          <div className="mx-1 w-px bg-border/60" aria-hidden />
+          {PERIODS.map((p) => (
+            <button
+              key={p.id}
+              type="button"
+              onClick={() => setActivePeriod(p.id)}
+              className={cn(
+                pillBase,
+                p.id === activePeriod
+                  ? "border-border bg-muted text-foreground"
+                  : "border-border/40 text-muted-foreground hover:border-border hover:text-foreground",
+              )}
+            >
+              {p.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-4">
+        <SvgAreaChart points={filteredPoints} />
+      </div>
+    </SurfaceCard>
+  );
+}

--- a/apps/web/components/company/company-kpi-row.tsx
+++ b/apps/web/components/company/company-kpi-row.tsx
@@ -1,0 +1,69 @@
+import { SurfaceCard } from "@/components/shared/design-system-recipes";
+import type { KPIBundle, TabularDataRow } from "@/lib/api";
+import { formatKpiDelta, formatKpiValue } from "@/lib/formatters";
+import { cn } from "@/lib/utils";
+
+const KPI_CARDS = [
+  { id: "MG_BRUTA", label: "Margem Bruta", formatType: "pct" },
+  { id: "MG_EBITDA", label: "Margem EBITDA", formatType: "pct" },
+  { id: "ROE", label: "ROE", formatType: "pct" },
+  { id: "MG_LIQ", label: "Margem Líquida", formatType: "pct" },
+] as const;
+
+type CompanyKpiRowProps = {
+  bundle: KPIBundle;
+};
+
+export function CompanyKpiRow({ bundle }: CompanyKpiRowProps) {
+  const annualRows = bundle.annual.rows as TabularDataRow[];
+  const yearColumns = bundle.annual.columns
+    .filter((c) => /^\d{4}$/.test(c))
+    .sort((a, b) => Number(a) - Number(b));
+  const lastYear = yearColumns.at(-1);
+  const kpiMap = new Map(annualRows.map((row) => [String(row.KPI_ID), row]));
+
+  return (
+    <div className="grid grid-cols-2 gap-3 xl:grid-cols-4">
+      {KPI_CARDS.map((kpi) => {
+        const row = kpiMap.get(kpi.id);
+        const currentValue =
+          row && lastYear ? Number(row[lastYear] ?? NaN) : null;
+        const deltaValue =
+          row?.DELTA_YOY === null || row?.DELTA_YOY === undefined
+            ? null
+            : Number(row.DELTA_YOY);
+        const isPositive = deltaValue !== null && deltaValue >= 0;
+
+        return (
+          <SurfaceCard key={kpi.id} tone="subtle" padding="md">
+            <div className="space-y-3">
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-xs text-muted-foreground">{kpi.label}</p>
+                <span className="text-[0.65rem] text-muted-foreground/60 tabular-nums">
+                  {lastYear ?? "—"}
+                </span>
+              </div>
+              <p className="font-heading text-2xl tracking-[-0.04em] text-foreground">
+                {formatKpiValue(currentValue, kpi.formatType)}
+              </p>
+              {deltaValue !== null ? (
+                <p
+                  className={cn(
+                    "text-xs",
+                    isPositive
+                      ? "text-green-600 dark:text-green-400"
+                      : "text-destructive",
+                  )}
+                >
+                  {formatKpiDelta(deltaValue, kpi.formatType)}
+                </p>
+              ) : (
+                <p className="text-xs text-muted-foreground/50">sem delta</p>
+              )}
+            </div>
+          </SurfaceCard>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/components/company/company-overview.tsx
+++ b/apps/web/components/company/company-overview.tsx
@@ -1,4 +1,12 @@
-import { Badge } from "@/components/ui/badge";
+import { CompanyFreshnessCard } from "@/components/company/company-freshness-card";
+import { CompanyHeroChart } from "@/components/company/company-hero-chart";
+import { CompanyKpiRow } from "@/components/company/company-kpi-row";
+import { CompanySectorRanking } from "@/components/company/company-sector-ranking";
+import { SparklineChip } from "@/components/shared/sparkline-chip";
+import {
+  SectionHeading,
+  SurfaceCard,
+} from "@/components/shared/design-system-recipes";
 import {
   Table,
   TableBody,
@@ -7,134 +15,149 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import {
-  SectionHeading,
-  SurfaceCard,
-} from "@/components/shared/design-system-recipes";
 import type { KPIBundle, TabularDataRow } from "@/lib/api";
-import { FEATURED_KPIS } from "@/lib/constants";
 import { formatKpiDelta, formatKpiValue } from "@/lib/formatters";
 
-type CompanyOverviewProps = {
-  bundle: KPIBundle;
-};
+const CHART_KPIS = [
+  { id: "RECEITA_LIQ", label: "Receita" },
+  { id: "EBITDA", label: "EBITDA" },
+  { id: "LUCRO_LIQ", label: "Lucro" },
+] as const;
+
+const SPARKLINE_KPIS = [
+  { id: "RECEITA_LIQ", label: "Receita Líquida", formatType: "brl" },
+  { id: "EBITDA", label: "EBITDA", formatType: "brl" },
+  { id: "MG_EBITDA", label: "Margem EBITDA", formatType: "pct" },
+] as const;
 
 function isYearColumn(value: string): boolean {
   return /^\d{4}$/.test(value);
 }
 
-export function CompanyOverview({ bundle }: CompanyOverviewProps) {
+type CompanyOverviewProps = {
+  bundle: KPIBundle;
+  cdCvm: number;
+};
+
+export function CompanyOverview({ bundle, cdCvm }: CompanyOverviewProps) {
   const annualRows = bundle.annual.rows as TabularDataRow[];
   const yearColumns = bundle.annual.columns
     .filter(isYearColumn)
-    .sort((left, right) => Number(left) - Number(right));
+    .sort((a, b) => Number(a) - Number(b));
   const lastYear = yearColumns.at(-1);
   const kpiMap = new Map(annualRows.map((row) => [String(row.KPI_ID), row]));
 
+  const chartSeries = CHART_KPIS.flatMap((kpi) => {
+    const row = kpiMap.get(kpi.id);
+    if (!row) return [];
+    const points = yearColumns.flatMap((year) => {
+      const val = row[year];
+      if (val === null || val === undefined) return [];
+      const num = Number(val);
+      if (isNaN(num)) return [];
+      return [{ year: Number(year), value: num }];
+    });
+    if (points.length < 2) return [];
+    return [{ label: kpi.label, points }];
+  });
+
   return (
-    <div className="space-y-8">
-      <section className="space-y-5">
-        <SectionHeading
-          eyebrow="Visao geral"
-          title="Indicadores-chave do periodo selecionado"
-          titleAs="h2"
-          descriptionClassName="text-base"
-        />
+    <div className="grid grid-cols-1 gap-6 lg:grid-cols-12 lg:gap-8">
+      <div className="flex flex-col gap-5 lg:col-span-8">
+        <CompanyKpiRow bundle={bundle} />
 
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-          {FEATURED_KPIS.map((kpi) => {
-            const row = kpiMap.get(kpi.id);
-            const formatType = String(row?.FORMAT_TYPE ?? kpi.formatType);
-            const currentValue = row && lastYear ? Number(row[lastYear] ?? NaN) : null;
-            const deltaValue =
-              row?.DELTA_YOY === null || row?.DELTA_YOY === undefined
-                ? null
-                : Number(row.DELTA_YOY);
+        {chartSeries.length > 0 ? (
+          <CompanyHeroChart series={chartSeries} />
+        ) : null}
 
-            return (
-              <SurfaceCard key={kpi.id} tone="subtle" padding="md">
-                <div className="space-y-4">
-                  <div className="flex items-center justify-between gap-3">
-                    <p className="text-sm text-muted-foreground">{kpi.label}</p>
-                    <Badge
-                      variant="outline"
-                      className="rounded-full border-border/80 bg-background/70 text-[0.68rem] uppercase tracking-[0.14em] text-muted-foreground"
-                    >
-                      {lastYear ?? "-"}
-                    </Badge>
-                  </div>
-                  <div className="space-y-2">
-                    <p className="font-heading text-3xl tracking-[-0.04em] text-foreground">
-                      {formatKpiValue(currentValue, formatType)}
-                    </p>
-                    <p className="text-sm text-muted-foreground">
-                      {formatKpiDelta(deltaValue, formatType)}
-                    </p>
-                  </div>
-                </div>
-              </SurfaceCard>
-            );
-          })}
-        </div>
-      </section>
-
-      <section className="space-y-4">
-        <SectionHeading
-          eyebrow="Matriz anual de KPIs"
-          title="Leitura compacta por indicador"
-          titleAs="h3"
-        />
-
-        <SurfaceCard tone="default" padding="none" className="overflow-hidden">
-          <Table>
-            <TableHeader className="bg-muted/35">
-              <TableRow>
-                <TableHead className="px-5">Indicador</TableHead>
-                <TableHead>Categoria</TableHead>
-                {yearColumns.map((year) => (
-                  <TableHead key={year}>{year}</TableHead>
-                ))}
-                <TableHead>Delta YoY</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {annualRows
-                .filter((row) => !Boolean(row.IS_PLACEHOLDER))
-                .map((row) => {
-                  const formatType = String(row.FORMAT_TYPE ?? "ratio");
-                  return (
-                    <TableRow key={String(row.KPI_ID)}>
-                      <TableCell className="px-5 font-medium text-foreground">
-                        {String(row.KPI_NOME)}
-                      </TableCell>
-                      <TableCell className="text-muted-foreground">
-                        {String(row.CATEGORIA)}
-                      </TableCell>
-                      {yearColumns.map((year) => (
-                        <TableCell key={year}>
-                          {formatKpiValue(
-                            row[year] === null || row[year] === undefined
+        <section className="space-y-4">
+          <SectionHeading
+            eyebrow="Matriz anual de KPIs"
+            title="Leitura compacta por indicador"
+            titleAs="h3"
+          />
+          <SurfaceCard tone="default" padding="none" className="overflow-hidden">
+            <Table>
+              <TableHeader className="bg-muted/35">
+                <TableRow>
+                  <TableHead className="px-5">Indicador</TableHead>
+                  <TableHead>Categoria</TableHead>
+                  {yearColumns.map((year) => (
+                    <TableHead key={year}>{year}</TableHead>
+                  ))}
+                  <TableHead>Delta YoY</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {annualRows
+                  .filter((row) => !Boolean(row.IS_PLACEHOLDER))
+                  .map((row) => {
+                    const formatType = String(row.FORMAT_TYPE ?? "ratio");
+                    return (
+                      <TableRow key={String(row.KPI_ID)}>
+                        <TableCell className="px-5 font-medium text-foreground">
+                          {String(row.KPI_NOME)}
+                        </TableCell>
+                        <TableCell className="text-muted-foreground">
+                          {String(row.CATEGORIA)}
+                        </TableCell>
+                        {yearColumns.map((year) => (
+                          <TableCell key={year}>
+                            {formatKpiValue(
+                              row[year] === null || row[year] === undefined
+                                ? null
+                                : Number(row[year]),
+                              formatType,
+                            )}
+                          </TableCell>
+                        ))}
+                        <TableCell className="text-muted-foreground">
+                          {formatKpiDelta(
+                            row.DELTA_YOY === null || row.DELTA_YOY === undefined
                               ? null
-                              : Number(row[year]),
+                              : Number(row.DELTA_YOY),
                             formatType,
                           )}
                         </TableCell>
-                      ))}
-                      <TableCell className="text-muted-foreground">
-                        {formatKpiDelta(
-                          row.DELTA_YOY === null || row.DELTA_YOY === undefined
-                            ? null
-                            : Number(row.DELTA_YOY),
-                          formatType,
-                        )}
-                      </TableCell>
-                    </TableRow>
-                  );
-                })}
-            </TableBody>
-          </Table>
-        </SurfaceCard>
-      </section>
+                      </TableRow>
+                    );
+                  })}
+              </TableBody>
+            </Table>
+          </SurfaceCard>
+        </section>
+      </div>
+
+      <div className="flex flex-col gap-4 lg:col-span-4">
+        {SPARKLINE_KPIS.map((kpi) => {
+          const row = kpiMap.get(kpi.id);
+          const values = yearColumns.flatMap((year) => {
+            const val = row?.[year];
+            if (val === null || val === undefined) return [];
+            const num = Number(val);
+            return isNaN(num) ? [] : [num];
+          });
+          const currentValue = row && lastYear ? Number(row[lastYear] ?? NaN) : null;
+          const deltaValue =
+            row?.DELTA_YOY === null || row?.DELTA_YOY === undefined
+              ? null
+              : Number(row.DELTA_YOY);
+
+          return (
+            <SparklineChip
+              key={kpi.id}
+              label={kpi.label}
+              value={formatKpiValue(currentValue, kpi.formatType)}
+              delta={deltaValue}
+              formatType={kpi.formatType}
+              values={values}
+            />
+          );
+        })}
+
+        <CompanyFreshnessCard cdCvm={cdCvm} />
+        <CompanySectorRanking />
+      </div>
     </div>
   );
 }

--- a/apps/web/components/company/company-sector-ranking.tsx
+++ b/apps/web/components/company/company-sector-ranking.tsx
@@ -1,0 +1,29 @@
+import { SurfaceCard } from "@/components/shared/design-system-recipes";
+
+const RANKING_ITEMS = [
+  { label: "Dívida/EBITDA" },
+  { label: "ROE" },
+  { label: "P/L" },
+  { label: "Margem EBIT" },
+];
+
+export function CompanySectorRanking() {
+  return (
+    <SurfaceCard tone="subtle" padding="md">
+      <p className="eyebrow mb-3 text-muted-foreground">Ranking no setor</p>
+      <div className="space-y-3">
+        {RANKING_ITEMS.map((item) => (
+          <div key={item.label} className="space-y-1">
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-muted-foreground">{item.label}</span>
+              <span className="text-xs text-muted-foreground/60">Em breve</span>
+            </div>
+            <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+              <div className="h-full w-0 rounded-full bg-primary/30" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </SurfaceCard>
+  );
+}

--- a/apps/web/components/shared/sparkline-chip.tsx
+++ b/apps/web/components/shared/sparkline-chip.tsx
@@ -1,0 +1,102 @@
+import { SurfaceCard } from "@/components/shared/design-system-recipes";
+import { formatKpiDelta, formatKpiValue } from "@/lib/formatters";
+import { cn } from "@/lib/utils";
+
+function buildPath(values: number[], w: number, h: number): string {
+  if (values.length < 2) return "";
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+  const pts = values.map((v, i) => {
+    const x = (i / (values.length - 1)) * w;
+    const y = h - ((v - min) / range) * (h * 0.8) - 2;
+    return `${x.toFixed(1)},${y.toFixed(1)}`;
+  });
+  const firstPt = pts[0]!.split(",");
+  const lastPt = pts[pts.length - 1]!.split(",");
+  return [
+    `M ${firstPt[0]} ${firstPt[1]}`,
+    pts.slice(1).map((p) => `L ${p}`).join(" "),
+    `L ${lastPt[0]} ${h} L ${firstPt[0]} ${h} Z`,
+  ].join(" ");
+}
+
+type SparklineChipProps = {
+  label: string;
+  value: string | null;
+  delta: number | null;
+  formatType?: string;
+  values?: number[];
+};
+
+export function SparklineChip({
+  label,
+  value,
+  delta,
+  formatType = "brl",
+  values = [],
+}: SparklineChipProps) {
+  const showSparkline = values.length >= 3;
+  const isPositive = delta !== null && delta >= 0;
+  const W = 80;
+  const H = 24;
+  const path = showSparkline ? buildPath(values, W, H) : "";
+
+  return (
+    <SurfaceCard tone="subtle" padding="md">
+      <div className="flex items-center justify-between gap-3">
+        <div className="space-y-1 min-w-0">
+          <p className="text-xs text-muted-foreground">{label}</p>
+          <p className="font-mono text-sm font-medium text-foreground">
+            {value ?? "—"}
+          </p>
+          {delta !== null ? (
+            <p
+              className={cn(
+                "text-xs",
+                isPositive ? "text-green-600 dark:text-green-400" : "text-destructive",
+              )}
+            >
+              {formatKpiDelta(delta, formatType)}
+            </p>
+          ) : null}
+        </div>
+
+        {showSparkline ? (
+          <svg
+            width={W}
+            height={H}
+            viewBox={`0 0 ${W} ${H}`}
+            className="shrink-0 text-primary"
+            aria-hidden
+          >
+            <defs>
+              <linearGradient id={`sg-${label}`} x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="currentColor" stopOpacity="0.2" />
+                <stop offset="100%" stopColor="currentColor" stopOpacity="0.02" />
+              </linearGradient>
+            </defs>
+            <path d={path} fill={`url(#sg-${label})`} />
+            <polyline
+              points={values
+                .map((v, i) => {
+                  const min = Math.min(...values);
+                  const max = Math.max(...values);
+                  const range = max - min || 1;
+                  const x = (i / (values.length - 1)) * W;
+                  const y = H - ((v - min) / range) * (H * 0.8) - 2;
+                  return `${x.toFixed(1)},${y.toFixed(1)}`;
+                })
+                .join(" ")}
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        ) : null}
+      </div>
+    </SurfaceCard>
+  );
+}


### PR DESCRIPTION
## Summary

- **CompanyHeader**: hero com `linear-gradient` de cor do setor, caixa de iniciais 88px (borda-radius 20px), h1 com `clamp(1.8rem,3.5vw,2.5rem)`, ticker + CVM chips, botões Excel/setor/comparar
- **CompanyKpiRow** (novo): 4 cards Margem Bruta / Margem EBITDA / ROE / Margem Líquida — valores `—` quando ausentes, delta YoY colorido
- **CompanyHeroChart** (novo): SVG area chart client com toggle métrica (Receita/EBITDA/Lucro extraídos do bundle) e período (3A/5A/Todos); fallback quando série insuficiente
- **SparklineChip** (novo em `shared/`): label + valor + delta + sparkline SVG 80×24 com fill-gradient; fallback sem SVG se `values.length < 3`
- **CompanyFreshnessCard** (novo): `SurfaceCard tone="inset"` + reutiliza `CompanyRequestRefresh` existente sem duplicar lógica de polling
- **CompanySectorRanking** (novo): 4 barras de percentil com placeholder "Em breve" (API não retorna dados setoriais por empresa ainda)
- **CompanyOverview**: grid `lg:grid-cols-12` — coluna 8 (KpiRow + HeroChart + tabela) e right rail 4 (SparklineChips + Freshness + SectorRanking)
- **`[cd_cvm]/page.tsx`**: passa `cdCvm` para `CompanyOverview`

## Test plan

- [ ] `/empresas/9512` (Petrobras): hero com gradiente azul/teal renderiza
- [ ] Caixa de iniciais (P + E) visível com cor do setor
- [ ] 4 KPI cards mostram margens e ROE (ou `—` sem crashar)
- [ ] Hero chart renderiza se KPIs RECEITA_LIQ/EBITDA/LUCRO_LIQ disponíveis; toggle métrica e período funcionam
- [ ] Right rail: SparklineChips, FreshnessCard e SectorRanking renderizam
- [ ] Grid 8/4 em lg+; colapsa em mobile
- [ ] CI: guardrail + tests passam

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)