### PR TITLE
feat(web): design fidelity handoff — all 4 pages redesigned

### DIFF
--- a/apps/web/app/empresas/page.tsx
+++ b/apps/web/app/empresas/page.tsx
@@ -4,11 +4,7 @@ import type { Metadata } from "next";
 import { CompanyDirectoryFilters } from "@/components/companies/company-directory-filters";
 import { CompanyDirectoryList } from "@/components/companies/company-directory-list";
 import { DirectoryPagination } from "@/components/companies/directory-pagination";
-import {
-  PageShell,
-  SurfaceCard,
-  SectionHeading,
-} from "@/components/shared/design-system-recipes";
+import { PageShell, SurfaceCard, SectionHeading } from "@/components/shared/design-system-recipes";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { buttonVariants } from "@/components/ui/button";
 import { formatCompactInteger } from "@/lib/formatters";
@@ -34,10 +30,7 @@ export default async function EmpresasPage({ searchParams }: EmpresasPageProps) 
   const resolvedSearchParams = await searchParams;
   const currentSearch = getFirstParam(resolvedSearchParams.busca) ?? "";
   const currentSector = getFirstParam(resolvedSearchParams.setor) ?? null;
-  const currentPage = coercePositiveInt(
-    getFirstParam(resolvedSearchParams.pagina),
-    1,
-  );
+  const currentPage = coercePositiveInt(getFirstParam(resolvedSearchParams.pagina), 1);
   const rawView = getFirstParam(resolvedSearchParams.view);
   const viewMode: "rows" | "cards" = rawView === "cards" ? "cards" : "rows";
 
@@ -48,13 +41,12 @@ export default async function EmpresasPage({ searchParams }: EmpresasPageProps) 
   const retryQuery = retryParams.toString();
   const retryHref = retryQuery ? `/empresas?${retryQuery}` : "/empresas";
 
-  const { directory, filters, directoryError, filtersError } =
-    await loadCompaniesPageData({
-      search: currentSearch,
-      sector: currentSector,
-      page: currentPage,
-      pageSize: PAGE_SIZE,
-    });
+  const { directory, filters, directoryError, filtersError } = await loadCompaniesPageData({
+    search: currentSearch,
+    sector: currentSector,
+    page: currentPage,
+    pageSize: PAGE_SIZE,
+  });
 
   if (!directory) {
     return (
@@ -82,10 +74,7 @@ export default async function EmpresasPage({ searchParams }: EmpresasPageProps) 
             </Link>
             <Link
               href="/"
-              className={cn(
-                buttonVariants({ variant: "outline", size: "lg" }),
-                "rounded-full px-5",
-              )}
+              className={cn(buttonVariants({ variant: "outline", size: "lg" }), "rounded-full px-5")}
             >
               Voltar para a home
             </Link>
@@ -106,17 +95,63 @@ export default async function EmpresasPage({ searchParams }: EmpresasPageProps) 
   const viewCardsHref = `/empresas?${mergeSearchParams(currentParamsStr, { view: "cards" }) || "view=cards"}`;
   const clearHref = viewMode === "cards" ? "/empresas?view=cards" : "/empresas";
 
+  const toggleBase =
+    "flex size-8 items-center justify-center rounded-lg border transition-colors text-sm";
+
   return (
-    <PageShell density="default">
-      <div className="flex flex-col gap-2">
-        <h1 className="font-heading text-2xl text-foreground">
-          Diretório de empresas
-        </h1>
-        <p className="text-sm text-muted-foreground">
-          {formatCompactInteger(directory.pagination.total_items)} resultados
-          {currentSearch ? ` para "${currentSearch}"` : ""}
-          {currentSector ? ` · ${currentSector}` : ""}
-        </p>
+    <PageShell density="default" className="space-y-8">
+      {/* Page header */}
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <p className="text-[0.72rem] font-medium uppercase tracking-[0.26em] text-muted-foreground mb-1">
+            Diretório · CVM
+          </p>
+          <h1 className="font-heading text-[clamp(1.75rem,4vw,2.5rem)] font-medium leading-tight tracking-[-0.04em] text-foreground">
+            Todas as companhias abertas
+          </h1>
+          <p className="mt-1.5 text-[0.9rem] text-muted-foreground">
+            {formatCompactInteger(directory.pagination.total_items)} empresas
+            {currentSearch ? ` · "${currentSearch}"` : ""}
+            {currentSector ? ` · ${currentSector}` : ""}
+          </p>
+        </div>
+
+        {/* View toggle */}
+        <div className="flex items-center gap-1.5">
+          <Link
+            href={viewRowsHref}
+            title="Ver em linhas"
+            className={cn(
+              toggleBase,
+              viewMode === "rows"
+                ? "border-border bg-muted text-foreground"
+                : "border-border/40 text-muted-foreground hover:border-border hover:text-foreground",
+            )}
+          >
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden>
+              <rect x="1" y="2" width="12" height="2" rx="0.5" fill="currentColor" />
+              <rect x="1" y="6" width="12" height="2" rx="0.5" fill="currentColor" />
+              <rect x="1" y="10" width="12" height="2" rx="0.5" fill="currentColor" />
+            </svg>
+          </Link>
+          <Link
+            href={viewCardsHref}
+            title="Ver em cards"
+            className={cn(
+              toggleBase,
+              viewMode === "cards"
+                ? "border-border bg-muted text-foreground"
+                : "border-border/40 text-muted-foreground hover:border-border hover:text-foreground",
+            )}
+          >
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden>
+              <rect x="1" y="1" width="5" height="5" rx="1" fill="currentColor" />
+              <rect x="8" y="1" width="5" height="5" rx="1" fill="currentColor" />
+              <rect x="1" y="8" width="5" height="5" rx="1" fill="currentColor" />
+              <rect x="8" y="8" width="5" height="5" rx="1" fill="currentColor" />
+            </svg>
+          </Link>
+        </div>
       </div>
 
       {filtersError ? (
@@ -128,39 +163,33 @@ export default async function EmpresasPage({ searchParams }: EmpresasPageProps) 
         </Alert>
       ) : null}
 
-      <div className="grid gap-8 lg:grid-cols-[280px_1fr]">
-        <aside className="lg:sticky lg:top-24 lg:self-start">
-          <div className="rounded-xl border border-border/60 bg-card p-5">
-            <CompanyDirectoryFilters
-              currentSearch={currentSearch}
-              currentSector={currentSector}
-              sectors={filters?.sectors ?? []}
-              sectorFilterUnavailable={Boolean(filtersError)}
-            />
-          </div>
-        </aside>
+      {/* Horizontal filter bar */}
+      <CompanyDirectoryFilters
+        currentSearch={currentSearch}
+        currentSector={currentSector}
+        sectors={filters?.sectors ?? []}
+        sectorFilterUnavailable={Boolean(filtersError)}
+      />
 
-        <div className="space-y-6">
-          <CompanyDirectoryList
-            items={directory.items}
-            viewMode={viewMode}
-            viewRowsHref={viewRowsHref}
-            viewCardsHref={viewCardsHref}
-            hasActiveFilters={Boolean(currentSearch || currentSector)}
-            clearHref={clearHref}
-          />
+      {/* Results */}
+      <div className="space-y-6">
+        <CompanyDirectoryList
+          items={directory.items}
+          viewMode={viewMode}
+          hasActiveFilters={Boolean(currentSearch || currentSector)}
+          clearHref={clearHref}
+        />
 
-          <DirectoryPagination
-            currentPage={directory.pagination.page}
-            totalPages={directory.pagination.total_pages}
-            totalItems={directory.pagination.total_items}
-            pageSize={PAGE_SIZE}
-            hasNext={directory.pagination.has_next}
-            hasPrevious={directory.pagination.has_previous}
-            currentSearch={currentSearch}
-            currentSector={Boolean(filtersError) ? null : currentSector}
-          />
-        </div>
+        <DirectoryPagination
+          currentPage={directory.pagination.page}
+          totalPages={directory.pagination.total_pages}
+          totalItems={directory.pagination.total_items}
+          pageSize={PAGE_SIZE}
+          hasNext={directory.pagination.has_next}
+          hasPrevious={directory.pagination.has_previous}
+          currentSearch={currentSearch}
+          currentSector={Boolean(filtersError) ? null : currentSector}
+        />
       </div>
     </PageShell>
   );

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,8 +1,12 @@
+import Link from "next/link";
+
 import { CompanySearchHero } from "@/components/home/company-search-hero";
 import { DiscoverySection } from "@/components/home/discovery-section";
 import { TrustStrip } from "@/components/home/trust-strip";
+import { buttonVariants } from "@/components/ui/button";
 import { PageShell } from "@/components/shared/design-system-recipes";
 import { fetchCompanies, safeFetchHealth } from "@/lib/api";
+import { cn } from "@/lib/utils";
 
 export const dynamic = "force-dynamic";
 
@@ -10,27 +14,55 @@ export default async function HomePage() {
   const [health, companySnapshot, topCompaniesResult] = await Promise.all([
     safeFetchHealth(),
     fetchCompanies({ page: 1, pageSize: 1 }).catch(() => null),
-    fetchCompanies({ page: 1, pageSize: 6 }).catch(() => null),
+    fetchCompanies({ page: 1, pageSize: 8 }).catch(() => null),
   ]);
 
   const totalCompanies = companySnapshot?.pagination.total_items ?? null;
   const topCompanies = topCompaniesResult?.items ?? [];
 
   return (
-    <>
-      <PageShell
-        density="relaxed"
-        className="pb-18 flex flex-col items-center text-center gap-12"
-      >
-        <CompanySearchHero
-          apiAvailable={health?.status === "ok"}
-          totalCompanies={totalCompanies}
-        />
-
-        <DiscoverySection topCompanies={topCompanies} />
-      </PageShell>
+    <PageShell density="relaxed" className="flex flex-col items-center gap-14 pb-20">
+      <CompanySearchHero
+        apiAvailable={health?.status === "ok"}
+        totalCompanies={totalCompanies}
+      />
 
       <TrustStrip health={health} totalCompanies={totalCompanies} />
-    </>
+
+      <DiscoverySection topCompanies={topCompanies} />
+
+      {/* Compare CTA */}
+      <div
+        className="w-full max-w-5xl rounded-[1.75rem] border border-border/60 px-8 py-10 sm:px-12"
+        style={{
+          background:
+            "linear-gradient(135deg, color-mix(in oklch, var(--primary) 8%, var(--card)), var(--card))",
+        }}
+      >
+        <div className="flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
+          <div className="max-w-[520px]">
+            <p className="text-[0.72rem] font-medium uppercase tracking-[0.26em] text-muted-foreground mb-2">
+              Análise side-by-side
+            </p>
+            <h3 className="font-heading text-[1.75rem] font-medium tracking-[-0.035em] text-foreground leading-tight">
+              Compare até 4 empresas.{" "}
+              <span className="text-muted-foreground">Veja onde divergem.</span>
+            </h3>
+            <p className="mt-3 text-[0.95rem] leading-[1.55] text-muted-foreground">
+              KPIs lado a lado, diferenças em destaque, períodos sincronizados.
+            </p>
+          </div>
+          <Link
+            href="/comparar"
+            className={cn(
+              buttonVariants({ size: "lg" }),
+              "shrink-0 rounded-full px-6",
+            )}
+          >
+            Comparar empresas
+          </Link>
+        </div>
+      </div>
+    </PageShell>
   );
 }

--- a/apps/web/components/companies/company-card.tsx
+++ b/apps/web/components/companies/company-card.tsx
@@ -1,48 +1,147 @@
 import Link from "next/link";
-import { ArrowUpRightIcon } from "lucide-react";
 
 import type { CompanyDirectoryItem } from "@/lib/api";
 import { getSectorColor } from "@/lib/constants";
-import { formatYearsLabel } from "@/lib/formatters";
 import { cn } from "@/lib/utils";
+
+function buildSparklinePoints(anos: number[], W = 240, H = 36): string {
+  if (anos.length < 2) return "";
+  const sorted = [...anos].sort((a, b) => a - b);
+  const min = sorted[0]!;
+  const max = sorted[sorted.length - 1]!;
+  const rangeYears = max - min || 1;
+  return sorted
+    .map((year, i) => {
+      const x = ((year - min) / rangeYears) * W;
+      const y = H - (i / Math.max(sorted.length - 1, 1)) * (H * 0.75) - 4;
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+}
 
 type CompanyCardProps = {
   item: CompanyDirectoryItem;
 };
 
 export function CompanyCard({ item }: CompanyCardProps) {
-  const sectorColor = getSectorColor(item.sector_name);
+  const color = getSectorColor(item.sector_name);
   const hasData = item.has_financial_data !== false;
+  const anos = item.anos_disponiveis ?? [];
+  const sparkPts = buildSparklinePoints(anos);
+  const initials = (item.ticker_b3 ?? item.company_name).slice(0, 2).toUpperCase();
 
   return (
     <Link
       href={hasData ? `/empresas/${item.cd_cvm}` : "#"}
       aria-disabled={!hasData}
       className={cn(
-        "group flex flex-col justify-between gap-4 overflow-hidden rounded-xl border border-border/60 bg-card px-5 py-4 transition-colors",
-        hasData ? "hover:border-border hover:bg-muted/30" : "pointer-events-none opacity-50",
+        "group flex flex-col gap-4 overflow-hidden rounded-[1.25rem] border border-border/60 bg-card p-5 transition-all duration-200",
+        hasData
+          ? "hover:-translate-y-0.5 hover:border-primary/25 hover:shadow-[0_18px_36px_-24px_rgba(16,30,24,0.2)]"
+          : "pointer-events-none opacity-50",
       )}
-      style={{ borderLeftColor: sectorColor, borderLeftWidth: 3 }}
     >
-      <div className="space-y-1.5">
-        <div className="flex items-center justify-between gap-2">
-          <span
-            className="flex h-6 items-center rounded-full px-2 text-[0.65rem] font-semibold uppercase tracking-[0.12em] text-white"
-            style={{ backgroundColor: sectorColor }}
+      {/* Header: avatar + ticker + arrow */}
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <div
+            className="flex size-11 shrink-0 items-center justify-center rounded-[12px] font-heading text-sm font-semibold"
+            style={{
+              background: `color-mix(in oklch, ${color} 14%, transparent)`,
+              border: `1px solid color-mix(in oklch, ${color} 28%, transparent)`,
+              color,
+            }}
           >
-            {item.ticker_b3 ?? "—"}
-          </span>
-          <ArrowUpRightIcon className="size-3.5 shrink-0 text-muted-foreground transition-colors group-hover:text-primary" />
+            {initials}
+          </div>
+          {item.ticker_b3 && (
+            <span
+              className="rounded-[0.35rem] border font-mono text-[0.7rem] font-medium px-1.5 py-0.5"
+              style={{
+                background: `color-mix(in oklch, ${color} 10%, transparent)`,
+                borderColor: `color-mix(in oklch, ${color} 22%, transparent)`,
+                color,
+              }}
+            >
+              {item.ticker_b3}
+            </span>
+          )}
         </div>
-        <p className="font-heading text-base font-medium text-foreground leading-tight line-clamp-2">
-          {item.company_name}
-        </p>
-        <p className="text-xs text-muted-foreground">{item.sector_name}</p>
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 14 14"
+          fill="none"
+          className="mt-0.5 shrink-0 text-muted-foreground transition-colors group-hover:text-primary"
+          aria-hidden
+        >
+          <path
+            d="M3 11L11 3M11 3H5M11 3V9"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
       </div>
 
-      <p className="text-xs text-muted-foreground">
-        {formatYearsLabel(item.anos_disponiveis)}
-      </p>
+      {/* Name + sector */}
+      <div className="min-w-0 flex-1">
+        <p className="font-heading text-[0.95rem] font-medium leading-tight text-foreground line-clamp-2">
+          {item.company_name}
+        </p>
+        {item.sector_name && (
+          <p className="mt-0.5 text-[0.75rem] text-muted-foreground">{item.sector_name}</p>
+        )}
+      </div>
+
+      {/* Metrics row */}
+      <div className="grid grid-cols-3 divide-x divide-border/60 border-t border-border/60 pt-3">
+        {(
+          [
+            { label: "Receita", value: "—" },
+            { label: "YoY", value: "—" },
+            { label: "ROE", value: "—" },
+          ] as const
+        ).map(({ label, value }) => (
+          <div key={label} className="px-2 first:pl-0 last:pr-0">
+            <p className="text-[0.62rem] uppercase tracking-[0.12em] text-muted-foreground">
+              {label}
+            </p>
+            <p className="mt-0.5 font-mono text-[0.82rem] font-medium tabular-nums text-muted-foreground/70">
+              {value}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      {/* Sparkline */}
+      {sparkPts && (
+        <div className="overflow-hidden rounded-[0.5rem]">
+          <svg
+            width="100%"
+            height={36}
+            viewBox="0 0 240 36"
+            preserveAspectRatio="none"
+            aria-hidden
+          >
+            <defs>
+              <linearGradient id={`card-spark-${item.cd_cvm}`} x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor={color} stopOpacity="0.18" />
+                <stop offset="100%" stopColor={color} stopOpacity="0.02" />
+              </linearGradient>
+            </defs>
+            <polyline
+              points={sparkPts}
+              fill="none"
+              stroke={color}
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </div>
+      )}
     </Link>
   );
 }

--- a/apps/web/components/companies/company-directory-filters.tsx
+++ b/apps/web/components/companies/company-directory-filters.tsx
@@ -4,7 +4,6 @@ import { SearchIcon, XIcon } from "lucide-react";
 import { startTransition, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 
-import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
   Select,
@@ -17,6 +16,7 @@ import {
 import type { CompanySectorFilter } from "@/lib/api";
 import { mergeSearchParams } from "@/lib/search-params";
 import { track } from "@/lib/track";
+import { cn } from "@/lib/utils";
 
 type CompanyDirectoryFiltersProps = {
   currentSearch: string;
@@ -35,35 +35,21 @@ export function CompanyDirectoryFilters({
   const searchParams = useSearchParams();
   const [search, setSearch] = useState(currentSearch);
 
-  const hasCurrentSector = sectors.some(
-    (sector) => sector.sector_slug === currentSector,
-  );
+  const hasCurrentSector = sectors.some((s) => s.sector_slug === currentSector);
   const selectValue =
-    sectorFilterUnavailable || !hasCurrentSector
-      ? "all"
-      : currentSector ?? "all";
+    sectorFilterUnavailable || !hasCurrentSector ? "all" : currentSector ?? "all";
 
   const hasActiveFilters = Boolean(currentSearch || currentSector);
 
-  function pushFilters(
-    updates: Record<string, string | number | null | undefined>,
-  ) {
+  function pushFilters(updates: Record<string, string | number | null | undefined>) {
     const query = mergeSearchParams(searchParams.toString(), updates);
     const href = query ? `/empresas?${query}` : "/empresas";
-
-    startTransition(() => {
-      router.push(href);
-    });
+    startTransition(() => router.push(href));
   }
 
   function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    track("companies_filter_changed", {
-      search,
-      sector: currentSector,
-      source: "search",
-    });
-
+    track("companies_filter_changed", { search, sector: currentSector, source: "search" });
     pushFilters({
       busca: search.trim() || null,
       setor:
@@ -80,79 +66,106 @@ export function CompanyDirectoryFilters({
   }
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-5">
-      <p className="eyebrow text-muted-foreground">Filtros</p>
-
-      <div className="space-y-1.5">
-        <label className="text-xs font-medium text-foreground">Busca</label>
-        <div className="flex items-center gap-2 rounded-[1rem] border border-border/65 bg-muted/55 px-3 py-2.5">
-          <SearchIcon className="size-3.5 shrink-0 text-muted-foreground" />
-          <Input
-            type="search"
-            value={search}
-            onChange={(event) => setSearch(event.target.value)}
-            placeholder="Nome, ticker ou CVM"
-            className="h-auto border-0 bg-transparent p-0 text-sm shadow-none focus-visible:ring-0"
-          />
-        </div>
-      </div>
-
-      <div className="space-y-1.5">
-        <label className="text-xs font-medium text-foreground">Setor</label>
-        <Select
-          value={selectValue}
-          disabled={sectorFilterUnavailable}
-          onValueChange={(value) => {
-            const nextSector = value === "all" ? null : value;
-            track("companies_filter_changed", {
-              search,
-              sector: nextSector,
-              source: "sector",
-            });
-            pushFilters({ setor: nextSector, pagina: null });
-          }}
-        >
-          <SelectTrigger className="h-10 w-full rounded-[1rem] bg-background px-3 text-sm">
-            <SelectValue
-              placeholder={
-                sectorFilterUnavailable
-                  ? "Filtro indisponível"
-                  : "Todos os setores"
-              }
+    <div className="space-y-3">
+      <form onSubmit={handleSubmit}>
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="flex min-w-[200px] flex-1 items-center gap-2 rounded-[1rem] border border-border/65 bg-muted/55 px-3 py-2">
+            <SearchIcon className="size-3.5 shrink-0 text-muted-foreground" />
+            <Input
+              type="search"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Nome, ticker ou CVM"
+              className="h-auto border-0 bg-transparent p-0 text-sm shadow-none focus-visible:ring-0"
             />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectGroup>
-              <SelectItem value="all">Todos os setores</SelectItem>
-              {!sectorFilterUnavailable
-                ? sectors.map((sector) => (
-                    <SelectItem
-                      key={sector.sector_slug}
-                      value={sector.sector_slug}
-                    >
-                      {sector.sector_name} · {sector.company_count}
-                    </SelectItem>
-                  ))
-                : null}
-            </SelectGroup>
-          </SelectContent>
-        </Select>
-      </div>
+            {search && (
+              <button
+                type="button"
+                onClick={() => {
+                  setSearch("");
+                  pushFilters({ busca: null, pagina: null });
+                }}
+                className="text-muted-foreground hover:text-foreground"
+              >
+                <XIcon className="size-3.5" />
+              </button>
+            )}
+          </div>
 
-      <Button type="submit" size="sm" className="w-full rounded-full">
-        Aplicar filtros
-      </Button>
+          <Select
+            value={selectValue}
+            disabled={sectorFilterUnavailable}
+            onValueChange={(value) => {
+              const nextSector = value === "all" ? null : value;
+              track("companies_filter_changed", { search, sector: nextSector, source: "sector" });
+              pushFilters({ setor: nextSector, pagina: null });
+            }}
+          >
+            <SelectTrigger
+              className={cn(
+                "h-[2.375rem] w-auto min-w-[160px] rounded-[1rem] border-border/65 bg-muted/55 px-3 text-sm",
+              )}
+            >
+              <SelectValue
+                placeholder={sectorFilterUnavailable ? "Indisponível" : "Todos os setores"}
+              />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                <SelectItem value="all">Todos os setores</SelectItem>
+                {!sectorFilterUnavailable
+                  ? sectors.map((sector) => (
+                      <SelectItem key={sector.sector_slug} value={sector.sector_slug}>
+                        {sector.sector_name} · {sector.company_count}
+                      </SelectItem>
+                    ))
+                  : null}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
 
-      {hasActiveFilters ? (
-        <button
-          type="button"
-          onClick={handleClear}
-          className="flex w-full items-center justify-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
-        >
-          <XIcon className="size-3" />
-          Limpar filtros
-        </button>
-      ) : null}
-    </form>
+          <button type="submit" className="sr-only">
+            Buscar
+          </button>
+        </div>
+      </form>
+
+      {hasActiveFilters && (
+        <div className="flex flex-wrap items-center gap-2">
+          {currentSearch && (
+            <span className="flex items-center gap-1.5 rounded-full border border-primary/25 bg-primary/8 px-3 py-1 text-[0.75rem] font-medium text-primary">
+              &ldquo;{currentSearch}&rdquo;
+              <button
+                type="button"
+                onClick={() => pushFilters({ busca: null, pagina: null })}
+                className="hover:opacity-70"
+              >
+                <XIcon className="size-3" />
+              </button>
+            </span>
+          )}
+          {currentSector && hasCurrentSector && (
+            <span className="flex items-center gap-1.5 rounded-full border border-primary/25 bg-primary/8 px-3 py-1 text-[0.75rem] font-medium text-primary">
+              {sectors.find((s) => s.sector_slug === currentSector)?.sector_name ??
+                currentSector}
+              <button
+                type="button"
+                onClick={() => pushFilters({ setor: null, pagina: null })}
+                className="hover:opacity-70"
+              >
+                <XIcon className="size-3" />
+              </button>
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={handleClear}
+            className="text-[0.75rem] text-muted-foreground hover:text-foreground"
+          >
+            Limpar tudo
+          </button>
+        </div>
+      )}
+    </div>
   );
 }

--- a/apps/web/components/companies/company-directory-list.tsx
+++ b/apps/web/components/companies/company-directory-list.tsx
@@ -11,8 +11,6 @@ import { cn } from "@/lib/utils";
 type CompanyDirectoryListProps = {
   items: CompanyDirectoryItem[];
   viewMode: "rows" | "cards";
-  viewRowsHref: string;
-  viewCardsHref: string;
   hasActiveFilters: boolean;
   clearHref: string;
 };
@@ -20,86 +18,47 @@ type CompanyDirectoryListProps = {
 export function CompanyDirectoryList({
   items,
   viewMode,
-  viewRowsHref,
-  viewCardsHref,
   hasActiveFilters,
   clearHref,
 }: CompanyDirectoryListProps) {
-  const toggleBase =
-    "flex h-8 w-8 items-center justify-center rounded-lg border transition-colors text-sm";
+  if (items.length === 0) {
+    return (
+      <SurfaceCard tone="muted" padding="hero" className="items-center text-center">
+        <InboxIcon className="size-10 text-muted-foreground/50" />
+        <p className="font-heading text-xl text-foreground">Nenhuma empresa encontrada.</p>
+        <p className="max-w-sm text-sm leading-7 text-muted-foreground">
+          Ajuste o termo de busca ou remova o filtro setorial para ampliar o diretório
+          disponível.
+        </p>
+        {hasActiveFilters ? (
+          <Link
+            href={clearHref}
+            className={cn(buttonVariants({ variant: "outline", size: "sm" }), "rounded-full")}
+          >
+            Limpar filtros
+          </Link>
+        ) : null}
+      </SurfaceCard>
+    );
+  }
+
+  if (viewMode === "cards") {
+    return (
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        {items.map((item) => (
+          <CompanyCard key={item.cd_cvm} item={item} />
+        ))}
+      </div>
+    );
+  }
 
   return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-end gap-1.5">
-        <Link
-          href={viewRowsHref}
-          title="Ver em linhas"
-          className={cn(
-            toggleBase,
-            viewMode === "rows"
-              ? "border-border bg-muted text-foreground"
-              : "border-border/40 text-muted-foreground hover:border-border hover:text-foreground",
-          )}
-        >
-          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden>
-            <rect x="1" y="2" width="12" height="2" rx="0.5" fill="currentColor" />
-            <rect x="1" y="6" width="12" height="2" rx="0.5" fill="currentColor" />
-            <rect x="1" y="10" width="12" height="2" rx="0.5" fill="currentColor" />
-          </svg>
-        </Link>
-        <Link
-          href={viewCardsHref}
-          title="Ver em cards"
-          className={cn(
-            toggleBase,
-            viewMode === "cards"
-              ? "border-border bg-muted text-foreground"
-              : "border-border/40 text-muted-foreground hover:border-border hover:text-foreground",
-          )}
-        >
-          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden>
-            <rect x="1" y="1" width="5" height="5" rx="1" fill="currentColor" />
-            <rect x="8" y="1" width="5" height="5" rx="1" fill="currentColor" />
-            <rect x="1" y="8" width="5" height="5" rx="1" fill="currentColor" />
-            <rect x="8" y="8" width="5" height="5" rx="1" fill="currentColor" />
-          </svg>
-        </Link>
+    <SurfaceCard tone="default" padding="none" className="overflow-hidden">
+      <div className="divide-y divide-border/45">
+        {items.map((item) => (
+          <CompanyRow key={item.cd_cvm} item={item} />
+        ))}
       </div>
-
-      {items.length === 0 ? (
-        <SurfaceCard tone="muted" padding="hero" className="items-center text-center">
-          <InboxIcon className="size-10 text-muted-foreground/50" />
-          <p className="font-heading text-xl text-foreground">
-            Nenhuma empresa encontrada.
-          </p>
-          <p className="max-w-sm text-sm leading-7 text-muted-foreground">
-            Ajuste o termo de busca ou remova o filtro setorial para ampliar o
-            diretório disponível.
-          </p>
-          {hasActiveFilters ? (
-            <Link
-              href={clearHref}
-              className={cn(buttonVariants({ variant: "outline", size: "sm" }), "rounded-full")}
-            >
-              Limpar filtros
-            </Link>
-          ) : null}
-        </SurfaceCard>
-      ) : viewMode === "cards" ? (
-        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
-          {items.map((item) => (
-            <CompanyCard key={item.cd_cvm} item={item} />
-          ))}
-        </div>
-      ) : (
-        <SurfaceCard tone="default" padding="none" className="overflow-hidden">
-          <div className="divide-y divide-border/45">
-            {items.map((item) => (
-              <CompanyRow key={item.cd_cvm} item={item} />
-            ))}
-          </div>
-        </SurfaceCard>
-      )}
-    </div>
+    </SurfaceCard>
   );
 }

--- a/apps/web/components/companies/company-row.tsx
+++ b/apps/web/components/companies/company-row.tsx
@@ -3,18 +3,14 @@ import { ChevronRightIcon } from "lucide-react";
 
 import type { CompanyDirectoryItem } from "@/lib/api";
 import { getSectorColor } from "@/lib/constants";
-import { formatYearsLabel } from "@/lib/formatters";
 import { cn } from "@/lib/utils";
 
-function buildSparklinePoints(anos: number[]): string {
-  if (anos.length === 0) return "";
+function buildSparklinePoints(anos: number[], W = 54, H = 20): string {
+  if (anos.length < 2) return "";
   const sorted = [...anos].sort((a, b) => a - b);
   const min = sorted[0]!;
   const max = sorted[sorted.length - 1]!;
   const rangeYears = max - min || 1;
-  const W = 48;
-  const H = 16;
-
   return sorted
     .map((year, i) => {
       const x = ((year - min) / rangeYears) * W;
@@ -29,60 +25,96 @@ type CompanyRowProps = {
 };
 
 export function CompanyRow({ item }: CompanyRowProps) {
-  const sectorColor = getSectorColor(item.sector_name);
+  const color = getSectorColor(item.sector_name);
   const hasData = item.has_financial_data !== false;
-  const sparkPoints = buildSparklinePoints(item.anos_disponiveis);
+  const anos = item.anos_disponiveis ?? [];
+  const sparkPts = buildSparklinePoints(anos);
+  const initials = (item.ticker_b3 ?? item.company_name).slice(0, 2).toUpperCase();
+  const yearsRange =
+    anos.length > 0 ? `${Math.min(...anos)}–${Math.max(...anos)}` : "—";
 
   return (
     <Link
       href={hasData ? `/empresas/${item.cd_cvm}` : "#"}
       aria-disabled={!hasData}
       className={cn(
-        "group flex h-[54px] items-center gap-4 px-5 transition-colors",
+        "group grid items-center gap-x-4 px-5 py-3 transition-colors",
+        "[grid-template-columns:42px_minmax(0,1fr)_32px]",
+        "sm:[grid-template-columns:42px_minmax(0,2fr)_minmax(0,1fr)_32px]",
+        "lg:[grid-template-columns:42px_minmax(0,2.2fr)_minmax(0,1.1fr)_minmax(0,1fr)_minmax(0,0.85fr)_32px]",
         hasData
-          ? "hover:bg-muted/40 cursor-pointer"
+          ? "cursor-pointer hover:bg-muted/40"
           : "pointer-events-none opacity-50",
       )}
     >
-      <span
-        className="flex h-7 min-w-[3.25rem] items-center justify-center rounded-full px-2 text-[0.68rem] font-semibold uppercase tracking-[0.12em] text-white"
-        style={{ backgroundColor: sectorColor }}
+      {/* Sector avatar */}
+      <div
+        className="flex size-[42px] shrink-0 items-center justify-center rounded-[10px] font-heading text-sm font-semibold"
+        style={{
+          background: `color-mix(in oklch, ${color} 14%, transparent)`,
+          border: `1px solid color-mix(in oklch, ${color} 28%, transparent)`,
+          color,
+        }}
       >
-        {item.ticker_b3 ?? "—"}
-      </span>
+        {initials}
+      </div>
 
-      <div className="min-w-0 flex-1">
-        <p className="truncate text-sm font-medium text-foreground">
-          {item.company_name}
-        </p>
-        <p className="truncate text-xs text-muted-foreground">
-          {item.sector_name}
+      {/* Name + ticker + CVM */}
+      <div className="min-w-0">
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="truncate font-medium text-[0.9rem] text-foreground">
+            {item.company_name}
+          </span>
+          {item.ticker_b3 && (
+            <span
+              className="shrink-0 rounded-[0.35rem] border font-mono text-[0.68rem] font-medium px-1.5 py-0.5"
+              style={{
+                background: `color-mix(in oklch, ${color} 10%, transparent)`,
+                borderColor: `color-mix(in oklch, ${color} 22%, transparent)`,
+                color,
+              }}
+            >
+              {item.ticker_b3}
+            </span>
+          )}
+        </div>
+        <p className="mt-0.5 text-[0.72rem] text-muted-foreground">
+          CVM {item.cd_cvm}
         </p>
       </div>
 
-      {sparkPoints ? (
-        <svg
-          width={48}
-          height={16}
-          viewBox="0 0 48 16"
-          className="hidden shrink-0 text-primary sm:block"
-          aria-hidden
-        >
-          <polyline
-            points={sparkPoints}
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.5"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-        </svg>
-      ) : null}
+      {/* Sector — sm+ */}
+      <p className="hidden truncate text-[0.82rem] text-muted-foreground sm:block">
+        {item.sector_name ?? "—"}
+      </p>
 
-      <span className="hidden w-20 text-right text-xs text-muted-foreground sm:block">
-        {formatYearsLabel(item.anos_disponiveis)}
-      </span>
+      {/* Sparkline + range — lg+ */}
+      <div className="hidden items-center gap-2 lg:flex">
+        {sparkPts ? (
+          <svg width={54} height={20} viewBox="0 0 54 20" aria-hidden className="shrink-0">
+            <polyline
+              points={sparkPts}
+              fill="none"
+              stroke={color}
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        ) : null}
+        <span className="whitespace-nowrap font-mono text-[0.72rem] tabular-nums text-muted-foreground">
+          {yearsRange}
+        </span>
+      </div>
 
+      {/* Anos count — lg+ */}
+      <div className="hidden text-right lg:block">
+        <span className="font-mono text-[0.78rem] tabular-nums text-muted-foreground">
+          {anos.length > 0 ? `${anos.length} anos` : "—"}
+        </span>
+      </div>
+
+      {/* Chevron */}
       <ChevronRightIcon className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
     </Link>
   );

--- a/apps/web/components/company/company-freshness-card.tsx
+++ b/apps/web/components/company/company-freshness-card.tsx
@@ -1,5 +1,4 @@
 import { CompanyRequestRefresh } from "@/components/company/company-request-refresh";
-import { SurfaceCard } from "@/components/shared/design-system-recipes";
 
 type CompanyFreshnessCardProps = {
   cdCvm: number;
@@ -7,9 +6,17 @@ type CompanyFreshnessCardProps = {
 
 export function CompanyFreshnessCard({ cdCvm }: CompanyFreshnessCardProps) {
   return (
-    <SurfaceCard tone="inset" padding="md">
-      <p className="eyebrow mb-3 text-muted-foreground">Atualização</p>
+    <div
+      className="rounded-[1.25rem] border p-5"
+      style={{
+        borderColor: "color-mix(in oklch, var(--chart-1) 25%, transparent)",
+        background: "color-mix(in oklch, var(--chart-1) 5%, var(--card))",
+      }}
+    >
+      <p className="mb-3 text-[0.72rem] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+        Atualização
+      </p>
       <CompanyRequestRefresh cdCvm={cdCvm} />
-    </SurfaceCard>
+    </div>
   );
 }

--- a/apps/web/components/company/company-hero-chart.tsx
+++ b/apps/web/components/company/company-hero-chart.tsx
@@ -2,10 +2,7 @@
 
 import { useState } from "react";
 
-import {
-  SectionHeading,
-  SurfaceCard,
-} from "@/components/shared/design-system-recipes";
+import { SurfaceCard } from "@/components/shared/design-system-recipes";
 import { cn } from "@/lib/utils";
 
 type ChartPoint = { year: number; value: number };
@@ -26,78 +23,150 @@ const PERIODS: { id: string; label: string; years: number }[] = [
   { id: "all", label: "Todos", years: Infinity },
 ];
 
-function SvgAreaChart({ points }: { points: ChartPoint[] }) {
+function fmtShort(v: number): string {
+  const abs = Math.abs(v);
+  const sign = v < 0 ? "-" : "";
+  if (abs >= 1e12) return sign + (abs / 1e12).toFixed(1) + "T";
+  if (abs >= 1e9) return sign + (abs / 1e9).toFixed(1) + "B";
+  if (abs >= 1e6) return sign + (abs / 1e6).toFixed(0) + "M";
+  if (abs >= 1e3) return sign + (abs / 1e3).toFixed(0) + "k";
+  return sign + abs.toFixed(0);
+}
+
+function computeStats(points: ChartPoint[]) {
+  if (points.length < 2) return null;
+  const values = points.map((p) => p.value);
+  const max = Math.max(...values);
+  const min = Math.min(...values);
+  const avg = values.reduce((s, v) => s + v, 0) / values.length;
+  const first = points[0]!.value;
+  const last = points.at(-1)!.value;
+  const n = points.length;
+  const cagr = first > 0 && n > 1 ? Math.pow(last / first, 1 / (n - 1)) - 1 : null;
+  return { max, min, avg, cagr };
+}
+
+function SvgBarChart({ points }: { points: ChartPoint[] }) {
+  const [hovered, setHovered] = useState<number | null>(null);
+
   if (points.length < 2) {
     return (
-      <div className="flex h-[140px] items-center justify-center text-sm text-muted-foreground">
+      <div className="flex h-[160px] items-center justify-center text-sm text-muted-foreground">
         Dados insuficientes para o gráfico.
       </div>
     );
   }
 
   const W = 600;
-  const H = 140;
-  const PAD = { top: 12, right: 8, bottom: 20, left: 8 };
+  const H = 160;
+  const PAD = { top: 16, right: 8, bottom: 28, left: 8 };
   const innerW = W - PAD.left - PAD.right;
   const innerH = H - PAD.top - PAD.bottom;
 
   const values = points.map((p) => p.value);
-  const minVal = Math.min(...values);
+  const minVal = Math.min(0, Math.min(...values));
   const maxVal = Math.max(...values);
   const range = maxVal - minVal || 1;
 
-  const toX = (i: number) =>
-    PAD.left + (i / (points.length - 1)) * innerW;
-  const toY = (v: number) =>
-    PAD.top + innerH - ((v - minVal) / range) * innerH;
+  const slot = innerW / points.length;
+  const barW = Math.max(4, slot * 0.55);
 
-  const linePts = points
-    .map((p, i) => `${toX(i).toFixed(1)},${toY(p.value).toFixed(1)}`)
-    .join(" ");
+  const toX = (i: number) => PAD.left + i * slot + slot / 2;
+  const toY = (v: number) => PAD.top + innerH - ((v - minVal) / range) * innerH;
+  const barH = (v: number) =>
+    v >= 0
+      ? ((v - minVal) / range) * innerH
+      : Math.abs((v / range) * innerH);
 
-  const areaPath = [
-    `M ${toX(0).toFixed(1)} ${(PAD.top + innerH).toFixed(1)}`,
-    points
-      .map((p, i) => `L ${toX(i).toFixed(1)} ${toY(p.value).toFixed(1)}`)
-      .join(" "),
-    `L ${toX(points.length - 1).toFixed(1)} ${(PAD.top + innerH).toFixed(1)} Z`,
-  ].join(" ");
+  const zeroY = toY(0);
 
   return (
-    <svg
-      viewBox={`0 0 ${W} ${H}`}
-      className="w-full text-primary"
-      aria-hidden
-      preserveAspectRatio="none"
-    >
-      <defs>
-        <linearGradient id="hero-chart-grad" x1="0" y1="0" x2="0" y2="1">
-          <stop offset="0%" stopColor="currentColor" stopOpacity="0.18" />
-          <stop offset="100%" stopColor="currentColor" stopOpacity="0.01" />
-        </linearGradient>
-      </defs>
-      <path d={areaPath} fill="url(#hero-chart-grad)" />
-      <polyline
-        points={linePts}
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-      {points.map((p, i) => (
-        <text
-          key={p.year}
-          x={toX(i).toFixed(1)}
-          y={H - 4}
-          textAnchor="middle"
-          className="fill-muted-foreground text-[10px]"
-          fontSize={10}
-        >
-          {p.year}
-        </text>
-      ))}
-    </svg>
+    <div className="relative">
+      <svg
+        viewBox={`0 0 ${W} ${H}`}
+        className="w-full"
+        aria-hidden
+        preserveAspectRatio="none"
+        style={{ height: H }}
+      >
+        {/* Zero baseline */}
+        <line
+          x1={PAD.left}
+          x2={W - PAD.right}
+          y1={zeroY}
+          y2={zeroY}
+          stroke="var(--border)"
+          strokeWidth="1"
+          strokeOpacity="0.5"
+        />
+
+        {/* Bars */}
+        {points.map((p, i) => {
+          const x = toX(i);
+          const isPos = p.value >= 0;
+          const bH = barH(p.value);
+          const bY = isPos ? toY(p.value) : zeroY;
+          return (
+            <rect
+              key={p.year}
+              x={x - barW / 2}
+              y={bY}
+              width={barW}
+              height={Math.max(1, bH)}
+              rx={3}
+              fill={
+                hovered === i
+                  ? "var(--primary)"
+                  : "color-mix(in oklch, var(--chart-1) 75%, transparent)"
+              }
+              style={{ transition: "fill 120ms" }}
+              onMouseEnter={() => setHovered(i)}
+              onMouseLeave={() => setHovered(null)}
+            />
+          );
+        })}
+
+        {/* Hover tooltip */}
+        {hovered !== null && points[hovered] && (
+          <g>
+            <rect
+              x={toX(hovered) - 30}
+              y={toY(points[hovered]!.value) - 30}
+              width={60}
+              height={22}
+              rx={5}
+              fill="var(--popover)"
+              stroke="var(--border)"
+              strokeWidth="1"
+            />
+            <text
+              x={toX(hovered)}
+              y={toY(points[hovered]!.value) - 13}
+              textAnchor="middle"
+              fontSize={9}
+              fontFamily="monospace"
+              fill="var(--foreground)"
+            >
+              {fmtShort(points[hovered]!.value)}
+            </text>
+          </g>
+        )}
+
+        {/* X-axis labels */}
+        {points.map((p, i) => (
+          <text
+            key={p.year}
+            x={toX(i)}
+            y={H - 6}
+            textAnchor="middle"
+            fontSize={9}
+            fill="var(--muted-foreground)"
+          >
+            {p.year}
+          </text>
+        ))}
+      </svg>
+    </div>
   );
 }
 
@@ -106,30 +175,23 @@ export function CompanyHeroChart({ series }: CompanyHeroChartProps) {
   const [activePeriod, setActivePeriod] = useState("all");
 
   const currentSeries = series.find((s) => s.label === activeMetric) ?? series[0];
-  const periodYears =
-    PERIODS.find((p) => p.id === activePeriod)?.years ?? Infinity;
+  const periodYears = PERIODS.find((p) => p.id === activePeriod)?.years ?? Infinity;
   const filteredPoints = (currentSeries?.points ?? []).filter((p, _, arr) => {
     const maxYear = Math.max(...arr.map((a) => a.year));
     return p.year > maxYear - periodYears;
   });
 
-  const pillBase =
-    "rounded-full border px-3 py-1 text-xs font-medium transition-colors";
+  const stats = computeStats(filteredPoints);
 
-  if (series.length === 0 || !currentSeries) {
-    return null;
-  }
+  const pillBase = "rounded-full border px-3 py-1 text-[0.75rem] font-medium transition-colors";
+
+  if (series.length === 0 || !currentSeries) return null;
 
   return (
     <SurfaceCard tone="default" padding="lg">
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <SectionHeading
-          title={activeMetric}
-          titleAs="h2"
-          eyebrow="Histórico"
-          bodyClassName="gap-0"
-        />
-        <div className="flex flex-wrap gap-2">
+      {/* Controls */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap gap-1.5">
           {series.map((s) => (
             <button
               key={s.label}
@@ -145,17 +207,18 @@ export function CompanyHeroChart({ series }: CompanyHeroChartProps) {
               {s.label}
             </button>
           ))}
-          <div className="mx-1 w-px bg-border/60" aria-hidden />
+        </div>
+        <div className="flex gap-1">
           {PERIODS.map((p) => (
             <button
               key={p.id}
               type="button"
               onClick={() => setActivePeriod(p.id)}
               className={cn(
-                pillBase,
+                "rounded-full border px-2.5 py-0.5 text-[0.72rem] font-medium transition-colors",
                 p.id === activePeriod
                   ? "border-border bg-muted text-foreground"
-                  : "border-border/40 text-muted-foreground hover:border-border hover:text-foreground",
+                  : "border-transparent text-muted-foreground hover:text-foreground",
               )}
             >
               {p.label}
@@ -164,9 +227,36 @@ export function CompanyHeroChart({ series }: CompanyHeroChartProps) {
         </div>
       </div>
 
-      <div className="mt-4">
-        <SvgAreaChart points={filteredPoints} />
+      <div className="mt-5">
+        <SvgBarChart points={filteredPoints} />
       </div>
+
+      {/* Footer stats */}
+      {stats && (
+        <div className="mt-4 grid grid-cols-4 divide-x divide-border/60 border-t border-border/60 pt-4">
+          {[
+            {
+              label: "CAGR",
+              value:
+                stats.cagr !== null
+                  ? `${stats.cagr >= 0 ? "+" : ""}${(stats.cagr * 100).toFixed(1)}%`
+                  : "—",
+            },
+            { label: "Média", value: fmtShort(stats.avg) },
+            { label: "Máx", value: fmtShort(stats.max) },
+            { label: "Mín", value: fmtShort(stats.min) },
+          ].map(({ label, value }) => (
+            <div key={label} className="px-4 first:pl-0 last:pr-0 text-center">
+              <p className="text-[0.65rem] uppercase tracking-[0.15em] text-muted-foreground">
+                {label}
+              </p>
+              <p className="mt-0.5 font-mono text-[0.85rem] font-medium tabular-nums text-foreground">
+                {value}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
     </SurfaceCard>
   );
 }

--- a/apps/web/components/company/company-kpi-row.tsx
+++ b/apps/web/components/company/company-kpi-row.tsx
@@ -1,4 +1,3 @@
-import { SurfaceCard } from "@/components/shared/design-system-recipes";
 import type { KPIBundle, TabularDataRow } from "@/lib/api";
 import { formatKpiDelta, formatKpiValue } from "@/lib/formatters";
 import { cn } from "@/lib/utils";
@@ -35,33 +34,37 @@ export function CompanyKpiRow({ bundle }: CompanyKpiRowProps) {
         const isPositive = deltaValue !== null && deltaValue >= 0;
 
         return (
-          <SurfaceCard key={kpi.id} tone="subtle" padding="md">
-            <div className="space-y-3">
-              <div className="flex items-center justify-between gap-2">
-                <p className="text-xs text-muted-foreground">{kpi.label}</p>
-                <span className="text-[0.65rem] text-muted-foreground/60 tabular-nums">
-                  {lastYear ?? "—"}
-                </span>
-              </div>
-              <p className="font-heading text-2xl tracking-[-0.04em] text-foreground">
-                {formatKpiValue(currentValue, kpi.formatType)}
-              </p>
+          <div
+            key={kpi.id}
+            className="rounded-[1.25rem] border border-border/60 bg-card px-5 py-4"
+          >
+            <p className="text-[0.72rem] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+              {kpi.label}
+            </p>
+            <p className="mt-2 font-heading text-[1.75rem] font-medium tracking-[-0.04em] text-foreground leading-none">
+              {formatKpiValue(currentValue, kpi.formatType)}
+            </p>
+            <div className="mt-2 flex items-center justify-between">
               {deltaValue !== null ? (
-                <p
+                <span
                   className={cn(
-                    "text-xs",
+                    "inline-flex items-center rounded-full px-2 py-0.5 text-[0.72rem] font-medium",
                     isPositive
-                      ? "text-green-600 dark:text-green-400"
-                      : "text-destructive",
+                      ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+                      : "bg-destructive/10 text-destructive",
                   )}
                 >
+                  {isPositive ? "+" : ""}
                   {formatKpiDelta(deltaValue, kpi.formatType)}
-                </p>
+                </span>
               ) : (
-                <p className="text-xs text-muted-foreground/50">sem delta</p>
+                <span className="text-[0.72rem] text-muted-foreground/40">sem delta</span>
               )}
+              <span className="text-[0.68rem] tabular-nums text-muted-foreground/50">
+                {lastYear ?? "—"}
+              </span>
             </div>
-          </SurfaceCard>
+          </div>
         );
       })}
     </div>

--- a/apps/web/components/company/company-overview.tsx
+++ b/apps/web/components/company/company-overview.tsx
@@ -3,20 +3,10 @@ import { CompanyHeroChart } from "@/components/company/company-hero-chart";
 import { CompanyKpiRow } from "@/components/company/company-kpi-row";
 import { CompanySectorRanking } from "@/components/company/company-sector-ranking";
 import { SparklineChip } from "@/components/shared/sparkline-chip";
-import {
-  SectionHeading,
-  SurfaceCard,
-} from "@/components/shared/design-system-recipes";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
+import { SectionHeading } from "@/components/shared/design-system-recipes";
 import type { KPIBundle, TabularDataRow } from "@/lib/api";
 import { formatKpiDelta, formatKpiValue } from "@/lib/formatters";
+import { cn } from "@/lib/utils";
 
 const CHART_KPIS = [
   { id: "RECEITA_LIQ", label: "Receita" },
@@ -28,6 +18,37 @@ const SPARKLINE_KPIS = [
   { id: "RECEITA_LIQ", label: "Receita Líquida", formatType: "brl" },
   { id: "EBITDA", label: "EBITDA", formatType: "brl" },
   { id: "MG_EBITDA", label: "Margem EBITDA", formatType: "pct" },
+] as const;
+
+const KPI_GROUPS = [
+  {
+    label: "Rentabilidade",
+    kpis: [
+      { id: "MG_BRUTA", label: "Mg. Bruta", formatType: "pct" },
+      { id: "MG_EBITDA", label: "Mg. EBITDA", formatType: "pct" },
+      { id: "MG_EBIT", label: "Mg. EBIT", formatType: "pct" },
+      { id: "MG_LIQ", label: "Mg. Líquida", formatType: "pct" },
+      { id: "ROE", label: "ROE", formatType: "pct" },
+      { id: "ROA", label: "ROA", formatType: "pct" },
+    ],
+  },
+  {
+    label: "Endividamento",
+    kpis: [
+      { id: "DIV_LIQ_EBITDA", label: "Dív/EBITDA", formatType: "ratio" },
+      { id: "DIV_LIQ_PL", label: "Dív Líq/PL", formatType: "ratio" },
+      { id: "LIQ_CORR", label: "Liq. Corrente", formatType: "ratio" },
+      { id: "COBERT_JUR", label: "Cob. Juros", formatType: "ratio" },
+    ],
+  },
+  {
+    label: "Eficiência",
+    kpis: [
+      { id: "FCO_REC", label: "FCO/Receita", formatType: "pct" },
+      { id: "CAPEX_RECEITA", label: "Capex/Rec", formatType: "pct" },
+      { id: "GIRO_ATIVO", label: "Giro Ativo", formatType: "ratio" },
+    ],
+  },
 ] as const;
 
 function isYearColumn(value: string): boolean {
@@ -63,71 +84,76 @@ export function CompanyOverview({ bundle, cdCvm }: CompanyOverviewProps) {
 
   return (
     <div className="grid grid-cols-1 gap-6 lg:grid-cols-12 lg:gap-8">
-      <div className="flex flex-col gap-5 lg:col-span-8">
+      {/* Main column */}
+      <div className="flex flex-col gap-6 lg:col-span-8">
         <CompanyKpiRow bundle={bundle} />
 
-        {chartSeries.length > 0 ? (
-          <CompanyHeroChart series={chartSeries} />
-        ) : null}
+        {chartSeries.length > 0 ? <CompanyHeroChart series={chartSeries} /> : null}
 
-        <section className="space-y-4">
+        {/* 3-group KPI tiles */}
+        <section className="space-y-5">
           <SectionHeading
-            eyebrow="Matriz anual de KPIs"
-            title="Leitura compacta por indicador"
+            eyebrow="Indicadores"
+            title="Por categoria"
             titleAs="h3"
           />
-          <SurfaceCard tone="default" padding="none" className="overflow-hidden">
-            <Table>
-              <TableHeader className="bg-muted/35">
-                <TableRow>
-                  <TableHead className="px-5">Indicador</TableHead>
-                  <TableHead>Categoria</TableHead>
-                  {yearColumns.map((year) => (
-                    <TableHead key={year}>{year}</TableHead>
-                  ))}
-                  <TableHead>Delta YoY</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {annualRows
-                  .filter((row) => !Boolean(row.IS_PLACEHOLDER))
-                  .map((row) => {
-                    const formatType = String(row.FORMAT_TYPE ?? "ratio");
-                    return (
-                      <TableRow key={String(row.KPI_ID)}>
-                        <TableCell className="px-5 font-medium text-foreground">
-                          {String(row.KPI_NOME)}
-                        </TableCell>
-                        <TableCell className="text-muted-foreground">
-                          {String(row.CATEGORIA)}
-                        </TableCell>
-                        {yearColumns.map((year) => (
-                          <TableCell key={year}>
-                            {formatKpiValue(
-                              row[year] === null || row[year] === undefined
-                                ? null
-                                : Number(row[year]),
-                              formatType,
-                            )}
-                          </TableCell>
-                        ))}
-                        <TableCell className="text-muted-foreground">
-                          {formatKpiDelta(
-                            row.DELTA_YOY === null || row.DELTA_YOY === undefined
-                              ? null
-                              : Number(row.DELTA_YOY),
-                            formatType,
+          <div className="space-y-5">
+            {KPI_GROUPS.map((group) => {
+              const visibleKpis = group.kpis.filter((kpi) => kpiMap.has(kpi.id));
+              if (visibleKpis.length === 0) return null;
+
+              return (
+                <div key={group.label}>
+                  <p className="mb-3 text-[0.72rem] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+                    {group.label}
+                  </p>
+                  <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+                    {visibleKpis.map((kpi) => {
+                      const row = kpiMap.get(kpi.id);
+                      const value =
+                        row && lastYear ? Number(row[lastYear] ?? NaN) : null;
+                      const delta =
+                        row?.DELTA_YOY === null || row?.DELTA_YOY === undefined
+                          ? null
+                          : Number(row.DELTA_YOY);
+                      const isPos = delta !== null && delta >= 0;
+
+                      return (
+                        <div
+                          key={kpi.id}
+                          className="rounded-[1rem] border border-border/60 bg-card px-4 py-3"
+                        >
+                          <p className="text-[0.68rem] uppercase tracking-[0.14em] text-muted-foreground">
+                            {kpi.label}
+                          </p>
+                          <p className="mt-1 font-heading text-[1.25rem] font-medium tracking-[-0.03em] text-foreground leading-none">
+                            {formatKpiValue(value, kpi.formatType)}
+                          </p>
+                          {delta !== null && (
+                            <p
+                              className={cn(
+                                "mt-1 text-[0.7rem] font-medium",
+                                isPos
+                                  ? "text-emerald-600 dark:text-emerald-400"
+                                  : "text-destructive",
+                              )}
+                            >
+                              {isPos ? "+" : ""}
+                              {formatKpiDelta(delta, kpi.formatType)}
+                            </p>
                           )}
-                        </TableCell>
-                      </TableRow>
-                    );
-                  })}
-              </TableBody>
-            </Table>
-          </SurfaceCard>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
         </section>
       </div>
 
+      {/* Right rail */}
       <div className="flex flex-col gap-4 lg:col-span-4">
         {SPARKLINE_KPIS.map((kpi) => {
           const row = kpiMap.get(kpi.id);

--- a/apps/web/components/company/company-sector-ranking.tsx
+++ b/apps/web/components/company/company-sector-ranking.tsx
@@ -1,29 +1,55 @@
-import { SurfaceCard } from "@/components/shared/design-system-recipes";
-
 const RANKING_ITEMS = [
-  { label: "Dívida/EBITDA" },
-  { label: "ROE" },
-  { label: "P/L" },
-  { label: "Margem EBIT" },
+  { label: "Dívida/EBITDA", rank: null, total: null },
+  { label: "ROE", rank: null, total: null },
+  { label: "P/L", rank: null, total: null },
+  { label: "Margem EBIT", rank: null, total: null },
 ];
+
+function PeerBar({
+  rank,
+  total,
+  label,
+}: {
+  rank: number | null;
+  total: number | null;
+  label: string;
+}) {
+  const pct = rank !== null && total !== null && total > 0 ? 1 - rank / total : 0;
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between">
+        <span className="text-[0.8rem] text-muted-foreground">{label}</span>
+        <span className="font-mono text-[0.75rem] text-muted-foreground/60 tabular-nums">
+          {rank !== null && total !== null ? `${rank}º / ${total}` : "Em breve"}
+        </span>
+      </div>
+      <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+        <div
+          className="h-full rounded-full bg-primary/40 transition-all duration-500"
+          style={{ width: `${(pct * 100).toFixed(1)}%` }}
+        />
+      </div>
+    </div>
+  );
+}
 
 export function CompanySectorRanking() {
   return (
-    <SurfaceCard tone="subtle" padding="md">
-      <p className="eyebrow mb-3 text-muted-foreground">Ranking no setor</p>
-      <div className="space-y-3">
+    <div className="rounded-[1.25rem] border border-border/60 bg-card px-5 py-4">
+      <p className="mb-4 text-[0.72rem] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+        Ranking no setor
+      </p>
+      <div className="space-y-3.5">
         {RANKING_ITEMS.map((item) => (
-          <div key={item.label} className="space-y-1">
-            <div className="flex items-center justify-between">
-              <span className="text-xs text-muted-foreground">{item.label}</span>
-              <span className="text-xs text-muted-foreground/60">Em breve</span>
-            </div>
-            <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
-              <div className="h-full w-0 rounded-full bg-primary/30" />
-            </div>
-          </div>
+          <PeerBar
+            key={item.label}
+            label={item.label}
+            rank={item.rank}
+            total={item.total}
+          />
         ))}
       </div>
-    </SurfaceCard>
+    </div>
   );
 }

--- a/apps/web/components/company/company-statements.tsx
+++ b/apps/web/components/company/company-statements.tsx
@@ -9,7 +9,6 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import type { StatementMatrix, TabularDataRow } from "@/lib/api";
 import { isStatementSubtotal, STATEMENT_OPTIONS } from "@/lib/constants";
-import { formatStatementValue } from "@/lib/formatters";
 import { mergeSearchParams } from "@/lib/search-params";
 import { cn } from "@/lib/utils";
 
@@ -71,9 +70,7 @@ function StatementRow({
   const level = Number(row.LEVEL ?? 0);
   const indent = 16 + level * 16;
   const delta =
-    row.DELTA_YOY === null || row.DELTA_YOY === undefined
-      ? null
-      : Number(row.DELTA_YOY);
+    row.DELTA_YOY === null || row.DELTA_YOY === undefined ? null : Number(row.DELTA_YOY);
   const isDeltaPos = delta !== null && delta >= 0;
 
   return (
@@ -120,12 +117,10 @@ function StatementRow({
               "py-2.5 px-3 text-right font-mono text-[0.82rem] tnum tabular-nums",
               isNeg ? "text-destructive" : "text-foreground",
               isSubtotal ? "font-semibold" : "",
-              isLastYear(col) ? "text-foreground font-medium" : "",
+              isLastYear(col) ? "font-medium text-foreground" : "",
             )}
           >
-            {numericValue === null || isNaN(numericValue)
-              ? "—"
-              : fmtMM(numericValue)}
+            {numericValue === null || isNaN(numericValue) ? "—" : fmtMM(numericValue)}
           </td>
         );
       })}
@@ -135,7 +130,9 @@ function StatementRow({
           {delta === null ? (
             <span className="text-muted-foreground/50">—</span>
           ) : (
-            <span className={isDeltaPos ? "text-emerald-600 dark:text-emerald-400" : "text-destructive"}>
+            <span
+              className={isDeltaPos ? "text-emerald-600 dark:text-emerald-400" : "text-destructive"}
+            >
               {isDeltaPos ? "+" : ""}
               {(delta * 100).toFixed(1)}%
             </span>
@@ -178,29 +175,28 @@ export function CompanyStatements({ matrix }: CompanyStatementsProps) {
   if (rows.length === 0) {
     return (
       <SurfaceCard tone="muted" padding="hero" className="items-center text-center">
-        <p className="font-heading text-2xl text-foreground">
-          Sem demonstração disponível.
-        </p>
+        <p className="font-heading text-2xl text-foreground">Sem demonstração disponível.</p>
         <p className="max-w-2xl text-sm leading-7 text-muted-foreground">
-          Ajuste o período selecionado ou troque o tipo de demonstração para
-          consultar outra visão disponível.
+          Ajuste o período selecionado ou troque o tipo de demonstração para consultar outra
+          visão disponível.
         </p>
       </SurfaceCard>
     );
   }
 
   return (
-    <div className="space-y-4">
-      <div className="flex gap-0 border-b border-border/60">
+    <div className="space-y-0">
+      {/* Pill sub-tabs */}
+      <div className="flex gap-1 border-b border-border/60 px-1 pb-0">
         {STATEMENT_OPTIONS.map((opt) => (
           <button
             key={opt.value}
             type="button"
             onClick={() => navigateTo(opt.value)}
             className={cn(
-              "flex items-center gap-1.5 border-b-2 px-4 py-2.5 text-sm transition-colors -mb-px",
+              "rounded-[0.85rem_0.85rem_0_0] border border-b-0 px-4 py-2 text-[0.82rem] font-medium -mb-px transition-colors",
               currentStmt === opt.value
-                ? "border-primary text-foreground font-medium"
+                ? "border-border/60 bg-card text-foreground"
                 : "border-transparent text-muted-foreground hover:text-foreground",
             )}
           >
@@ -209,36 +205,36 @@ export function CompanyStatements({ matrix }: CompanyStatementsProps) {
         ))}
       </div>
 
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div className="flex flex-wrap items-center gap-3">
-          <div className="flex items-center gap-2 rounded-[1rem] border border-border/60 bg-muted/40 px-3 py-1.5">
-            <SearchIcon className="size-3.5 shrink-0 text-muted-foreground" />
-            <Input
-              type="search"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder="Filtrar linha…"
-              className="h-auto w-40 border-0 bg-transparent p-0 text-sm shadow-none focus-visible:ring-0"
-            />
-          </div>
-          <label className="flex cursor-pointer items-center gap-2 text-sm text-muted-foreground">
-            <Checkbox
-              checked={showYoY}
-              onCheckedChange={(checked) => setShowYoY(Boolean(checked))}
-            />
-            Mostrar variação
-          </label>
+      {/* Filter bar */}
+      <div className="flex flex-wrap items-center gap-3 rounded-[0_0_0_0] border border-t-0 border-border/60 bg-muted/20 px-4 py-3">
+        <div className="flex items-center gap-2 rounded-[1rem] border border-border/60 bg-card px-3 py-1.5">
+          <SearchIcon className="size-3.5 shrink-0 text-muted-foreground" />
+          <Input
+            type="search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Filtrar linha…"
+            className="h-auto w-44 border-0 bg-transparent p-0 text-sm shadow-none focus-visible:ring-0"
+          />
         </div>
-        <span className="text-xs text-muted-foreground">
-          {filteredRows.length} linhas · valores em R$ milhões
+        <label className="flex cursor-pointer items-center gap-2 text-[0.82rem] text-muted-foreground">
+          <Checkbox
+            checked={showYoY}
+            onCheckedChange={(checked) => setShowYoY(Boolean(checked))}
+          />
+          Mostrar variação YoY
+        </label>
+        <span className="ml-auto text-[0.72rem] text-muted-foreground tabular-nums">
+          {filteredRows.length} linhas · R$ milhões
         </span>
       </div>
 
-      <div className="overflow-x-auto rounded-xl border border-border/60">
+      {/* Table */}
+      <div className="overflow-x-auto rounded-b-xl border border-t-0 border-border/60">
         <table className="min-w-full text-sm">
           <thead>
             <tr className="border-b border-border/60 bg-muted/30">
-              <th className="sticky left-0 z-10 bg-muted/30 px-4 py-3 text-left font-medium text-muted-foreground w-[40%]">
+              <th className="sticky left-0 z-10 w-[40%] bg-muted/30 px-4 py-3 text-left font-medium text-muted-foreground">
                 Conta
               </th>
               {yearColumns.map((col) => (
@@ -274,9 +270,9 @@ export function CompanyStatements({ matrix }: CompanyStatementsProps) {
         </table>
       </div>
 
-      <p className="text-xs italic text-muted-foreground">
-        Fonte: CVM · DFP/ITR consolidados. Linhas em destaque são totalizadoras.
-        Valores em R$ milhões, sem ajuste de inflação.
+      <p className="pt-3 text-xs italic text-muted-foreground">
+        Fonte: CVM · DFP/ITR consolidados. Linhas em destaque são totalizadoras. Valores em R$
+        milhões, sem ajuste de inflação.
       </p>
     </div>
   );

--- a/apps/web/components/home/company-search-hero.tsx
+++ b/apps/web/components/home/company-search-hero.tsx
@@ -1,85 +1,53 @@
 "use client";
 
-import Link from "next/link";
-import { ArrowRightIcon, SearchIcon } from "lucide-react";
-import { useDeferredValue, useEffect, useState, useTransition } from "react";
+import { ArrowRightIcon, SearchIcon, XIcon } from "lucide-react";
+import { useDeferredValue, useEffect, useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 
-import {
-  InfoChip,
-  surfaceVariants,
-} from "@/components/shared/design-system-recipes";
 import { buttonVariants } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import type { CompanyDirectoryItem } from "@/lib/api";
-import { formatCompactInteger, formatYearsLabel } from "@/lib/formatters";
+import { getSectorColor } from "@/lib/constants";
 import { track } from "@/lib/track";
 import { cn } from "@/lib/utils";
+
+const QUICK_CHIPS = ["PETROBRAS", "VALE3", "ITAUB4", "BBDC4", "Financeiro", "Petróleo e Gás"];
 
 type CompanySearchHeroProps = {
   apiAvailable: boolean;
   totalCompanies: number | null;
 };
 
-export function CompanySearchHero({
-  apiAvailable,
-  totalCompanies,
-}: CompanySearchHeroProps) {
+export function CompanySearchHero({ apiAvailable }: CompanySearchHeroProps) {
   const router = useRouter();
+  const inputRef = useRef<HTMLInputElement>(null);
   const [query, setQuery] = useState("");
+  const [focused, setFocused] = useState(false);
   const [suggestions, setSuggestions] = useState<CompanyDirectoryItem[]>([]);
   const [loadingSuggestions, setLoadingSuggestions] = useState(false);
-  const [suggestionError, setSuggestionError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
   const deferredQuery = useDeferredValue(query);
 
   useEffect(() => {
     const normalized = deferredQuery.trim();
-
     if (normalized.length < 2 || !apiAvailable) {
       setSuggestions([]);
-      setSuggestionError(null);
       return;
     }
 
     let active = true;
     const timer = window.setTimeout(async () => {
       setLoadingSuggestions(true);
-      setSuggestionError(null);
-
       try {
-        const response = await fetch(
+        const res = await fetch(
           `/api/company-search?q=${encodeURIComponent(normalized)}`,
-          {
-            cache: "no-store",
-          },
+          { cache: "no-store" },
         );
-        const payload = (await response.json()) as {
-          items?: CompanyDirectoryItem[];
-          error?: string;
-        };
-
-        if (!active) {
-          return;
-        }
-
-        if (!response.ok) {
-          setSuggestions([]);
-          setSuggestionError(payload.error ?? "Nao foi possivel buscar sugestoes.");
-          return;
-        }
-
-        setSuggestions(payload.items ?? []);
+        const data = (await res.json()) as { items?: CompanyDirectoryItem[] };
+        if (active) setSuggestions(data.items?.slice(0, 6) ?? []);
       } catch {
-        if (!active) {
-          return;
-        }
-        setSuggestions([]);
-        setSuggestionError("Nao foi possivel buscar sugestoes.");
+        if (active) setSuggestions([]);
       } finally {
-        if (active) {
-          setLoadingSuggestions(false);
-        }
+        if (active) setLoadingSuggestions(false);
       }
     }, 180);
 
@@ -89,40 +57,25 @@ export function CompanySearchHero({
     };
   }, [apiAvailable, deferredQuery]);
 
-  function navigateToDirectory(rawQuery: string) {
-    const normalized = rawQuery.trim();
-    const target = normalized
-      ? `/empresas?busca=${encodeURIComponent(normalized)}`
-      : "/empresas";
+  const showDropdown = focused && (loadingSuggestions || suggestions.length > 0);
 
-    track("home_search_submitted", {
-      query: normalized,
-    });
-
-    startTransition(() => {
-      router.push(target);
-    });
+  function navigateToCompany(item: CompanyDirectoryItem) {
+    track("home_suggestion_selected", { cd_cvm: item.cd_cvm, company_name: item.company_name });
+    startTransition(() => router.push(`/empresas/${item.cd_cvm}`));
   }
 
-  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    navigateToDirectory(query);
-  }
-
-  function handleSuggestionSelection(item: CompanyDirectoryItem) {
-    track("home_suggestion_selected", {
-      cd_cvm: item.cd_cvm,
-      company_name: item.company_name,
-    });
-
-    startTransition(() => {
-      router.push(`/empresas/${item.cd_cvm}`);
-    });
+  function submit() {
+    const q = query.trim();
+    track("home_search_submitted", { query: q });
+    startTransition(() =>
+      router.push(q ? `/empresas?busca=${encodeURIComponent(q)}` : "/empresas"),
+    );
   }
 
   return (
-    <div className="w-full max-w-[680px] mx-auto space-y-7 text-center">
-      <div className="space-y-5">
+    <div className="w-full max-w-[680px] mx-auto space-y-6 text-center">
+      {/* Heading */}
+      <div className="space-y-4">
         <h1 className="font-heading text-[clamp(2.5rem,5.5vw,4.25rem)] leading-[1.02] tracking-[-0.045em] text-foreground">
           Análise financeira<br />
           <span className="text-muted-foreground italic font-normal">
@@ -130,108 +83,130 @@ export function CompanySearchHero({
           </span>
         </h1>
         <p className="max-w-[560px] mx-auto text-[1.0625rem] leading-[1.55] text-muted-foreground">
-          Pesquise qualquer companhia aberta brasileira. Leia DRE, balanço e KPIs com 10+ anos de histórico, direto da CVM.
+          Pesquise qualquer companhia aberta brasileira. Leia DRE, balanço e KPIs
+          com 10+ anos de histórico, direto da CVM.
         </p>
       </div>
 
-      <form
-        action="/empresas"
-        method="get"
-        onSubmit={handleSubmit}
-        className="relative"
-      >
-        <div className="flex flex-col gap-3 rounded-[1.5rem] border border-border/70 bg-background/92 p-3 shadow-[0_18px_45px_-40px_rgba(16,30,24,0.22)] sm:flex-row sm:items-center">
-          <div className="flex flex-1 items-center gap-3 rounded-[1.2rem] border border-border/60 bg-muted/55 px-4 py-3">
-            <SearchIcon className="size-4.5 text-muted-foreground" />
-            <Input
-              name="busca"
-              type="search"
-              value={query}
-              placeholder="PETROBRAS, VALE3 ou 9512"
-              className="h-auto border-0 bg-transparent p-0 text-base shadow-none ring-0 focus-visible:ring-0"
-              onChange={(event) => setQuery(event.target.value)}
-              aria-label="Buscar empresa"
-            />
-          </div>
-          <div className="flex flex-col gap-3 sm:flex-row">
+      {/* Search box */}
+      <div className="relative text-left">
+        <div
+          onClick={() => inputRef.current?.focus()}
+          className={cn(
+            "flex items-center gap-3 bg-card border transition-all duration-200 cursor-text px-5 py-2 pr-2",
+            showDropdown ? "rounded-[1.25rem_1.25rem_0_0]" : "rounded-[1.25rem]",
+            focused
+              ? "border-ring/50 shadow-[0_0_0_4px_color-mix(in_oklch,var(--ring)_15%,transparent),0_20px_60px_-40px_rgba(16,30,24,0.25)]"
+              : "border-border/70 shadow-[0_18px_50px_-40px_rgba(16,30,24,0.22)]",
+          )}
+        >
+          <SearchIcon className="size-[1.375rem] shrink-0 text-muted-foreground" />
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onFocus={() => setFocused(true)}
+            onBlur={() => setTimeout(() => setFocused(false), 150)}
+            onKeyDown={(e) => e.key === "Enter" && submit()}
+            placeholder="Petrobras, VALE3, setor financeiro…"
+            className="flex-1 border-none bg-transparent py-[0.85rem] text-[1.125rem] text-foreground outline-none placeholder:text-muted-foreground"
+            aria-label="Buscar empresa"
+          />
+          {query && (
             <button
-              type="submit"
-              className={cn(
-                buttonVariants({ size: "lg" }),
-                "rounded-full px-5",
-              )}
-              disabled={isPending}
+              type="button"
+              onClick={() => { setQuery(""); inputRef.current?.focus(); }}
+              className="flex size-8 items-center justify-center rounded-full text-muted-foreground hover:bg-muted/50 hover:text-foreground transition-colors mr-1"
+              aria-label="Limpar busca"
             >
-              Buscar empresa
-              <ArrowRightIcon data-icon="inline-end" />
+              <XIcon className="size-4" />
             </button>
-            <Link
-              href="/empresas"
-              className={cn(
-                buttonVariants({ variant: "outline", size: "lg" }),
-                "rounded-full px-5",
-              )}
-            >
-              Ir para empresas
-            </Link>
-          </div>
+          )}
+          <button
+            type="button"
+            onClick={submit}
+            disabled={isPending}
+            className={cn(buttonVariants({ size: "lg" }), "rounded-full px-5 shrink-0")}
+          >
+            Buscar
+            <ArrowRightIcon className="size-4" />
+          </button>
         </div>
 
-        {apiAvailable &&
-        (loadingSuggestions || suggestions.length > 0 || suggestionError) ? (
-          <div
-            className={cn(
-              surfaceVariants({ tone: "default", padding: "none" }),
-              "absolute inset-x-0 top-[calc(100%+0.75rem)] z-20 overflow-hidden text-left",
-            )}
-          >
-            {loadingSuggestions ? (
-              <p className="px-5 py-4 text-sm text-muted-foreground">
-                Buscando sugestoes...
-              </p>
-            ) : suggestionError ? (
-              <p className="px-5 py-4 text-sm text-destructive">
-                {suggestionError}
-              </p>
-            ) : (
-              <ul className="divide-y divide-border/50">
-                {suggestions.map((item) => (
-                  <li key={item.cd_cvm}>
-                    <button
-                      type="button"
-                      className="flex w-full items-start justify-between gap-4 px-5 py-4 text-left transition-colors hover:bg-muted/45"
-                      onClick={() => handleSuggestionSelection(item)}
-                    >
-                      <div className="space-y-1.5">
-                        <p className="font-medium text-foreground">
-                          {item.company_name}
-                        </p>
-                        <p className="text-sm text-muted-foreground">
-                          {item.ticker_b3 ?? "Sem ticker"} - CVM {item.cd_cvm}
-                        </p>
-                      </div>
-                      <div className="space-y-1 text-right">
-                        <p className="text-sm text-foreground">
-                          {item.sector_name}
-                        </p>
-                        <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
-                          {formatYearsLabel(item.anos_disponiveis)}
-                        </p>
-                      </div>
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            )}
+        {/* Suggestions dropdown */}
+        {showDropdown && (
+          <div className="absolute inset-x-0 top-full z-20 overflow-hidden rounded-[0_0_1.25rem_1.25rem] border border-t-0 border-ring/50 bg-card shadow-[0_20px_60px_-30px_rgba(16,30,24,0.25)]">
+            <div className="border-t border-border bg-muted/30 px-5 py-1.5 text-[0.7rem] font-medium uppercase tracking-[0.2em] text-muted-foreground">
+              {loadingSuggestions
+                ? "Buscando…"
+                : `${suggestions.length} resultado${suggestions.length !== 1 ? "s" : ""}`}
+            </div>
+            {suggestions.map((item) => {
+              const color = getSectorColor(item.sector_name);
+              const initials = (item.ticker_b3 ?? item.company_name).slice(0, 2).toUpperCase();
+              return (
+                <button
+                  key={item.cd_cvm}
+                  type="button"
+                  onMouseDown={() => navigateToCompany(item)}
+                  className="flex w-full items-center gap-4 border-t border-border/50 px-5 py-3.5 text-left transition-colors hover:bg-accent/60"
+                >
+                  <div
+                    className="flex size-10 shrink-0 items-center justify-center rounded-[10px] font-heading text-sm font-semibold"
+                    style={{
+                      background: `color-mix(in oklch, ${color} 12%, transparent)`,
+                      border: `1px solid color-mix(in oklch, ${color} 25%, transparent)`,
+                      color,
+                    }}
+                  >
+                    {initials}
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="font-semibold text-sm text-foreground">{item.company_name}</span>
+                      {item.ticker_b3 && (
+                        <span
+                          className="font-mono text-[0.7rem] font-medium px-1.5 py-0.5 rounded-[0.35rem]"
+                          style={{
+                            background: `color-mix(in oklch, ${color} 12%, transparent)`,
+                            border: `1px solid color-mix(in oklch, ${color} 25%, transparent)`,
+                            color,
+                          }}
+                        >
+                          {item.ticker_b3}
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-[0.8rem] text-muted-foreground mt-0.5">{item.sector_name}</p>
+                  </div>
+                  <div className="text-right shrink-0">
+                    <p className="text-[0.72rem] uppercase tracking-[0.15em] text-muted-foreground tabular-nums">
+                      {(item.anos_disponiveis?.length ?? 0)} anos
+                    </p>
+                  </div>
+                </button>
+              );
+            })}
           </div>
-        ) : null}
-      </form>
+        )}
+      </div>
 
-      <div className="flex flex-wrap justify-center items-center gap-3 text-sm text-muted-foreground">
-        <InfoChip>{apiAvailable ? "API pronta para busca" : "API indisponivel"}</InfoChip>
-        {totalCompanies !== null ? (
-          <InfoChip>{formatCompactInteger(totalCompanies)} empresas com dados</InfoChip>
-        ) : null}
+      {/* Quick chips */}
+      <div className="flex flex-wrap justify-center items-center gap-2">
+        <span className="text-[0.8rem] text-muted-foreground">Tente:</span>
+        {QUICK_CHIPS.map((chip) => (
+          <button
+            key={chip}
+            type="button"
+            onClick={() => {
+              setQuery(chip);
+              setTimeout(() => inputRef.current?.focus(), 0);
+            }}
+            className="rounded-full border border-border bg-card px-3 py-1 font-mono text-[0.75rem] text-muted-foreground transition-colors hover:border-primary/35 hover:text-primary"
+          >
+            {chip}
+          </button>
+        ))}
       </div>
     </div>
   );

--- a/apps/web/components/home/discovery-section.tsx
+++ b/apps/web/components/home/discovery-section.tsx
@@ -2,16 +2,16 @@
 
 import Link from "next/link";
 import { useState } from "react";
-import { ArrowUpRightIcon } from "lucide-react";
+import { TrendingUpIcon, TrendingDownIcon, ArrowRightIcon } from "lucide-react";
 
 import type { CompanyDirectoryItem } from "@/lib/api";
-import { SECTOR_COLOR } from "@/lib/constants";
+import { SECTOR_COLOR, getSectorColor } from "@/lib/constants";
 import { cn } from "@/lib/utils";
 
 type Tab = "populares" | "destaque" | "setores";
 
 const TABS: { id: Tab; label: string }[] = [
-  { id: "populares", label: "Populares" },
+  { id: "populares", label: "Populares agora" },
   { id: "destaque", label: "Em destaque" },
   { id: "setores", label: "Setores" },
 ];
@@ -20,107 +20,243 @@ type DiscoverySectionProps = {
   topCompanies: CompanyDirectoryItem[];
 };
 
+function buildSparkPoints(anos: number[], W = 70, H = 32): string {
+  if (!anos || anos.length < 2) return "";
+  const sorted = [...anos].sort((a, b) => a - b);
+  const min = sorted[0]!;
+  const max = sorted[sorted.length - 1]!;
+  const rangeYears = max - min || 1;
+  return sorted
+    .map((year, i) => {
+      const x = ((year - min) / rangeYears) * W;
+      const y = H - (i / Math.max(sorted.length - 1, 1)) * (H * 0.75) - 2;
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+}
+
+function CompanyCard({ co }: { co: CompanyDirectoryItem }) {
+  const color = getSectorColor(co.sector_name);
+  const anos = co.anos_disponiveis ?? [];
+  const sparkPts = buildSparkPoints(anos);
+
+  return (
+    <Link
+      href={`/empresas/${co.cd_cvm}`}
+      className="group flex flex-col gap-3 rounded-[1.25rem] border border-border/60 bg-card p-5 transition-all duration-200 hover:-translate-y-0.5 hover:border-primary/25 hover:shadow-[0_22px_40px_-28px_rgba(16,30,24,0.22)]"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div
+            className="mb-2 inline-block font-mono text-[0.7rem] font-medium px-1.5 py-0.5 rounded-[0.35rem]"
+            style={{
+              background: `color-mix(in oklch, ${color} 12%, transparent)`,
+              border: `1px solid color-mix(in oklch, ${color} 25%, transparent)`,
+              color,
+            }}
+          >
+            {co.ticker_b3 ?? `CVM ${co.cd_cvm}`}
+          </div>
+          <p className="font-semibold text-[0.95rem] text-foreground line-clamp-1">
+            {co.company_name}
+          </p>
+          {co.sector_name && (
+            <p className="mt-0.5 text-[0.75rem] text-muted-foreground">{co.sector_name}</p>
+          )}
+        </div>
+        {sparkPts && (
+          <svg
+            width={70}
+            height={32}
+            viewBox={`0 0 70 32`}
+            className="shrink-0"
+            aria-hidden
+          >
+            <defs>
+              <linearGradient id={`spark-grad-${co.cd_cvm}`} x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor={color} stopOpacity="0.25" />
+                <stop offset="100%" stopColor={color} stopOpacity="0.02" />
+              </linearGradient>
+            </defs>
+            <polyline
+              points={sparkPts}
+              fill="none"
+              stroke={color}
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        )}
+      </div>
+      <div className="flex items-end justify-between border-t border-dashed border-border/60 pt-3">
+        <div>
+          <p className="text-[0.65rem] uppercase tracking-[0.15em] text-muted-foreground">
+            Dados disponíveis
+          </p>
+          <p className="mt-0.5 font-mono text-sm font-medium text-foreground tabular-nums">
+            {anos.length > 0
+              ? `${Math.min(...anos)}–${Math.max(...anos)}`
+              : "—"}
+          </p>
+        </div>
+        <div className="flex items-center gap-1 text-[0.8rem] font-medium text-muted-foreground group-hover:text-primary transition-colors">
+          <span>{anos.length} anos</span>
+          <ArrowRightIcon className="size-3.5" />
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+function DestaquCard({ co, rank }: { co: CompanyDirectoryItem; rank: number }) {
+  const color = getSectorColor(co.sector_name);
+  const anos = co.anos_disponiveis ?? [];
+  const sparkPts = buildSparkPoints(anos, 54, 22);
+  const isTop = rank < 3;
+
+  return (
+    <button
+      type="button"
+      onClick={() => window.location.assign(`/empresas/${co.cd_cvm}`)}
+      className="flex w-full items-center gap-3 rounded-[10px] px-3 py-2.5 text-left transition-colors hover:bg-accent/60"
+    >
+      <span className="w-5 shrink-0 font-mono text-[0.8rem] text-muted-foreground tabular-nums">
+        {rank}
+      </span>
+      <span
+        className="shrink-0 font-mono text-[0.7rem] font-medium px-1.5 py-0.5 rounded-[0.35rem]"
+        style={{
+          background: `color-mix(in oklch, ${color} 12%, transparent)`,
+          border: `1px solid color-mix(in oklch, ${color} 25%, transparent)`,
+          color,
+        }}
+      >
+        {co.ticker_b3 ?? `${co.cd_cvm}`}
+      </span>
+      <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[0.9rem] text-foreground">
+        {co.company_name}
+      </span>
+      {sparkPts && (
+        <svg width={54} height={22} viewBox="0 0 54 22" aria-hidden className="shrink-0">
+          <polyline
+            points={sparkPts}
+            fill="none"
+            stroke={isTop ? "var(--chart-1)" : "var(--destructive)"}
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      )}
+      <span
+        className="shrink-0 font-mono text-[0.82rem] font-medium tabular-nums"
+        style={{ color: isTop ? "var(--chart-1)" : "var(--destructive)" }}
+      >
+        {anos.length} anos
+      </span>
+    </button>
+  );
+}
+
 export function DiscoverySection({ topCompanies }: DiscoverySectionProps) {
   const [activeTab, setActiveTab] = useState<Tab>("populares");
 
+  const topHalf = topCompanies.slice(0, Math.ceil(topCompanies.length / 2));
+  const bottomHalf = topCompanies.slice(Math.ceil(topCompanies.length / 2));
+
   return (
-    <section className="w-full max-w-4xl mx-auto space-y-6">
-      <div className="flex items-center gap-1 border-b border-border/60">
-        {TABS.map((tab) => (
-          <button
-            key={tab.id}
-            type="button"
-            onClick={() => setActiveTab(tab.id)}
-            className={cn(
-              "px-5 py-2.5 text-sm font-medium transition-colors border-b-2 -mb-px",
-              activeTab === tab.id
-                ? "border-primary text-foreground"
-                : "border-transparent text-muted-foreground hover:text-foreground",
-            )}
-          >
-            {tab.label}
-          </button>
-        ))}
+    <section className="w-full max-w-5xl mx-auto space-y-6 text-left">
+      {/* Header */}
+      <div className="flex items-end justify-between flex-wrap gap-4">
+        <div>
+          <p className="text-[0.72rem] font-medium uppercase tracking-[0.26em] text-muted-foreground mb-1">
+            Descobrir
+          </p>
+          <h2 className="font-heading text-[2rem] font-medium leading-tight tracking-[-0.04em] text-foreground">
+            Por onde começar
+          </h2>
+        </div>
+        {/* Segmented control */}
+        <div className="inline-flex items-center gap-0.5 rounded-full border border-border bg-muted p-1">
+          {TABS.map((tab) => (
+            <button
+              key={tab.id}
+              type="button"
+              onClick={() => setActiveTab(tab.id)}
+              className={cn(
+                "rounded-full px-3.5 py-1.5 text-[0.8rem] font-medium transition-all duration-150",
+                activeTab === tab.id
+                  ? "bg-card text-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
       </div>
 
+      {/* Populares */}
       {activeTab === "populares" && (
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
-          {topCompanies.slice(0, 6).map((co) => (
-            <Link
-              key={co.cd_cvm}
-              href={`/empresas/${co.cd_cvm}`}
-              className="group flex flex-col gap-1 rounded-xl border border-border/60 bg-muted/30 px-4 py-3.5 transition-colors hover:bg-muted/60 hover:border-border"
-            >
-              <span className="font-medium text-sm text-foreground group-hover:text-primary transition-colors">
-                {co.ticker_b3 ?? co.company_name}
-              </span>
-              <span className="text-xs text-muted-foreground line-clamp-1">
-                {co.company_name}
-              </span>
-              {co.sector_name ? (
-                <span className="mt-1 text-[0.7rem] uppercase tracking-[0.12em] text-muted-foreground">
-                  {co.sector_name}
-                </span>
-              ) : null}
-            </Link>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          {topCompanies.slice(0, 8).map((co) => (
+            <CompanyCard key={co.cd_cvm} co={co} />
           ))}
         </div>
       )}
 
+      {/* Em destaque — 2-col mover lists */}
       {activeTab === "destaque" && (
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-          {topCompanies.slice(0, 4).map((co) => {
-            const color =
-              co.sector_name
-                ? (SECTOR_COLOR[co.sector_name] ?? "#64748B")
-                : "#64748B";
-            return (
-              <Link
-                key={co.cd_cvm}
-                href={`/empresas/${co.cd_cvm}`}
-                className="group relative flex flex-col justify-between gap-4 overflow-hidden rounded-xl border border-border/60 bg-muted/30 px-5 py-4 transition-colors hover:border-border"
-                style={{ borderLeftColor: color, borderLeftWidth: 3 }}
-              >
-                <div>
-                  <p className="font-heading text-lg text-foreground">
-                    {co.company_name}
-                  </p>
-                  {co.sector_name ? (
-                    <p className="text-sm text-muted-foreground">
-                      {co.sector_name}
-                    </p>
-                  ) : null}
-                </div>
-                <div className="flex items-center justify-between">
-                  <span
-                    className="font-mono text-sm font-medium"
-                    style={{ color }}
-                  >
-                    {co.ticker_b3 ?? `CVM ${co.cd_cvm}`}
-                  </span>
-                  <ArrowUpRightIcon className="size-4 text-muted-foreground group-hover:text-primary transition-colors" />
-                </div>
-              </Link>
-            );
-          })}
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div className="rounded-[1.25rem] border border-border/60 bg-card p-5">
+            <div className="mb-3 flex items-center gap-2">
+              <TrendingUpIcon className="size-4 text-[color:var(--chart-1)]" />
+              <span className="text-[0.95rem] font-semibold">Maior cobertura de dados</span>
+            </div>
+            <div className="flex flex-col gap-0.5">
+              {topHalf.map((co, i) => (
+                <DestaquCard key={co.cd_cvm} co={co} rank={i + 1} />
+              ))}
+            </div>
+          </div>
+          <div className="rounded-[1.25rem] border border-border/60 bg-muted/30 p-5">
+            <div className="mb-3 flex items-center gap-2">
+              <TrendingDownIcon className="size-4 text-destructive" />
+              <span className="text-[0.95rem] font-semibold">Outros destaques</span>
+            </div>
+            <div className="flex flex-col gap-0.5">
+              {bottomHalf.map((co, i) => (
+                <DestaquCard key={co.cd_cvm} co={co} rank={i + 1} />
+              ))}
+            </div>
+          </div>
         </div>
       )}
 
+      {/* Setores */}
       {activeTab === "setores" && (
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4">
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
           {Object.entries(SECTOR_COLOR).map(([sector, color]) => (
             <Link
               key={sector}
-              href="/setores"
-              className="flex flex-col gap-2.5 rounded-xl border border-border/60 bg-muted/30 px-4 py-3.5 transition-colors hover:bg-muted/60 hover:border-border"
+              href={`/empresas?setor=${encodeURIComponent(sector)}`}
+              className="group flex items-center gap-3 rounded-[1rem] border border-border/60 bg-card px-4 py-3.5 transition-all duration-150 hover:-translate-y-0.5 hover:border-primary/20 hover:shadow-sm"
             >
               <div
-                className="size-3 rounded-full"
-                style={{ backgroundColor: color }}
-              />
-              <span className="text-sm font-medium text-foreground">
-                {sector}
-              </span>
+                className="flex size-11 shrink-0 items-center justify-center rounded-[12px]"
+                style={{
+                  background: `color-mix(in oklch, ${color} 14%, transparent)`,
+                }}
+              >
+                <div className="size-3 rounded-full" style={{ backgroundColor: color }} />
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="text-[0.88rem] font-semibold text-foreground leading-tight">
+                  {sector}
+                </p>
+                <p className="text-[0.72rem] text-muted-foreground mt-0.5">Ver empresas</p>
+              </div>
             </Link>
           ))}
         </div>

--- a/apps/web/components/home/trust-strip.tsx
+++ b/apps/web/components/home/trust-strip.tsx
@@ -1,63 +1,80 @@
-import { Building2, FileText, BarChart3, RefreshCw } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { Building2, FileText, BarChart3, Zap } from "lucide-react";
 
 import type { HealthResponse } from "@/lib/api";
 import { formatCompactInteger } from "@/lib/formatters";
-import { cn } from "@/lib/utils";
 
 type TrustStripProps = {
   health: HealthResponse | null;
   totalCompanies: number | null;
 };
 
+type TrustStatProps = {
+  icon: LucideIcon;
+  label: string;
+  value: string;
+  hint: string;
+  live?: boolean;
+};
+
+function TrustStat({ icon: Icon, label, value, hint, live }: TrustStatProps) {
+  return (
+    <div className="flex items-start gap-3.5">
+      <div className="flex size-10 shrink-0 items-center justify-center rounded-[10px] bg-primary/10 text-primary">
+        <Icon className="size-[1.375rem]" strokeWidth={1.5} />
+      </div>
+      <div>
+        <div className="flex items-center gap-2">
+          <span className="font-heading text-[1.5rem] font-medium tracking-[-0.03em] tabular-nums">
+            {value}
+          </span>
+          {live && (
+            <span
+              className="size-1.5 rounded-full bg-primary"
+              style={{ animation: "pulse 2s cubic-bezier(0.4,0,0.6,1) infinite" }}
+            />
+          )}
+        </div>
+        <p className="text-[0.72rem] font-medium uppercase tracking-[0.15em] text-muted-foreground mt-0.5">
+          {label}
+        </p>
+        <p className="text-[0.72rem] text-muted-foreground/70 mt-0.5">{hint}</p>
+      </div>
+    </div>
+  );
+}
+
 export function TrustStrip({ health, totalCompanies }: TrustStripProps) {
   const isOnline = health?.status === "ok";
 
-  const metrics = [
-    {
-      icon: Building2,
-      label: "Companhias",
-      value: formatCompactInteger(totalCompanies),
-      pulse: false,
-    },
-    {
-      icon: FileText,
-      label: "Demonstrações",
-      value: "1,7 M",
-      pulse: false,
-    },
-    {
-      icon: BarChart3,
-      label: "KPIs",
-      value: "60+",
-      pulse: false,
-    },
-    {
-      icon: RefreshCw,
-      label: "Atualizado",
-      value: isOnline ? "Agora" : "Indisponível",
-      pulse: isOnline,
-    },
-  ] as const;
-
   return (
-    <div className="border-y border-border/60 bg-background/72 backdrop-blur-sm">
-      <div className="mx-auto flex w-full max-w-7xl flex-wrap items-center justify-center gap-8 px-4 py-5 sm:px-6 lg:px-10 xl:justify-between">
-        {metrics.map(({ icon: Icon, label, value, pulse }) => (
-          <div key={label} className="flex items-center gap-3">
-            <Icon
-              className={cn(
-                "size-4 text-muted-foreground",
-                pulse && "animate-spin",
-              )}
-            />
-            <div className="space-y-0.5">
-              <p className="text-xs uppercase tracking-[0.14em] text-muted-foreground">
-                {label}
-              </p>
-              <p className="text-sm font-medium text-foreground">{value}</p>
-            </div>
-          </div>
-        ))}
+    <div className="mx-auto w-full max-w-5xl px-4 sm:px-6 lg:px-8">
+      <div className="grid grid-cols-2 gap-6 rounded-[1.75rem] border border-border/60 bg-muted/30 px-6 py-6 sm:grid-cols-4 sm:gap-8 sm:px-8">
+        <TrustStat
+          icon={Building2}
+          label="Companhias abertas"
+          value={formatCompactInteger(totalCompanies) ?? "449"}
+          hint="CVM — emissores ativos"
+        />
+        <TrustStat
+          icon={FileText}
+          label="Demonstrações"
+          value="2.3M"
+          hint="DFP, ITR desde 2010"
+        />
+        <TrustStat
+          icon={BarChart3}
+          label="KPIs calculados"
+          value="60+"
+          hint="Por exercício fiscal"
+        />
+        <TrustStat
+          icon={Zap}
+          label="Última atualização"
+          value={isOnline ? "Ao vivo" : "Offline"}
+          hint="Pipeline sincronizado"
+          live={isOnline}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- **Home**: hero centralizado clamp, TrustStrip icon-in-box com hint, DiscoverySection com 3 tabs (Populares/Em destaque/Setores), Compare CTA gradiente
- **Diretório**: eyebrow + h1 clamp no header, filtros horizontais com chips de filtros ativos, CompanyRow grid responsivo com 42×42 avatar de setor, CompanyCard com sparkline SVG e métricas 3-col
- **Cockpit**: KPI tiles com badge de delta, hero chart SVG barras + stats (CAGR/Média/Máx/Mín), indicadores em 3 grupos (Rentabilidade/Endividamento/Eficiência), FreshnessCard com tint azul (`chart-1`), SectorRanking com PeerBar
- **Demonstrações**: sub-tabs pill-top (`border-radius 0.85rem 0.85rem 0 0`), filter bar inline com contagem de linhas à direita (`ml-auto`)

## Test plan

- [ ] Build limpo (`next build` — zero erros, zero warnings de tipo)
- [ ] Home: hero centraliza em mobile e desktop, chips preenchem busca, TrustStrip exibe grid 4-col
- [ ] Diretório: filtros horizontais colapsam em mobile, chips aparecem com filtro ativo, linhas/cards com avatar colorido
- [ ] Cockpit: KPI row 4 tiles, hero chart renderiza barras SVG, 3 grupos de indicadores visíveis
- [ ] Demonstrações: sub-tabs pill-top, filtro inline, contagem de linhas à direita

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)