### PR TITLE
docs: regularize governance paths and master lane

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -50,6 +50,7 @@ body:
         - frontend
         - backend
         - ops-quality
+        - master
     validations:
       required: true
   - type: dropdown
@@ -62,6 +63,7 @@ body:
         - frontend
         - backend
         - ops-quality
+        - master
     validations:
       required: true
   - type: input

--- a/.github/guardrails/path-policy.json
+++ b/.github/guardrails/path-policy.json
@@ -18,7 +18,8 @@
     "areaByLane": {
       "frontend": "web",
       "backend": "core",
-      "ops-quality": "infra"
+      "ops-quality": "infra",
+      "master": "core"
     },
     "backendAreaPatterns": [
       "apps/api/**",
@@ -40,9 +41,26 @@
       "main.py",
       "requirements.txt"
     ],
+    "master": [
+      "apps/web/**",
+      "apps/api/**",
+      "src/**",
+      "desktop/**",
+      "dashboard/**",
+      "tests/**",
+      "apps/api/tests/**",
+      "main.py",
+      "requirements.txt"
+    ],
     "ops-quality": [
       ".github/**",
+      ".claude/launch.json",
+      ".claude/settings.json",
+      ".claude/agent-context-preferences.json",
+      ".claude/skills/**",
+      ".claudeignore",
       "docs/**",
+      "skills/**",
       "scripts/**",
       "config/**",
       "AGENTS.md",
@@ -68,8 +86,16 @@
         "README.md",
         "COMO_RODAR.md",
         "docs/AGENTS.md",
+        "docs/GOVERNANCE_QUICK_REFERENCE.md",
+        "docs/governance/**",
+        ".claude/launch.json",
+        ".claude/settings.json",
+        ".claude/agent-context-preferences.json",
+        ".claude/skills/**",
+        ".claudeignore",
         "docs/STUDENT_PACK_PLAN.md",
         ".github/**",
+        "skills/**",
         ".gitignore"
       ],
       "ownerLane": "ops-quality",
@@ -117,7 +143,8 @@
       ],
       "ownerLane": "backend",
       "allowedLanes": [
-        "backend"
+        "backend",
+        "master"
       ],
       "minimumRisk": "shared",
       "requireDraft": true,
@@ -132,7 +159,8 @@
       ],
       "ownerLane": "backend",
       "allowedLanes": [
-        "backend"
+        "backend",
+        "master"
       ],
       "minimumRisk": "contract-sensitive",
       "requireDraft": true,
@@ -150,6 +178,9 @@
         "apps/api/**",
         "desktop/**",
         "dashboard/**"
+      ],
+      "exemptLanes": [
+        "master"
       ]
     }
   ],

--- a/.github/scripts/jules-pr-governance.cjs
+++ b/.github/scripts/jules-pr-governance.cjs
@@ -512,16 +512,6 @@ module.exports = async function runJulesPrGovernance({ github, context, core }) 
       }
     }
 
-    const blockingMix = (policy.disallowedDomainMixes || []).find((mix) => {
-      const leftTouched = files.some((file) => matchesAnyPattern(file, mix.left));
-      const rightTouched = files.some((file) => matchesAnyPattern(file, mix.right));
-      return leftTouched && rightTouched;
-    });
-
-    if (blockingMix) {
-      failureReason = `a PR mistura dominios proibidos pelo guardrail "${blockingMix.name}".`;
-    }
-
     let lane = policy.julesIntake.fallbackLane;
     if (!failureReason) {
       if (laneCandidates.length === 1) {
@@ -542,6 +532,19 @@ module.exports = async function runJulesPrGovernance({ github, context, core }) 
         } else {
           failureReason = `a inferencia de lane ficou ambigua entre: ${laneCandidates.join(', ')}.`;
         }
+      }
+    }
+
+    if (!failureReason) {
+      const blockingMix = (policy.disallowedDomainMixes || []).find((mix) => {
+        const leftTouched = files.some((file) => matchesAnyPattern(file, mix.left));
+        const rightTouched = files.some((file) => matchesAnyPattern(file, mix.right));
+        const exemptLanes = mix.exemptLanes || [];
+        return leftTouched && rightTouched && !exemptLanes.includes(lane);
+      });
+
+      if (blockingMix) {
+        failureReason = `a PR mistura dominios proibidos pelo guardrail "${blockingMix.name}".`;
       }
     }
 

--- a/.github/skills/first-message-governance-kickoff/SKILL.md
+++ b/.github/skills/first-message-governance-kickoff/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: first-message-governance-kickoff
 description: "Kick off a new chat with governance-ready context loading and lane triage before implementation. Use for first message, start chat, initialize context, or when user invokes /first-message-governance-kickoff lane:<lane>. Reads mandatory operational docs, checks lane tasks/child tasks/PR state, and reports if execution is ready or blocked."
-argument-hint: "Preferred: /first-message-governance-kickoff lane:frontend|backend|ops-quality. If no lane is provided, runs lane-agnostic kickoff."
+argument-hint: "Preferred: /first-message-governance-kickoff lane:frontend|backend|ops-quality|master. If no lane is provided, runs lane-agnostic kickoff."
 ---
 
 # First Message Governance Kickoff
@@ -20,12 +20,13 @@ Preferred invocation includes lane:
 - `/first-message-governance-kickoff lane:frontend`
 - `/first-message-governance-kickoff lane:backend`
 - `/first-message-governance-kickoff lane:ops-quality`
+- `/first-message-governance-kickoff lane:master`
 
 Lane-agnostic invocation is allowed:
 - `/first-message-governance-kickoff`
 
 Lane parsing rules:
-- accepted forms: `lane:frontend`, `lane:backend`, `lane:ops-quality`
+- accepted forms: `lane:frontend`, `lane:backend`, `lane:ops-quality`, `lane:master`
 - if no lane token is provided: run lane-agnostic mode
 - if invalid lane token is provided: report invalid token and continue in lane-agnostic mode
 - if multiple lanes are provided: stop and ask user to choose exactly one lane
@@ -71,7 +72,9 @@ If mode is `lane-aware`, check:
 2. child tasks received from other lanes,
 3. child tasks opened by this lane to other lanes,
 4. open PRs linked to those issues,
-5. pending `status:awaiting-consumption` deliveries.
+5. pending `status:awaiting-consumption` deliveries,
+6. merged PRs with linked issue still open - governance drift; report as `NEEDS_ISSUE_CLOSURE`,
+7. open PRs where guardrails passed and PR is not draft - auto-merge may be pending; report state.
 
 If mode is `lane-agnostic`, do a lightweight generic triage and mark lane checks as skipped.
 
@@ -81,13 +84,14 @@ Return one status:
 - `BLOCKED_AWAITING_CONSUMPTION`
 - `BLOCKED_MISSING_TASK_ISSUE`
 - `READY_WITH_TRIAGE_DEGRADED` (when remote issue/PR triage is unavailable)
+- `NEEDS_ISSUE_CLOSURE` (merged PR found with linked issue still open - close issue before new work)
 
 ## Output Format
 Return a concise startup briefing with:
 1. `Mode`: lane-aware or lane-agnostic
 2. `Lane`: explicit lane or `none`
 3. `Mandatory docs loaded`: list
-4. `Triage summary`: tasks, child tasks, PRs, awaiting-consumption
+4. `Triage summary`: tasks, child tasks, PRs, awaiting-consumption, merged-but-open issues, auto-merge pending
 5. `Blocking conditions`: explicit yes/no with reason
 6. `Next allowed action`: exact next step before coding
 
@@ -110,6 +114,7 @@ If lane is not provided and request is not lane-specific, do not force a lane qu
 - `/first-message-governance-kickoff lane:backend`
 - `/first-message-governance-kickoff lane:frontend`
 - `/first-message-governance-kickoff lane:ops-quality`
+- `/first-message-governance-kickoff lane:master`
 - `/first-message-governance-kickoff` (generic kickoff)
 
 ## Completion Gate

--- a/.github/workflows/pr-issue-guardrails.yml
+++ b/.github/workflows/pr-issue-guardrails.yml
@@ -645,8 +645,9 @@ jobs:
               const rightTouched = filenames.some((file) =>
                 matchesAnyPattern(file, mix.right),
               );
+              const exemptLanes = mix.exemptLanes || [];
 
-              if (leftTouched && rightTouched) {
+              if (leftTouched && rightTouched && !exemptLanes.includes(laneSection)) {
                 core.setFailed(
                   `A PR mistura dominios proibidos pelo guardrail "${mix.name}". Quebre o trabalho em tasks separadas por lane.`,
                 );

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ repositorio.
    - `Write-set esperado`
    - `Classificacao de risco`
 5. Trabalhe sempre em uma worktree dedicada:
-   - repo raiz permanece em `master`
+   - repo raiz permanece em `main`
    - a task usa branch `task/<issue-number>-<slug>`
    - a worktree vive em `.claude/worktrees/<lane>/<issue-number>-<slug>/`
 6. Abra PR com `Closes #<issue-number>` no corpo.
@@ -109,9 +109,35 @@ repositorio.
   - ownership principal: `.github/**`, `docs/**`, `README.md`,
     `COMO_RODAR.md`, `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`,
     scripts operacionais e smokes
+- `lane:master`
+  - orchestrador transversal com amplo acesso de escrita a paths de aplicacao
+    e backend; veja secao dedicada abaixo
 
 Uma task pertence a exatamente uma lane. Se o trabalho realmente precisar tocar
 duas lanes de produto, divida em child tasks separadas.
+
+## Lane master
+
+A lane `master` e o orquestrador transversal com acesso de escrita irrestrito
+a todos os paths de aplicacao e backend. Ela existe para:
+- corrigir bugs que cruzam multiplos dominios,
+- desbloquear trabalho que outras lanes hesitam em tocar,
+- executar correcoes de proximo passo em todo o codigo.
+
+A lane master tem dois modos:
+- **Modo execucao** (`lane:master`): execucao normal com amplo acesso de
+  escrita. Pode tocar `apps/web/**`, `apps/api/**`, `src/**`, `desktop/**`,
+  `dashboard/**`, `tests/**` e todos os outros paths de runtime/UI. A restricao
+  de domain mix (`frontend-with-backend-runtime`) e isenta para essa lane.
+- **Modo planejamento** (`lane:master.plan`): orquestracao somente leitura.
+  Sem edicoes de arquivos, sem escrita de codigo. Apenas pesquisa profunda do
+  projeto e propostas estruturadas de tasks.
+
+**Exclusao de governanca:** a lane master NAO possui e NAO pode escrever em
+paths de governanca criticos (`critical-bootstrap`). Esse dominio permanece
+exclusivamente com `ops-quality`. Isso significa que master nao pode modificar
+`.github/workflows/**`, `.github/guardrails/**`, scripts de bootstrap ou os
+proprios arquivos de governanca.
 
 ## Protocolo de trabalho paralelo
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,12 +25,12 @@ Before changing any versioned file:
 4. Ensure the issue body declares `Owner atual`, `Lane oficial`, `Workspace da task`, `Write-set esperado`, and `Classificacao de risco`.
 5. Update the issue when work starts and keep the checklist/evidence current.
 6. Create or reuse a dedicated worktree at `.claude/worktrees/<lane>/<issue-number>-<slug>/`.
-7. Keep the repo root stable on `master` and do not switch task branches in the main workspace.
+7. Keep the repo root stable on `main` and do not switch task branches in the main workspace.
 8. Work in a branch named `task/<issue-number>-<slug>`.
 9. Open a PR with `Closes #<issue-number>` in the body.
 10. Finish the task with `scripts/pr_complete.ps1 -Pr <number>` or an equivalent flow that waits for checks, confirms merge, verifies the linked issue is closed, and confirms the remote branch is gone when applicable.
 11. Update the issue and relevant docs before considering the task complete.
-12. Commit validated checkpoints, push them promptly, and merge to `master` when the task is complete and checks are green unless the user explicitly says not to.
+12. Commit validated checkpoints, push them promptly, and merge to `main` when the task is complete and checks are green unless the user explicitly says not to.
 
 ### Jules-only exception
 
@@ -49,7 +49,7 @@ Before changing any versioned file:
 - When acceptance criteria are satisfied and relevant checks pass:
   - update the issue;
   - mark the PR ready if needed;
-  - use `scripts/pr_complete.ps1` or an equivalent flow to wait through green checks and complete the merge into `master`.
+  - use `scripts/pr_complete.ps1` or an equivalent flow to wait through green checks and complete the merge into `main`.
 - Prefer squash merge for short-lived Codex branches.
 - After merge, confirm the linked task closes and the remote branch is removed when possible.
 - Remove the linked task worktree after merge when it is no longer needed.
@@ -62,10 +62,13 @@ Do not use `docs/AGENTS.md` as a backlog. The official backlog lives in GitHub I
   - `lane:frontend`
   - `lane:backend`
   - `lane:ops-quality`
+  - `lane:master`
 - Rule of thumb: `1 task = 1 owner = 1 branch = 1 worktree = 1 PR`
-- Use the repo root only as the stable `master` worktree.
+- Use the repo root only as the stable `main` worktree.
 - If you need to inspect another task, open a second editor window on that
   task's worktree instead of switching branches in the root workspace.
+- `lane:master` is the cross-cutting execution lane for application/runtime work.
+- `lane:master.plan` is read-only orchestration mode and does not write code.
 - Sensitive files are governed by `.github/guardrails/path-policy.json`.
 - Paths in `shared-governance`, `critical-bootstrap`, `critical-runtime`, and
   `critical-contract` require the lane and `risk:*` classification allowed by

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -70,6 +70,12 @@
 
 ## Sessoes Recentes
 
+### Sessao 48 - 2026-04-18 (regularizacao de governanca para lane master e skills locais)
+- `lane:master` documentada como lane transversal de execucao; `lane:master.plan` mantida como modo somente leitura
+- `.github/guardrails/path-policy.json` passa a classificar `skills/**` e arquivos versionados em `.claude/` como governanca compartilhada de `ops-quality`
+- Guardrails (`pr-issue-guardrails` e `jules-pr-governance`) passam a respeitar `exemptLanes` nos domain mixes
+- `docs/GOVERNANCE_QUICK_REFERENCE.md` e a skill versionada em `.github/skills/` foram atualizados para reduzir custo de contexto na abertura de sessao
+
 ### Sessao 39 - 2026-04-12 (Jules-only intake automatica por GitHub Actions)
 - `jules-pr-governance.yml` passa a criar ou reconciliar automaticamente a task retroativa do Jules via `pull_request_target`
 - Identificacao do Jules depende dos marcadores no corpo da PR + label persistente `source:jules`

--- a/docs/GOVERNANCE_QUICK_REFERENCE.md
+++ b/docs/GOVERNANCE_QUICK_REFERENCE.md
@@ -1,0 +1,114 @@
+# Governance Quick Reference
+
+> **For agents.** Operational checklist and lane rules. See `CLAUDE.md` for full context, `AGENTS.md` for workflow contract, `docs/AGENTS.md` for session state.
+
+---
+
+## Issue-First Workflow (8 Steps)
+
+Before changing any versioned file:
+
+1. **Locate or create a `task issue`** in GitHub
+2. **Label the issue** with `kind:task`, one `status:*`, one `priority:*`, one `area:*`, one `risk:*`, one `lane:*`
+3. **Declare in issue body:** `Owner atual`, `Lane oficial`, `Workspace da task`, `Write-set esperado`, `Classificacao de risco`
+4. **Create a worktree** at `.claude/worktrees/<lane>/<issue-number>-<slug>/`
+5. **Work in branch** `task/<issue-number>-<slug>` and keep the repo root stable on `main`
+6. **Open a PR** with `Closes #<issue-number>` in the body
+7. **Complete via script:** `scripts/pr_complete.ps1 -Pr <number>` (waits for checks, merges, verifies closure)
+8. **Update issue and docs** before marking task complete
+
+---
+
+## Lane Assignments
+
+**Official lanes:**
+- `lane:frontend` - JavaScript/TypeScript, Next.js app, UI components
+- `lane:backend` - Python, database, scraper, KPI engine, API
+- `lane:ops-quality` - testing, validation, documentation, governance
+- `lane:master` - cross-cutting execution across frontend/backend runtime paths
+
+**Planning mode:**
+- `lane:master.plan` - read-only orchestration mode, no file edits
+
+**Rule:** 1 task = 1 owner = 1 lane = 1 branch = 1 worktree = 1 PR
+
+---
+
+## Worktree Rules
+
+- **Repo root** stays on `main` and stable
+- **Each task** gets a dedicated worktree: `.claude/worktrees/<lane>/<issue-number>-<slug>/`
+- **Branching** from task worktree: `git checkout -b task/<issue-number>-<slug>`
+- **Switching tasks** -> open second editor window on the other task's worktree (do NOT switch branches in the root)
+
+---
+
+## Risk Classifications
+
+| Class | Definition | PR Setup | Write-set |
+|-------|-----------|----------|-----------|
+| `risk:safe` | Isolated, no shared files | Open as ready | Single task-specific files |
+| `risk:shared` | Touches shared files | Open as DRAFT | Shared docs, configs, scripts, governance |
+| `risk:contract-sensitive` | Public API/schema/docs | Open as DRAFT + document compatibility | Public interfaces only |
+
+---
+
+## Child Task Template
+
+When your lane needs work from another lane:
+
+- **Task mae:** Link to parent task
+- **Lane solicitante:** Your lane (`frontend`, `backend`, `ops-quality`, `master`)
+- **Criterio de consumo:** How you'll verify the delivery is ready
+- **Write-set esperado:** Files the other lane will change
+
+Parent task remains `status:blocked` until child merges.  
+After merge, parent moves to `status:awaiting-consumption`.  
+Only requester lane marks delivery as consumed.
+
+---
+
+## Critical Paths
+
+Paths in `.github/guardrails/path-policy.json` require:
+- Correct `lane:*` label
+- Matching `risk:*` classification
+- Explicit approval in the task body
+
+Categories:
+- `shared-governance`
+- `critical-bootstrap`
+- `critical-runtime`
+- `critical-contract`
+
+`lane:master` may cross frontend/backend runtime boundaries only where the path policy explicitly allows it. It does **not** own governance or bootstrap paths.
+
+---
+
+## PR Completion Flow
+
+```bash
+scripts/pr_complete.ps1 -Pr <number>
+# Waits for checks -> merges -> verifies issue closure -> removes branch
+```
+
+---
+
+## Common Mistakes
+
+X **Switching branches in repo root** - use a dedicated worktree  
+X **Opening PR without issue** - issue first, always  
+X **Missing labels on issue** - keep the 6 required labels  
+X **Skipping `Write-set esperado`** - declare what files will change  
+X **Leaving work only local** - push the branch before session end  
+X **Assuming `lane:master` can edit governance** - it cannot touch `critical-bootstrap` or shared governance paths
+
+---
+
+## References
+
+- Full workflow: `CLAUDE.md`
+- Governance contract: `AGENTS.md`
+- Session state: `docs/AGENTS.md`
+- Business rules: `docs/CONTEXT.md`
+- Parallel lanes: `docs/governance/parallel-lanes.md`

--- a/docs/governance/parallel-lanes.md
+++ b/docs/governance/parallel-lanes.md
@@ -2,15 +2,16 @@
 
 ## Resumo
 
-O repositorio opera com tres frentes oficiais:
+O repositorio opera com quatro frentes oficiais:
 
 - `lane:frontend`
 - `lane:backend`
 - `lane:ops-quality`
+- `lane:master`
 
 Regra central: `1 task = 1 owner = 1 branch = 1 worktree = 1 PR`.
 
-O repo raiz permanece em `master`. Toda task executavel roda em uma worktree
+O repo raiz permanece em `main`. Toda task executavel roda em uma worktree
 dedicada em `.claude/worktrees/<lane>/<issue-number>-<slug>/`.
 
 ## Check inicial por chat
@@ -47,6 +48,16 @@ antes de abrir nova frente dependente de outra lane.
   operacionais
 - pode tocar `critical-bootstrap`
 - pode tocar `shared-governance`
+
+### `lane:master`
+
+- ownership principal: `apps/web/**`, `apps/api/**`, `src/**`, `desktop/**`,
+  `dashboard/**`, `tests/**`, `apps/api/tests/**`, `main.py`,
+  `requirements.txt`
+- pode tocar `critical-runtime`
+- pode tocar `critical-contract`
+- e isenta do domain mix `frontend-with-backend-runtime`
+- nao pode tocar `critical-bootstrap` nem `shared-governance`
 
 Se uma entrega realmente exigir frontend e backend ao mesmo tempo, quebre em
 child tasks. Nao use uma task gigante multi-lane.
@@ -167,6 +178,8 @@ Regras duras:
 - `critical-runtime` e `critical-bootstrap` exigem pelo menos `risk:shared`.
 - `shared-governance` pode acompanhar qualquer lane, mas nao libera misturar
   `apps/web/**` com `src/**` ou `apps/api/**` na mesma PR.
+- `frontend-with-backend-runtime` continua proibido para outras lanes; a unica
+  excecao formal e `lane:master`, quando o write-set convergir para essa lane.
 - Se um arquivo nao estiver coberto pela policy ou pela allowlist da lane, ele
   deve ser classificado antes de a PR ser aprovada.
 
@@ -181,7 +194,7 @@ Scripts oficiais:
 
 Boas praticas:
 
-- mantenha o repo raiz estavel em `master`
+- mantenha o repo raiz estavel em `main`
 - abra uma segunda janela do editor para a worktree da task
 - nao reuse a mesma worktree para duas tasks diferentes
 - nao remova worktree com branch nao mergeada sem `-Force`


### PR DESCRIPTION
## Summary

- document `lane:master` and `lane:master.plan` across the governance contract and quick-reference docs
- classify repo-local `.claude/**` and `skills/**` paths in the policy owned by `ops-quality`
- teach both PR guardrails to respect `exemptLanes` for the `frontend-with-backend-runtime` mix
- update the kickoff/task templates that depend on the governance model

## Validation

- `ConvertFrom-Json .github/guardrails/path-policy.json`
- `node --check .github/scripts/jules-pr-governance.cjs`
- `git diff --check`
- `docs/AGENTS.md` kept at 150 lines

## Notes

- This PR intentionally lands the governance/policy unblocker first.
- Follow-up repo-local helper files live in task #93 after this policy reaches `main`.

Closes #91