### PR TITLE
chore: add local governance helper assets

### DIFF
--- a/.claude/agent-context-preferences.json
+++ b/.claude/agent-context-preferences.json
@@ -1,0 +1,47 @@
+{
+  "metadata": {
+    "version": "1.0",
+    "created": "2026-04-15",
+    "purpose": "Hints for agent context initialization to reduce token consumption"
+  },
+  "governance_mode": "compact",
+  "preferred_refs": {
+    "quick_checklist": "docs/GOVERNANCE_QUICK_REFERENCE.md",
+    "operational_rules": "CLAUDE.md",
+    "session_state": "docs/AGENTS.md",
+    "business_rules": "docs/CONTEXT.md",
+    "architecture_details": "CLAUDE.md (section: Architecture)"
+  },
+  "exclude_from_context": [
+    ".workflow/.scratchpad/",
+    "archive/",
+    "docs/references/sites_ex/",
+    "build/",
+    "dist/",
+    ".pytest_cache/",
+    "node_modules/",
+    "data/db/"
+  ],
+  "lane_workspaces": {
+    "frontend": ".claude/worktrees/frontend/",
+    "backend": ".claude/worktrees/backend/",
+    "ops-quality": ".claude/worktrees/ops-quality/",
+    "master": ".claude/worktrees/master/"
+  },
+  "context_optimization": {
+    "initial_load": "Load GOVERNANCE_QUICK_REFERENCE.md before full CLAUDE.md",
+    "lane_filtering": "If lane:* label is set, can optionally load only lane-specific guidance",
+    "session_history": "For task state, consult docs/AGENTS.md (not AGENTS.md root contract)",
+    "architecture_deep_dive": "Only load full architecture section if working on infra/refactoring tasks"
+  },
+  "agent_lessons": {
+    "governance_priority": "Always follow recorded repository instructions and governance before improvising process.",
+    "project_session_start": [
+      {
+        "date": "2026-04-16",
+        "scope": "this repository",
+        "rule": "When the user invokes project-session-start with a known lane, the first assistant response must already provide the kickoff output. Do not replace that first response with clarifying questions unless a required input is genuinely unknown."
+      }
+    ]
+  }
+}

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -8,6 +8,12 @@
       "port": 3000
     },
     {
+      "name": "Next.js Web (79-foundation-tokens)",
+      "runtimeExecutable": "cmd",
+      "runtimeArgs": ["/c", ".claude\\worktrees\\frontend\\79-foundation-tokens\\apps\\web\\start-web-wt.cmd"],
+      "port": 3001
+    },
+    {
       "name": "Dashboard Streamlit",
       "runtimeExecutable": ".venv\\Scripts\\streamlit.exe",
       "runtimeArgs": ["run", "dashboard/app.py", "--server.headless", "true"],

--- a/.claude/skills/master-plan/SKILL.md
+++ b/.claude/skills/master-plan/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: master-plan
+description: "Read-only project orchestration mode. Deep-researches the entire project context and proposes prioritized, sequenced tasks for execution lanes. No file edits, no code writing. Invoked via /master-plan."
+argument-hint: "No arguments. Activates read-only planning mode automatically."
+---
+
+# Master Plan - Read-Only Orchestration Mode
+
+## Purpose
+This skill activates the master lane in planning mode. The agent becomes a project planning and task-orchestration agent. It does NOT implement, edit files, write production code, refactor, or make changes. It ONLY deeply researches the current project context and proposes the next best tasks for the execution lanes.
+
+## Hard Constraints
+- Do NOT write code
+- Do NOT edit any files
+- Do NOT create artifacts unless explicitly asked
+- Do NOT propose implementation details deeper than needed for task definition
+- Do NOT jump straight to solutions without first understanding the project
+- Do NOT give shallow generic agile-style filler
+- Do NOT suggest "next steps" until you have first synthesized the repository and context
+- Stay in research + planning mode only
+
+## Core Behavior
+- First, spend significant effort understanding the project before proposing anything.
+- Do not rush into generic recommendations.
+- Read the repository and available context carefully.
+- Infer the current state of the project: what already exists, what is missing, what is broken, what is unclear, and what would create the most leverage next.
+- Think carefully about dependencies, architecture, UX implications, technical debt, risk, effort, and sequencing.
+- Prefer fewer high-quality tasks over many vague ones.
+- Only suggest tasks that are concrete, useful, and executable by a lane.
+
+## Research Process
+Before suggesting tasks, investigate as much of the following as possible:
+1. Project objective and product purpose
+2. Current architecture and stack
+3. Existing modules, pages, flows, APIs, and data models
+4. Roadmap clues from docs, TODOs, issues, comments, and naming
+5. Recent unfinished work, inconsistencies, or broken flows
+6. UX gaps, technical blockers, missing infrastructure, or unclear ownership
+7. Dependencies between parts of the system
+8. What is likely to unblock or accelerate the team the most next
+
+## Planning Principles
+- Prioritize by impact, dependency, and execution readiness
+- Separate foundational work from polish
+- Avoid recommending tasks that depend on undefined decisions unless you explicitly flag that
+- Surface assumptions and unknowns
+- If context is incomplete, do not stop at "not enough info"; instead, make the best grounded task suggestions possible and clearly label assumptions
+- Suggest tasks in a sequence that a multi-lane team can realistically execute
+- If multiple lanes can work in parallel, identify that clearly
+- Avoid duplicate or overlapping tasks
+- Avoid vague tasks like "improve UI" or "fix backend"
+- Every task must have a clear outcome and acceptance criteria
+
+## Lane Names
+Use the project's established lanes:
+- `frontend` - Next.js web app (`apps/web/**`)
+- `backend` - FastAPI, scraper, desktop app, dashboard (`apps/api/**`, `src/**`, `desktop/**`, `dashboard/**`)
+- `ops-quality` - Governance, docs, scripts, CI/CD
+- `master` - Cross-cutting execution (bug fixes, unblocking work across lanes)
+
+## Task Design Rules
+For each task, define:
+- Lane
+- Task title
+- Why this task matters now
+- Objective
+- Scope
+- Inputs / files / areas to inspect
+- Dependencies
+- Acceptance criteria
+- Risks or open questions
+- Priority (P0, P1, P2)
+- Estimated complexity (S, M, L)
+- Parallelizable or not
+
+## Output Format
+Return your answer in this exact structure:
+
+```
+# Project Understanding
+A concise but thoughtful summary of:
+- what the project appears to be
+- current stage
+- major gaps
+- likely priorities
+
+# Assumptions and Unknowns
+List the main assumptions you had to make and what remains uncertain.
+
+# Recommended Next Tasks for Lanes
+
+## Wave 1
+Tasks that should happen first because they unblock everything else.
+
+## Wave 2
+Tasks that depend on Wave 1 or become clearer after it.
+
+## Wave 3
+Tasks for polish, optimization, robustness, or scale.
+
+For each task, use this template:
+
+### [Lane Name] - [Task Title]
+- Priority:
+- Complexity:
+- Parallelizable:
+- Why now:
+- Objective:
+- Scope:
+- Inspect / Context:
+- Dependencies:
+- Acceptance criteria:
+- Risks / Open questions:
+
+# Sequencing Logic
+Explain why this order is best and which tasks can run in parallel.
+
+# Top 3 Most Important Tasks
+End with the three highest-leverage tasks in order, with one sentence each justifying why.
+```
+
+## Completion Gate
+This skill is complete when it has:
+- deeply researched the project (read key files, checked issues, understood architecture),
+- produced a structured task proposal following the output format above,
+- not edited any versioned files.

--- a/skills/first-message-governance-kickoff/SKILL.md
+++ b/skills/first-message-governance-kickoff/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: first-message-governance-kickoff
+description: "Kick off a new chat with governance-ready context loading and lane triage before implementation. Use for first message, start chat, initialize context, or when user invokes /first-message-governance-kickoff lane:<lane>. Reads mandatory operational docs, checks lane tasks/child tasks/PR state, and reports if execution is ready or blocked."
+argument-hint: "Preferred: /first-message-governance-kickoff lane:frontend|backend|ops-quality|master. If no lane is provided, runs lane-agnostic kickoff."
+---
+
+# First Message Governance Kickoff
+
+## Purpose
+Use this skill at the start of a new chat to make the agent load the right operational context before coding.
+
+This skill is startup-only and governance-first:
+- it prepares context,
+- it checks execution preconditions,
+- it reports readiness,
+- then hands off to implementation.
+
+## Invocation Contract
+Preferred invocation includes lane:
+- `/first-message-governance-kickoff lane:frontend`
+- `/first-message-governance-kickoff lane:backend`
+- `/first-message-governance-kickoff lane:ops-quality`
+- `/first-message-governance-kickoff lane:master`
+
+Lane-agnostic invocation is allowed:
+- `/first-message-governance-kickoff`
+
+Lane parsing rules:
+- accepted forms: `lane:frontend`, `lane:backend`, `lane:ops-quality`, `lane:master`
+- if no lane token is provided: run lane-agnostic mode
+- if invalid lane token is provided: report invalid token and continue in lane-agnostic mode
+- if multiple lanes are provided: stop and ask user to choose exactly one lane
+
+## Mandatory Sources To Read First
+Always read these before any implementation action:
+- `AGENTS.md`
+- `CLAUDE.md`
+- `docs/governance/parallel-lanes.md`
+- `docs/AGENTS.md`
+- `README.md`
+
+Also read path policy when governance enforcement is relevant:
+- `.github/guardrails/path-policy.json`
+
+## Area-Specific Required Reading
+If the request already targets one of these areas, load required docs before edits:
+- area `apps/web/**`: `docs/INTERFACE_MAP.md`
+- area `apps/api/**`: `docs/INTERFACE_MAP.md` and `docs/V2_API_CONTRACT.md`
+- area `src/**`: `docs/CONTEXT.md`
+- area `docs/SITEMAP.MD`: `docs/INTERFACE_MAP.md`
+
+## Startup Workflow
+
+### Phase 1: Normalize Startup Mode
+1. Parse lane token from the invocation.
+2. Set mode:
+   - `lane-aware` when lane is provided,
+   - `lane-agnostic` when lane is missing.
+
+### Phase 2: Load Operational Context
+1. Read mandatory governance files.
+2. Extract key rules:
+   - issue-first requirement,
+   - one task/owner/branch/worktree/PR,
+   - child-task protocol,
+   - critical-path and risk requirements,
+   - completion criteria (checks green + merge confirmed).
+
+### Phase 3: Triage Work State
+If mode is `lane-aware`, check:
+1. open task issues in the lane,
+2. child tasks received from other lanes,
+3. child tasks opened by this lane to other lanes,
+4. open PRs linked to those issues,
+5. pending `status:awaiting-consumption` deliveries,
+6. merged PRs with linked issue still open - governance drift; report as `NEEDS_ISSUE_CLOSURE`,
+7. open PRs where guardrails passed and PR is not draft - auto-merge may be pending; report state.
+
+If mode is `lane-agnostic`, do a lightweight generic triage and mark lane checks as skipped.
+
+### Phase 4: Readiness Decision
+Return one status:
+- `READY_TO_EXECUTE`
+- `BLOCKED_AWAITING_CONSUMPTION`
+- `BLOCKED_MISSING_TASK_ISSUE`
+- `READY_WITH_TRIAGE_DEGRADED` (when remote issue/PR triage is unavailable)
+- `NEEDS_ISSUE_CLOSURE` (merged PR found with linked issue still open - close issue before new work)
+
+## Output Format
+Return a concise startup briefing with:
+1. `Mode`: lane-aware or lane-agnostic
+2. `Lane`: explicit lane or `none`
+3. `Mandatory docs loaded`: list
+4. `Triage summary`: tasks, child tasks, PRs, awaiting-consumption, merged-but-open issues, auto-merge pending
+5. `Blocking conditions`: explicit yes/no with reason
+6. `Next allowed action`: exact next step before coding
+
+## Hard Rules Enforced By This Skill
+- never start changing versioned files before issue-first checks
+- if lane-aware and awaiting-consumption exists, consume it before expanding scope
+- do not ignore child-task dependencies
+- do not proceed with lane-specific execution on ambiguous lane ownership
+- do not treat docs/AGENTS.md as live backlog; use GitHub Issues as source of truth
+
+## Question Policy
+Keep startup questions minimal.
+Ask only when necessary:
+- lane ambiguous and request is clearly lane-owned
+- triage unavailable and user must decide fallback confidence
+
+If lane is not provided and request is not lane-specific, do not force a lane question.
+
+## Examples
+- `/first-message-governance-kickoff lane:backend`
+- `/first-message-governance-kickoff lane:frontend`
+- `/first-message-governance-kickoff lane:ops-quality`
+- `/first-message-governance-kickoff lane:master`
+- `/first-message-governance-kickoff` (generic kickoff)
+
+## Completion Gate
+This skill is complete only when it has:
+- loaded mandatory sources,
+- completed lane-aware or lane-agnostic triage,
+- reported readiness/blocking status,
+- provided a concrete next step for execution.


### PR DESCRIPTION
## Summary

- add repo-local context preferences for governance-first session startup
- add the local read-only `master-plan` skill under `.claude/skills/`
- add the repo version of `first-message-governance-kickoff`
- register the extra local web launcher entry in `.claude/launch.json`

## Validation

- `ConvertFrom-Json .claude/agent-context-preferences.json`
- `git diff --check`

Closes #93