### PR TITLE
perf: add B-tree indexes to financial_reports and companies

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -78,6 +78,25 @@ def init_db_tables(engine: Engine) -> None:
                 updated_at      TEXT NOT NULL
             )
         """))
+
+    _index_ddl = [
+        'CREATE INDEX {c}IF NOT EXISTS idx_fr_cd_cvm ON financial_reports("CD_CVM")',
+        'CREATE INDEX {c}IF NOT EXISTS idx_fr_cd_cvm_stmt_year ON financial_reports("CD_CVM", "STATEMENT_TYPE", "REPORT_YEAR")',
+        'CREATE INDEX {c}IF NOT EXISTS idx_fr_cd_conta ON financial_reports("CD_CONTA")',
+        "CREATE INDEX {c}IF NOT EXISTS idx_companies_setor ON companies(setor_analitico)",
+        "CREATE INDEX {c}IF NOT EXISTS idx_companies_ticker ON companies(ticker_b3)",
+    ]
+    if dialect == "postgresql":
+        # CONCURRENTLY cannot run inside a transaction — requires AUTOCOMMIT
+        with engine.connect() as idx_conn:
+            idx_conn = idx_conn.execution_options(isolation_level="AUTOCOMMIT")
+            for ddl in _index_ddl:
+                idx_conn.execute(text(ddl.format(c="CONCURRENTLY ")))
+    else:
+        with engine.begin() as idx_conn:
+            for ddl in _index_ddl:
+                idx_conn.execute(text(ddl.format(c="")))
+
     logger.info("init_db_tables completed dialect=%s", dialect)
 SQLITE_WRITE_BACKOFF_SECONDS = 0.6
 DEFAULT_TO_SQL_CHUNKSIZE = 2000

--- a/tests/test_database_portability.py
+++ b/tests/test_database_portability.py
@@ -27,6 +27,9 @@ class _RecorderConn:
             raise RuntimeError("forced execute failure")
         return None
 
+    def execution_options(self, **kwargs):
+        return self
+
 
 class _Ctx:
     def __init__(self, conn):
@@ -83,16 +86,26 @@ def test_init_db_applies_pragmas_for_sqlite_only():
     ddl_sql = "\n".join(sql for sql, _ in db._engine.begin_conn.calls)
     assert "CREATE TABLE IF NOT EXISTS financial_reports" in ddl_sql
     assert "CREATE TABLE IF NOT EXISTS qa_logs" in ddl_sql
+    # SQLite indexes use regular begin() — no CONCURRENTLY
+    assert "idx_fr_cd_cvm" in ddl_sql
+    assert "CONCURRENTLY" not in ddl_sql
 
 
 def test_init_db_skips_pragmas_for_postgresql():
     db = _new_db_with_engine(_FakeEngine("postgresql"))
     db._init_db()
 
-    assert db._engine.connect_calls == 0
+    # connect() is called once for CONCURRENTLY index creation (outside transaction)
+    assert db._engine.connect_calls == 1
     ddl_sql = "\n".join(sql for sql, _ in db._engine.begin_conn.calls)
     assert "PRAGMA" not in ddl_sql
     assert "CREATE TABLE IF NOT EXISTS financial_reports" in ddl_sql
+
+    idx_sql = "\n".join(sql for sql, _ in db._engine.connect_conn.calls)
+    assert "CONCURRENTLY" in idx_sql
+    assert "idx_fr_cd_cvm" in idx_sql
+    assert "idx_fr_cd_cvm_stmt_year" in idx_sql
+    assert "idx_companies_setor" in idx_sql
 
 
 def test_upsert_company_metadata_uses_dialect_safe_sql():


### PR DESCRIPTION
## Summary

- Adds 5 B-tree indexes to `financial_reports` and `companies` via `init_db_tables()`, eliminating full-table scans on every query in `query_layer.py`
- PostgreSQL path uses `CREATE INDEX CONCURRENTLY` on an AUTOCOMMIT connection (outside any transaction) to avoid exclusive table locks on existing data
- SQLite path uses a regular `engine.begin()` block (no CONCURRENTLY support)
- All DDL uses `IF NOT EXISTS` — fully idempotent, safe to redeploy

**Indexes added:**
| Index | Table | Columns |
|---|---|---|
| `idx_fr_cd_cvm` | `financial_reports` | `CD_CVM` |
| `idx_fr_cd_cvm_stmt_year` | `financial_reports` | `CD_CVM`, `STATEMENT_TYPE`, `REPORT_YEAR` |
| `idx_fr_cd_conta` | `financial_reports` | `CD_CONTA` |
| `idx_companies_setor` | `companies` | `setor_analitico` |
| `idx_companies_ticker` | `companies` | `ticker_b3` |

## Test plan

- [x] `tests/test_database_portability.py` updated to assert CONCURRENTLY indexes land on the PostgreSQL path and plain indexes on SQLite
- [x] 122/122 tests passing
- [ ] Post-deploy: run `EXPLAIN ANALYZE` on `get_companies_directory_page()` and `get_statement()` to confirm index scans (see Issue #109)

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)