### PR TITLE
perf(api): configure uvicorn multi-workers with uvloop in production Dockerfile

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -24,7 +24,10 @@ COPY desktop/ desktop/
 COPY apps/__init__.py apps/__init__.py
 COPY apps/api/ apps/api/
 
-# Variavel de ambiente padrao (substituida pela Railway via PORT)
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+# PORT substituido pela Railway; WEB_CONCURRENCY=2 para planos single-vCPU
 ENV PORT=8000
+ENV WEB_CONCURRENCY=4
 
-CMD ["sh", "-c", "uvicorn apps.api.app.main:app --host 0.0.0.0 --port ${PORT}"]
+CMD ["sh", "-c", "uvicorn apps.api.app.main:app --host 0.0.0.0 --port ${PORT} --workers ${WEB_CONCURRENCY} --loop uvloop --access-log"]


### PR DESCRIPTION
## Summary
- Replaces single-worker uvicorn with `--workers ${WEB_CONCURRENCY}` (default 4) + `--loop uvloop` + `--access-log`
- Adds `PYTHONUNBUFFERED=1` and `PYTHONDONTWRITEBYTECODE=1` env vars for container hygiene
- `uvloop` already bundled via `uvicorn[standard]` — no requirements change needed
- `WEB_CONCURRENCY=2` is the safe override for single-vCPU Railway plans

## Connection pool note
4 workers × pool_size=5 = 20 total PostgreSQL connections. Railway/Supabase free tier allows 50 — safe margin.

## Acceptance criteria
- [ ] Container shows configured number of uvicorn worker processes (`ps aux`)
- [ ] Dependency installation completes without errors on first build
- [ ] No connection pool exhaustion errors under concurrent load

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)