### PR TITLE
perf(api): add cache headers to cacheable read endpoints

### DIFF
--- a/apps/api/app/routes/companies.py
+++ b/apps/api/app/routes/companies.py
@@ -35,6 +35,19 @@ from src.read_service import CVMReadService
 
 router = APIRouter(tags=["companies"])
 
+COMPANY_DIRECTORY_CACHE_CONTROL = "public, max-age=300, stale-while-revalidate=3600"
+COMPANY_INFO_CACHE_CONTROL = "public, max-age=3600"
+COMPANY_YEARS_CACHE_CONTROL = "public, max-age=86400, stale-while-revalidate=604800"
+COMPANY_DATA_CACHE_CONTROL = "public, max-age=600"
+
+
+def _apply_cache_headers(response: Response, cache_control: str) -> None:
+    response.headers["Cache-Control"] = cache_control
+    vary_values = [value.strip() for value in response.headers.get("Vary", "").split(",") if value.strip()]
+    if not any(value.lower() == "origin" for value in vary_values):
+        vary_values.append("Origin")
+    response.headers["Vary"] = ", ".join(vary_values)
+
 
 @router.get(
     "/companies",
@@ -42,6 +55,7 @@ router = APIRouter(tags=["companies"])
     summary="Retorna o diretorio paginado de empresas com dados.",
 )
 def list_companies(
+    response: Response,
     request: Request,
     search: str = Query(default="", description="Filtro livre por nome, ticker ou codigo CVM."),
     sector: str | None = Query(default=None, description="Slug canonico do setor."),
@@ -50,6 +64,7 @@ def list_companies(
     service: CVMReadService = Depends(get_read_service),
 ) -> CompanyDirectoryPagePayload:
     ensure_api_ready(get_settings(request))
+    _apply_cache_headers(response, COMPANY_DIRECTORY_CACHE_CONTROL)
     page_dto = service.list_companies(
         search=search,
         sector_slug=sector,
@@ -148,6 +163,7 @@ def request_top_ranked_refresh(
 )
 def get_company(
     cd_cvm: int,
+    response: Response,
     request: Request,
     service: CVMReadService = Depends(get_read_service),
 ) -> CompanyInfoPayload:
@@ -155,6 +171,7 @@ def get_company(
     info = service.get_company_info(cd_cvm)
     if info is None:
         raise NotFoundError(f"Empresa {cd_cvm} nao encontrada.")
+    _apply_cache_headers(response, COMPANY_INFO_CACHE_CONTROL)
     return present_company_info(info)
 
 
@@ -190,11 +207,13 @@ def export_company_excel(
 )
 def get_company_years(
     cd_cvm: int,
+    response: Response,
     request: Request,
     service: CVMReadService = Depends(get_read_service),
 ) -> list[int]:
     ensure_api_ready(get_settings(request))
     coerce_company(cd_cvm, service)
+    _apply_cache_headers(response, COMPANY_YEARS_CACHE_CONTROL)
     return service.get_available_years(cd_cvm)
 
 
@@ -205,6 +224,7 @@ def get_company_years(
 )
 def get_company_statement(
     cd_cvm: int,
+    response: Response,
     request: Request,
     stmt: str = Depends(statement_dependency),
     years: list[int] = Depends(years_dependency),
@@ -212,6 +232,7 @@ def get_company_statement(
 ) -> StatementMatrixPayload:
     ensure_api_ready(get_settings(request))
     coerce_company(cd_cvm, service)
+    _apply_cache_headers(response, COMPANY_DATA_CACHE_CONTROL)
     matrix = service.get_statement_matrix(cd_cvm=cd_cvm, years=years, stmt_type=stmt)
     return present_statement(matrix)
 
@@ -223,12 +244,14 @@ def get_company_statement(
 )
 def get_company_kpis(
     cd_cvm: int,
+    response: Response,
     request: Request,
     years: list[int] = Depends(years_dependency),
     service: CVMReadService = Depends(get_read_service),
 ) -> KPIBundlePayload:
     ensure_api_ready(get_settings(request))
     coerce_company(cd_cvm, service)
+    _apply_cache_headers(response, COMPANY_DATA_CACHE_CONTROL)
     bundle = service.get_kpi_bundle(cd_cvm=cd_cvm, years=years)
     return present_kpis(bundle)
 

--- a/apps/api/app/routes/sectors.py
+++ b/apps/api/app/routes/sectors.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, Request
+from fastapi.responses import Response
 
 from apps.api.app.dependencies import (
     InvalidRequestError,
@@ -20,6 +21,16 @@ from src.read_service import CVMReadService
 
 router = APIRouter(tags=["sectors"])
 
+SECTOR_DIRECTORY_CACHE_CONTROL = "public, max-age=3600, stale-while-revalidate=86400"
+
+
+def _apply_cache_headers(response: Response, cache_control: str) -> None:
+    response.headers["Cache-Control"] = cache_control
+    vary_values = [value.strip() for value in response.headers.get("Vary", "").split(",") if value.strip()]
+    if not any(value.lower() == "origin" for value in vary_values):
+        vary_values.append("Origin")
+    response.headers["Vary"] = ", ".join(vary_values)
+
 
 @router.get(
     "/sectors",
@@ -27,10 +38,12 @@ router = APIRouter(tags=["sectors"])
     summary="Retorna o hub setorial com snapshot agregado por setor.",
 )
 def list_sectors(
+    response: Response,
     request: Request,
     service: CVMReadService = Depends(get_read_service),
 ) -> SectorDirectoryPayload:
     ensure_api_ready(get_settings(request))
+    _apply_cache_headers(response, SECTOR_DIRECTORY_CACHE_CONTROL)
     return present_sector_directory(service.list_sectors())
 
 

--- a/apps/api/tests/test_api_contract.py
+++ b/apps/api/tests/test_api_contract.py
@@ -43,6 +43,39 @@ def test_companies_empty_search_returns_paginated_directory(client: TestClient):
     assert sem_dados["anos_disponiveis"] == []
 
 
+@pytest.mark.parametrize(
+    ("path", "params", "expected_cache_control"),
+    [
+        ("/companies", None, "public, max-age=300, stale-while-revalidate=3600"),
+        ("/companies/9512", None, "public, max-age=3600"),
+        ("/companies/9512/years", None, "public, max-age=86400, stale-while-revalidate=604800"),
+        (
+            "/companies/9512/statements",
+            {"stmt": "DRE", "years": "2023,2024"},
+            "public, max-age=600",
+        ),
+        (
+            "/companies/9512/kpis",
+            {"years": "2023,2024"},
+            "public, max-age=600",
+        ),
+        ("/sectors", None, "public, max-age=3600, stale-while-revalidate=86400"),
+    ],
+)
+def test_cacheable_endpoints_expose_cache_headers(
+    client: TestClient,
+    path: str,
+    params: dict[str, str] | None,
+    expected_cache_control: str,
+):
+    response = client.get(path, params=params)
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == expected_cache_control
+    vary_values = {value.strip() for value in response.headers["vary"].split(",")}
+    assert "Origin" in vary_values
+
+
 def test_companies_search_filters_results(client: TestClient):
     response = client.get("/companies", params={"search": "vale", "page_size": 20})
 
@@ -747,6 +780,13 @@ def test_company_summary_blocks_have_non_empty_titles(client: TestClient):
     assert response.status_code == 200
     for block in response.json()["blocks"]:
         assert isinstance(block["title"], str) and len(block["title"]) > 0
+
+
+def test_non_targeted_endpoints_do_not_expose_api_cache_headers(client: TestClient):
+    response = client.get("/companies/9512/summary", params={"years": "2023,2024"})
+
+    assert response.status_code == 200
+    assert "cache-control" not in response.headers
 
 
 # ── Regressao: /years exclui anos com apenas dados trimestrais ITR ─────────────

--- a/docs/V2_API_CONTRACT.md
+++ b/docs/V2_API_CONTRACT.md
@@ -79,6 +79,9 @@ Regras do endpoint:
 - ordena por `company_name ASC`
 - `sector` usa slug canonico estavel, nao label livre
 - `anos_disponiveis` e montado de forma portavel na camada de leitura
+- headers de cache:
+  - `Cache-Control: public, max-age=300, stale-while-revalidate=3600`
+  - `Vary: Origin`
 - `anos_disponiveis` representa apenas anos anuais exportaveis:
   exige `PERIOD_LABEL = REPORT_YEAR`, portanto anos com apenas `1Q/2Q/3Q` nao
   entram no payload
@@ -136,6 +139,9 @@ Resposta exemplo:
 Regras do endpoint:
 - `snapshot` usa os KPIs agregados do `latest_year` do setor
 - `roe`, `mg_ebit` e `mg_liq` podem ser `null` quando o setor nao tiver contas suficientes
+- headers de cache:
+  - `Cache-Control: public, max-age=3600, stale-while-revalidate=86400`
+  - `Vary: Origin`
 - o item do setor continua valido mesmo quando o snapshot vier parcial ou nulo
 
 ### `GET /sectors/{slug}?year=`
@@ -203,6 +209,11 @@ Resposta exemplo:
 }
 ```
 
+Regras do endpoint:
+- headers de cache:
+  - `Cache-Control: public, max-age=3600`
+  - `Vary: Origin`
+
 ### `GET /companies/{cd_cvm}/export/excel`
 
 Uso:
@@ -254,6 +265,9 @@ Resposta:
 Regras do endpoint:
 - retorna apenas anos anuais exportaveis
 - usa `PERIOD_LABEL = REPORT_YEAR` como criterio de disponibilidade
+- headers de cache:
+  - `Cache-Control: public, max-age=86400, stale-while-revalidate=604800`
+  - `Vary: Origin`
 - anos com apenas ITR trimestral nao aparecem no seletor de anos
 - para anos fechados, a presenca trimestral isolada nao deve ser interpretada
   como cobertura anual
@@ -294,6 +308,9 @@ Resposta exemplo:
 Regras do endpoint:
 - aceita anos anuais no filtro `years`, mas a matriz pode expor colunas
   trimestrais quando elas existirem para os anos solicitados
+- headers de cache:
+  - `Cache-Control: public, max-age=600`
+  - `Vary: Origin`
 - `4Q` so pode aparecer quando houver base suficiente para derivacao do periodo:
   em especial, `DRE` e `DFC` dependem do anual `YYYY` combinado com `3Q`
 
@@ -332,6 +349,9 @@ Resposta exemplo:
 Regras do endpoint:
 - `annual` usa somente `PERIOD_LABEL = REPORT_YEAR`
 - `quarterly` pode usar periodos trimestrais dos anos solicitados
+- headers de cache:
+  - `Cache-Control: public, max-age=600`
+  - `Vary: Origin`
 - `4Q` depende da disponibilidade do anual `YYYY`; trimestre isolado sem anual
   nao converte o ano em disponivel no seletor
 - o bundle trimestral deduplica `4Q` contra o fechamento anual `YYYY`; quando o


### PR DESCRIPTION
## Summary
- add `Cache-Control` headers to the cacheable company and sector read endpoints covered by #103
- ensure cached responses also expose `Vary: Origin`
- document the HTTP cache contract and add API tests for the targeted endpoints
- consume the already-merged frontend child delivery from PR #120

## Testing
- `pytest apps/api/tests/test_api_contract.py`

## Compatibilidade
- additive-only: the change adds response headers for existing GET endpoints without altering response bodies, status codes, or request parameters

Closes #103
