### PR TITLE
perf(web): refactor empresas route for ISR

### DIFF
--- a/apps/web/app/api/companies-directory/route.ts
+++ b/apps/web/app/api/companies-directory/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { readCompaniesDirectoryQuery } from "@/lib/companies-directory-query";
+import { loadCompaniesPageData } from "@/lib/companies-page-data";
+
+export async function GET(request: NextRequest) {
+  const query = readCompaniesDirectoryQuery(request.nextUrl.searchParams);
+  const payload = await loadCompaniesPageData({
+    search: query.search,
+    sector: query.sector,
+    page: query.page,
+    pageSize: query.pageSize,
+  });
+
+  return NextResponse.json(payload, {
+    headers: {
+      "cache-control": "no-store",
+    },
+  });
+}

--- a/apps/web/app/empresas/page.tsx
+++ b/apps/web/app/empresas/page.tsx
@@ -1,16 +1,10 @@
-import Link from "next/link";
+import { Suspense } from "react";
 import type { Metadata } from "next";
 
-import { CompanyDirectoryFilters } from "@/components/companies/company-directory-filters";
-import { CompanyDirectoryList } from "@/components/companies/company-directory-list";
-import { DirectoryPagination } from "@/components/companies/directory-pagination";
-import { PageShell, SurfaceCard, SectionHeading } from "@/components/shared/design-system-recipes";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { buttonVariants } from "@/components/ui/button";
-import { formatCompactInteger } from "@/lib/formatters";
-import { loadCompaniesPageData } from "@/lib/companies-page-data";
-import { coercePositiveInt, getFirstParam, mergeSearchParams } from "@/lib/search-params";
-import { cn } from "@/lib/utils";
+import {
+  CompaniesDirectoryClient,
+  CompaniesDirectoryLoadingState,
+} from "@/components/companies/companies-directory-client";
 
 export const metadata: Metadata = {
   title: "Empresas",
@@ -18,179 +12,12 @@ export const metadata: Metadata = {
     "Diretorio publico e paginado de empresas com dados financeiros ja processados na base CVM Analytics.",
 };
 
-export const dynamic = "force-dynamic";
+export const revalidate = 3600;
 
-const PAGE_SIZE = 20;
-
-type EmpresasPageProps = {
-  searchParams: Promise<Record<string, string | string[] | undefined>>;
-};
-
-export default async function EmpresasPage({ searchParams }: EmpresasPageProps) {
-  const resolvedSearchParams = await searchParams;
-  const currentSearch = getFirstParam(resolvedSearchParams.busca) ?? "";
-  const currentSector = getFirstParam(resolvedSearchParams.setor) ?? null;
-  const currentPage = coercePositiveInt(getFirstParam(resolvedSearchParams.pagina), 1);
-  const rawView = getFirstParam(resolvedSearchParams.view);
-  const viewMode: "rows" | "cards" = rawView === "cards" ? "cards" : "rows";
-
-  const retryParams = new URLSearchParams();
-  if (currentSearch) retryParams.set("busca", currentSearch);
-  if (currentSector) retryParams.set("setor", currentSector);
-  if (currentPage > 1) retryParams.set("pagina", String(currentPage));
-  const retryQuery = retryParams.toString();
-  const retryHref = retryQuery ? `/empresas?${retryQuery}` : "/empresas";
-
-  const { directory, filters, directoryError, filtersError } = await loadCompaniesPageData({
-    search: currentSearch,
-    sector: currentSector,
-    page: currentPage,
-    pageSize: PAGE_SIZE,
-  });
-
-  if (!directory) {
-    return (
-      <PageShell density="relaxed" className="max-w-4xl">
-        <SurfaceCard tone="hero" padding="hero" className="space-y-6">
-          <SectionHeading
-            eyebrow="Empresas"
-            title="Diretório temporariamente indisponível"
-            titleAs="h1"
-            description="A listagem de empresas não respondeu agora. O fluxo de busca e navegação pode ser retomado assim que a API voltar a responder."
-          />
-          <Alert className="rounded-[1.75rem] border border-destructive/25 bg-destructive/6 px-5 py-5 text-left">
-            <AlertTitle>Falha controlada da listagem</AlertTitle>
-            <AlertDescription>
-              {directoryError ??
-                "Não foi possível carregar o diretório de empresas agora. Tente novamente em instantes."}
-            </AlertDescription>
-          </Alert>
-          <div className="flex flex-wrap gap-3">
-            <Link
-              href={retryHref}
-              className={cn(buttonVariants({ size: "lg" }), "rounded-full px-5")}
-            >
-              Tentar novamente
-            </Link>
-            <Link
-              href="/"
-              className={cn(buttonVariants({ variant: "outline", size: "lg" }), "rounded-full px-5")}
-            >
-              Voltar para a home
-            </Link>
-          </div>
-        </SurfaceCard>
-      </PageShell>
-    );
-  }
-
-  const currentParamsStr = mergeSearchParams("", {
-    busca: currentSearch || null,
-    setor: currentSector,
-    pagina: currentPage > 1 ? currentPage : null,
-  });
-  const viewRowsHref = mergeSearchParams(currentParamsStr, { view: null })
-    ? `/empresas?${mergeSearchParams(currentParamsStr, { view: null })}`
-    : "/empresas";
-  const viewCardsHref = `/empresas?${mergeSearchParams(currentParamsStr, { view: "cards" }) || "view=cards"}`;
-  const clearHref = viewMode === "cards" ? "/empresas?view=cards" : "/empresas";
-
-  const toggleBase =
-    "flex size-8 items-center justify-center rounded-lg border transition-colors text-sm";
-
+export default function EmpresasPage() {
   return (
-    <PageShell density="default" className="space-y-8">
-      {/* Page header */}
-      <div className="flex flex-wrap items-end justify-between gap-4">
-        <div>
-          <p className="text-[0.72rem] font-medium uppercase tracking-[0.26em] text-muted-foreground mb-1">
-            Diretório · CVM
-          </p>
-          <h1 className="font-heading text-[clamp(1.75rem,4vw,2.5rem)] font-medium leading-tight tracking-[-0.04em] text-foreground">
-            Todas as companhias abertas
-          </h1>
-          <p className="mt-1.5 text-[0.9rem] text-muted-foreground">
-            {formatCompactInteger(directory.pagination.total_items)} empresas
-            {currentSearch ? ` · "${currentSearch}"` : ""}
-            {currentSector ? ` · ${currentSector}` : ""}
-          </p>
-        </div>
-
-        {/* View toggle */}
-        <div className="flex items-center gap-1.5">
-          <Link
-            href={viewRowsHref}
-            title="Ver em linhas"
-            className={cn(
-              toggleBase,
-              viewMode === "rows"
-                ? "border-border bg-muted text-foreground"
-                : "border-border/40 text-muted-foreground hover:border-border hover:text-foreground",
-            )}
-          >
-            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden>
-              <rect x="1" y="2" width="12" height="2" rx="0.5" fill="currentColor" />
-              <rect x="1" y="6" width="12" height="2" rx="0.5" fill="currentColor" />
-              <rect x="1" y="10" width="12" height="2" rx="0.5" fill="currentColor" />
-            </svg>
-          </Link>
-          <Link
-            href={viewCardsHref}
-            title="Ver em cards"
-            className={cn(
-              toggleBase,
-              viewMode === "cards"
-                ? "border-border bg-muted text-foreground"
-                : "border-border/40 text-muted-foreground hover:border-border hover:text-foreground",
-            )}
-          >
-            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden>
-              <rect x="1" y="1" width="5" height="5" rx="1" fill="currentColor" />
-              <rect x="8" y="1" width="5" height="5" rx="1" fill="currentColor" />
-              <rect x="1" y="8" width="5" height="5" rx="1" fill="currentColor" />
-              <rect x="8" y="8" width="5" height="5" rx="1" fill="currentColor" />
-            </svg>
-          </Link>
-        </div>
-      </div>
-
-      {filtersError ? (
-        <Alert className="rounded-[1.75rem] border border-border/70 bg-background/85 px-5 py-4">
-          <AlertTitle>Filtro setorial indisponível</AlertTitle>
-          <AlertDescription>
-            {filtersError} A busca livre e a paginação continuam disponíveis.
-          </AlertDescription>
-        </Alert>
-      ) : null}
-
-      {/* Horizontal filter bar */}
-      <CompanyDirectoryFilters
-        currentSearch={currentSearch}
-        currentSector={currentSector}
-        sectors={filters?.sectors ?? []}
-        sectorFilterUnavailable={Boolean(filtersError)}
-      />
-
-      {/* Results */}
-      <div className="space-y-6">
-        <CompanyDirectoryList
-          items={directory.items}
-          viewMode={viewMode}
-          hasActiveFilters={Boolean(currentSearch || currentSector)}
-          clearHref={clearHref}
-        />
-
-        <DirectoryPagination
-          currentPage={directory.pagination.page}
-          totalPages={directory.pagination.total_pages}
-          totalItems={directory.pagination.total_items}
-          pageSize={PAGE_SIZE}
-          hasNext={directory.pagination.has_next}
-          hasPrevious={directory.pagination.has_previous}
-          currentSearch={currentSearch}
-          currentSector={Boolean(filtersError) ? null : currentSector}
-        />
-      </div>
-    </PageShell>
+    <Suspense fallback={<CompaniesDirectoryLoadingState />}>
+      <CompaniesDirectoryClient />
+    </Suspense>
   );
 }

--- a/apps/web/app/setores/page.tsx
+++ b/apps/web/app/setores/page.tsx
@@ -21,7 +21,7 @@ export const metadata: Metadata = {
     "Hub setorial da V2 web com leitura agregada por setor, contagem de empresas e snapshots anuais.",
 };
 
-export const dynamic = "force-dynamic";
+export const revalidate = 3600;
 
 export default async function SetoresPage() {
   const { directory, directoryError } = await loadSectorsPageData();

--- a/apps/web/components/companies/companies-directory-client.tsx
+++ b/apps/web/components/companies/companies-directory-client.tsx
@@ -1,0 +1,309 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+
+import { CompanyDirectoryFilters } from "@/components/companies/company-directory-filters";
+import { CompanyDirectoryList } from "@/components/companies/company-directory-list";
+import { DirectoryPagination } from "@/components/companies/directory-pagination";
+import {
+  PageShell,
+  SectionHeading,
+  SurfaceCard,
+} from "@/components/shared/design-system-recipes";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { buttonVariants } from "@/components/ui/button";
+import {
+  buildCompaniesDirectoryApiHref,
+  COMPANIES_DIRECTORY_PAGE_SIZE,
+  readCompaniesDirectoryQuery,
+} from "@/lib/companies-directory-query";
+import { formatCompactInteger } from "@/lib/formatters";
+import type { CompaniesPageData } from "@/lib/companies-page-data";
+import { mergeSearchParams } from "@/lib/search-params";
+import { cn } from "@/lib/utils";
+
+type RequestState = {
+  data: CompaniesPageData | null;
+  requestError: string | null;
+  loading: boolean;
+};
+
+const DIRECTORY_LOAD_ERROR =
+  "Nao foi possivel carregar o diretorio de empresas agora. Tente novamente em instantes.";
+
+const INITIAL_STATE: RequestState = {
+  data: null,
+  requestError: null,
+  loading: true,
+};
+
+async function fetchCompaniesDirectoryData(
+  href: string,
+  signal: AbortSignal,
+): Promise<CompaniesPageData> {
+  const response = await fetch(href, {
+    cache: "no-store",
+    headers: {
+      Accept: "application/json",
+    },
+    signal,
+  });
+
+  if (!response.ok) {
+    throw new Error(DIRECTORY_LOAD_ERROR);
+  }
+
+  return (await response.json()) as CompaniesPageData;
+}
+
+export function CompaniesDirectoryClient() {
+  const searchParams = useSearchParams();
+  const {
+    search: currentSearch,
+    sector: currentSector,
+    page: currentPage,
+    pageSize,
+    viewMode,
+  } = readCompaniesDirectoryQuery(searchParams, COMPANIES_DIRECTORY_PAGE_SIZE);
+  const requestHref = buildCompaniesDirectoryApiHref({
+    search: currentSearch,
+    sector: currentSector,
+    page: currentPage,
+    pageSize,
+  });
+  const [state, setState] = useState<RequestState>(INITIAL_STATE);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    setState({
+      data: null,
+      requestError: null,
+      loading: true,
+    });
+
+    void fetchCompaniesDirectoryData(requestHref, controller.signal)
+      .then((data) => {
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        setState({
+          data,
+          requestError: null,
+          loading: false,
+        });
+      })
+      .catch((error) => {
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        setState({
+          data: null,
+          requestError:
+            error instanceof Error && error.message ? error.message : DIRECTORY_LOAD_ERROR,
+          loading: false,
+        });
+      });
+
+    return () => controller.abort();
+  }, [requestHref]);
+
+  if (state.loading && !state.data) {
+    return <CompaniesDirectoryLoadingState />;
+  }
+
+  const retryParams = new URLSearchParams();
+  if (currentSearch) {
+    retryParams.set("busca", currentSearch);
+  }
+  if (currentSector) {
+    retryParams.set("setor", currentSector);
+  }
+  if (currentPage > 1) {
+    retryParams.set("pagina", String(currentPage));
+  }
+  if (viewMode === "cards") {
+    retryParams.set("view", "cards");
+  }
+  const retryQuery = retryParams.toString();
+  const retryHref = retryQuery ? `/empresas?${retryQuery}` : "/empresas";
+
+  if (!state.data?.directory) {
+    return (
+      <PageShell density="relaxed" className="max-w-4xl">
+        <SurfaceCard tone="hero" padding="hero" className="space-y-6">
+          <SectionHeading
+            eyebrow="Empresas"
+            title="Diretorio temporariamente indisponivel"
+            titleAs="h1"
+            description="A listagem de empresas nao respondeu agora. O fluxo de busca e navegacao pode ser retomado assim que a API voltar a responder."
+          />
+          <Alert className="rounded-[1.75rem] border border-destructive/25 bg-destructive/6 px-5 py-5 text-left">
+            <AlertTitle>Falha controlada da listagem</AlertTitle>
+            <AlertDescription>
+              {state.requestError ??
+                state.data?.directoryError ??
+                "Nao foi possivel carregar o diretorio de empresas agora. Tente novamente em instantes."}
+            </AlertDescription>
+          </Alert>
+          <div className="flex flex-wrap gap-3">
+            <Link
+              href={retryHref}
+              className={cn(buttonVariants({ size: "lg" }), "rounded-full px-5")}
+            >
+              Tentar novamente
+            </Link>
+            <Link
+              href="/"
+              className={cn(
+                buttonVariants({ variant: "outline", size: "lg" }),
+                "rounded-full px-5",
+              )}
+            >
+              Voltar para a home
+            </Link>
+          </div>
+        </SurfaceCard>
+      </PageShell>
+    );
+  }
+
+  const { directory, directoryError, filters, filtersError } = state.data;
+  const currentParamsStr = mergeSearchParams("", {
+    busca: currentSearch || null,
+    setor: currentSector,
+    pagina: currentPage > 1 ? currentPage : null,
+  });
+  const viewRowsQuery = mergeSearchParams(currentParamsStr, { view: null });
+  const viewRowsHref = viewRowsQuery ? `/empresas?${viewRowsQuery}` : "/empresas";
+  const viewCardsQuery = mergeSearchParams(currentParamsStr, { view: "cards" });
+  const viewCardsHref = viewCardsQuery ? `/empresas?${viewCardsQuery}` : "/empresas?view=cards";
+  const clearHref = viewMode === "cards" ? "/empresas?view=cards" : "/empresas";
+  const toggleBase =
+    "flex size-8 items-center justify-center rounded-lg border transition-colors text-sm";
+
+  return (
+    <PageShell density="default" className="space-y-8">
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <p className="mb-1 text-[0.72rem] font-medium uppercase tracking-[0.26em] text-muted-foreground">
+            Diretorio · CVM
+          </p>
+          <h1 className="font-heading text-[clamp(1.75rem,4vw,2.5rem)] font-medium leading-tight tracking-[-0.04em] text-foreground">
+            Todas as companhias abertas
+          </h1>
+          <p className="mt-1.5 text-[0.9rem] text-muted-foreground">
+            {formatCompactInteger(directory.pagination.total_items)} empresas
+            {currentSearch ? ` · "${currentSearch}"` : ""}
+            {currentSector ? ` · ${currentSector}` : ""}
+          </p>
+        </div>
+
+        <div className="flex items-center gap-1.5">
+          <Link
+            href={viewRowsHref}
+            title="Ver em linhas"
+            className={cn(
+              toggleBase,
+              viewMode === "rows"
+                ? "border-border bg-muted text-foreground"
+                : "border-border/40 text-muted-foreground hover:border-border hover:text-foreground",
+            )}
+          >
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden>
+              <rect x="1" y="2" width="12" height="2" rx="0.5" fill="currentColor" />
+              <rect x="1" y="6" width="12" height="2" rx="0.5" fill="currentColor" />
+              <rect x="1" y="10" width="12" height="2" rx="0.5" fill="currentColor" />
+            </svg>
+          </Link>
+          <Link
+            href={viewCardsHref}
+            title="Ver em cards"
+            className={cn(
+              toggleBase,
+              viewMode === "cards"
+                ? "border-border bg-muted text-foreground"
+                : "border-border/40 text-muted-foreground hover:border-border hover:text-foreground",
+            )}
+          >
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden>
+              <rect x="1" y="1" width="5" height="5" rx="1" fill="currentColor" />
+              <rect x="8" y="1" width="5" height="5" rx="1" fill="currentColor" />
+              <rect x="1" y="8" width="5" height="5" rx="1" fill="currentColor" />
+              <rect x="8" y="8" width="5" height="5" rx="1" fill="currentColor" />
+            </svg>
+          </Link>
+        </div>
+      </div>
+
+      {directoryError ? (
+        <Alert className="rounded-[1.75rem] border border-border/70 bg-background/85 px-5 py-4">
+          <AlertTitle>Atualizacao parcial da listagem</AlertTitle>
+          <AlertDescription>{directoryError}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      {filtersError ? (
+        <Alert className="rounded-[1.75rem] border border-border/70 bg-background/85 px-5 py-4">
+          <AlertTitle>Filtro setorial indisponivel</AlertTitle>
+          <AlertDescription>
+            {filtersError} A busca livre e a paginacao continuam disponiveis.
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      <CompanyDirectoryFilters
+        key={`${currentSearch}|${currentSector ?? "all"}|${filtersError ? "filters-down" : "filters-up"}`}
+        currentSearch={currentSearch}
+        currentSector={currentSector}
+        sectors={filters?.sectors ?? []}
+        sectorFilterUnavailable={Boolean(filtersError)}
+      />
+
+      <div className="space-y-6">
+        <CompanyDirectoryList
+          items={directory.items}
+          viewMode={viewMode}
+          hasActiveFilters={Boolean(currentSearch || currentSector)}
+          clearHref={clearHref}
+        />
+
+        <DirectoryPagination
+          currentPage={directory.pagination.page}
+          totalPages={directory.pagination.total_pages}
+          totalItems={directory.pagination.total_items}
+          pageSize={pageSize}
+          hasNext={directory.pagination.has_next}
+          hasPrevious={directory.pagination.has_previous}
+          currentSearch={currentSearch}
+          currentSector={Boolean(filtersError) ? null : currentSector}
+        />
+      </div>
+    </PageShell>
+  );
+}
+
+export function CompaniesDirectoryLoadingState() {
+  return (
+    <PageShell density="default" className="space-y-8">
+      <div className="space-y-2">
+        <div className="h-3 w-28 rounded-full bg-muted/70" />
+        <div className="h-10 w-72 max-w-full rounded-full bg-muted/70" />
+        <div className="h-4 w-80 max-w-full rounded-full bg-muted/55" />
+      </div>
+
+      <SurfaceCard tone="subtle" padding="lg" className="space-y-4">
+        <div className="h-10 rounded-[1rem] bg-muted/55" />
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+          <div className="h-28 rounded-[1.5rem] bg-muted/45" />
+          <div className="h-28 rounded-[1.5rem] bg-muted/45" />
+          <div className="h-28 rounded-[1.5rem] bg-muted/45" />
+        </div>
+      </SurfaceCard>
+    </PageShell>
+  );
+}

--- a/apps/web/lib/companies-directory-query.ts
+++ b/apps/web/lib/companies-directory-query.ts
@@ -1,0 +1,55 @@
+import { coercePositiveInt } from "./search-params.ts";
+
+export const COMPANIES_DIRECTORY_PAGE_SIZE = 20;
+
+export type CompaniesDirectoryViewMode = "rows" | "cards";
+
+type SearchParamsReader = {
+  get(name: string): string | null;
+};
+
+export type CompaniesDirectoryQueryState = {
+  search: string;
+  sector: string | null;
+  page: number;
+  pageSize: number;
+  viewMode: CompaniesDirectoryViewMode;
+};
+
+export function readCompaniesDirectoryQuery(
+  searchParams: SearchParamsReader,
+  pageSize = COMPANIES_DIRECTORY_PAGE_SIZE,
+): CompaniesDirectoryQueryState {
+  const search = searchParams.get("busca")?.trim() ?? "";
+  const rawSector = searchParams.get("setor")?.trim() ?? "";
+
+  return {
+    search,
+    sector: rawSector ? rawSector : null,
+    page: coercePositiveInt(searchParams.get("pagina") ?? undefined, 1),
+    pageSize,
+    viewMode: searchParams.get("view") === "cards" ? "cards" : "rows",
+  };
+}
+
+export function buildCompaniesDirectoryApiHref(
+  state: Pick<CompaniesDirectoryQueryState, "search" | "sector" | "page" | "pageSize">,
+): string {
+  const query = new URLSearchParams();
+
+  if (state.search) {
+    query.set("busca", state.search);
+  }
+
+  if (state.sector) {
+    query.set("setor", state.sector);
+  }
+
+  if (state.page > 1) {
+    query.set("pagina", String(state.page));
+  }
+
+  query.set("pageSize", String(state.pageSize));
+
+  return `/api/companies-directory?${query.toString()}`;
+}

--- a/apps/web/tests/companies-page-data.test.ts
+++ b/apps/web/tests/companies-page-data.test.ts
@@ -2,6 +2,10 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { ApiClientError } from "../lib/api.ts";
+import {
+  buildCompaniesDirectoryApiHref,
+  readCompaniesDirectoryQuery,
+} from "../lib/companies-directory-query.ts";
 import { loadCompaniesPageData } from "../lib/companies-page-data.ts";
 
 test("loadCompaniesPageData keeps filters when the directory request fails", async () => {
@@ -68,4 +72,29 @@ test("loadCompaniesPageData keeps the directory when filters fail", async () => 
   assert.equal(result.directoryError, null);
   assert.equal(result.filters, null);
   assert.match(result.filtersError ?? "", /A API da V2 nao conseguiu concluir esta solicitacao agora/i);
+});
+
+test("readCompaniesDirectoryQuery normalizes search params for the client loader", () => {
+  const query = new URLSearchParams("busca=%20PETR4%20&setor=energia&pagina=0&view=cards");
+
+  const result = readCompaniesDirectoryQuery(query);
+
+  assert.deepEqual(result, {
+    search: "PETR4",
+    sector: "energia",
+    page: 1,
+    pageSize: 20,
+    viewMode: "cards",
+  });
+});
+
+test("buildCompaniesDirectoryApiHref keeps only the params used by the directory route", () => {
+  const href = buildCompaniesDirectoryApiHref({
+    search: "PETR4",
+    sector: "energia",
+    page: 3,
+    pageSize: 20,
+  });
+
+  assert.equal(href, "/api/companies-directory?busca=PETR4&setor=energia&pagina=3&pageSize=20");
 });


### PR DESCRIPTION
## Summary
- refactor `/empresas` into a static ISR shell and move query-param-driven directory loading behind a frontend-owned route handler + client boundary
- keep search, sector filters, pagination, and view mode wired to the URL through the new client loader
- switch `/setores` from `force-dynamic` to `revalidate = 3600` and add coverage for the new companies query helper

## Testing
- `npm run test:unit`
- `npm run build`
- `npm run typecheck`

## Notes
- `next build` now reports `/empresas` and `/setores` as static routes with `Revalidate 1h`
- Live verification of filtered results against the backend was not possible in this session because `http://127.0.0.1:8000/health` was unavailable locally

Closes #104