### PR TITLE
chore(web): clear lint blockers for backend task #108

### DIFF
--- a/apps/web/app/design-system/page.tsx
+++ b/apps/web/app/design-system/page.tsx
@@ -277,9 +277,10 @@ function Section({
 export default function DesignSystemPage() {
   return (
     <>
+      {/* eslint-disable-next-line @next/next/no-page-custom-font */}
       <link
         rel="stylesheet"
-        href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,200,0,0"
+        href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,200,0,0&display=optional"
       />
 
       <div className="flex min-h-screen">

--- a/apps/web/components/companies/companies-directory-client.tsx
+++ b/apps/web/components/companies/companies-directory-client.tsx
@@ -30,6 +30,13 @@ type RequestState = {
   loading: boolean;
 };
 
+type CompaniesDirectoryClientContentProps = Pick<
+  ReturnType<typeof readCompaniesDirectoryQuery>,
+  "page" | "pageSize" | "search" | "sector" | "viewMode"
+> & {
+  requestHref: string;
+};
+
 const DIRECTORY_LOAD_ERROR =
   "Nao foi possivel carregar o diretorio de empresas agora. Tente novamente em instantes.";
 
@@ -60,29 +67,42 @@ async function fetchCompaniesDirectoryData(
 
 export function CompaniesDirectoryClient() {
   const searchParams = useSearchParams();
-  const {
-    search: currentSearch,
-    sector: currentSector,
-    page: currentPage,
-    pageSize,
-    viewMode,
-  } = readCompaniesDirectoryQuery(searchParams, COMPANIES_DIRECTORY_PAGE_SIZE);
+  const directoryQuery = readCompaniesDirectoryQuery(
+    searchParams,
+    COMPANIES_DIRECTORY_PAGE_SIZE,
+  );
   const requestHref = buildCompaniesDirectoryApiHref({
-    search: currentSearch,
-    sector: currentSector,
-    page: currentPage,
-    pageSize,
+    search: directoryQuery.search,
+    sector: directoryQuery.sector,
+    page: directoryQuery.page,
+    pageSize: directoryQuery.pageSize,
   });
+
+  return (
+    <CompaniesDirectoryClientContent
+      key={requestHref}
+      requestHref={requestHref}
+      page={directoryQuery.page}
+      pageSize={directoryQuery.pageSize}
+      search={directoryQuery.search}
+      sector={directoryQuery.sector}
+      viewMode={directoryQuery.viewMode}
+    />
+  );
+}
+
+function CompaniesDirectoryClientContent({
+  page: currentPage,
+  pageSize,
+  search: currentSearch,
+  sector: currentSector,
+  viewMode,
+  requestHref,
+}: CompaniesDirectoryClientContentProps) {
   const [state, setState] = useState<RequestState>(INITIAL_STATE);
 
   useEffect(() => {
     const controller = new AbortController();
-
-    setState({
-      data: null,
-      requestError: null,
-      loading: true,
-    });
 
     void fetchCompaniesDirectoryData(requestHref, controller.signal)
       .then((data) => {

--- a/apps/web/components/feature-carousel.tsx
+++ b/apps/web/components/feature-carousel.tsx
@@ -240,6 +240,7 @@ export function FeatureCarousel() {
                   }}
                   className="absolute inset-0 rounded-[2rem] md:rounded-[2.8rem] overflow-hidden border-4 md:border-8 border-background bg-background origin-center"
                 >
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
                   <img
                     src={feature.image}
                     alt={feature.label}

--- a/apps/web/components/leads-data-table.tsx
+++ b/apps/web/components/leads-data-table.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
 import { useTheme } from "next-themes";
 import { ChevronDown, MoreHorizontal } from "lucide-react";
 
@@ -137,17 +137,14 @@ const defaultLeads: Lead[] = [
 ];
 
 export function LeadsTable({
-  title = "Leads",
   leads: initialLeads = defaultLeads,
   onLeadAction,
   className = ""
 }: LeadsTableProps = {}) {
   const [leads, setLeads] = useState<Lead[]>(initialLeads);
   const [selectedLeads, setSelectedLeads] = useState<Set<string>>(new Set());
-  const [hoveredRow, setHoveredRow] = useState<string | null>(null);
   const [hoveredAction, setHoveredAction] = useState<string | null>(null);
   const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
-  const shouldReduceMotion = useReducedMotion();
   const { theme } = useTheme();
   const isDark = theme === "dark";
 
@@ -403,11 +400,9 @@ export function LeadsTable({
                   isSelected(lead.id) ? "bg-blue-50/50 dark:bg-blue-900/10" : ""
                 } ${index < leads.length - 1 ? "border-b border-border/20" : ""}`}
                 onMouseEnter={() => {
-                  setHoveredRow(lead.id);
                   setHoveredAction(lead.id);
                 }}
                 onMouseLeave={() => {
-                  setHoveredRow(null);
                   setHoveredAction(null);
                 }}
               >

--- a/apps/web/components/shared/sparkline-chip.tsx
+++ b/apps/web/components/shared/sparkline-chip.tsx
@@ -1,5 +1,5 @@
 import { SurfaceCard } from "@/components/shared/design-system-recipes";
-import { formatKpiDelta, formatKpiValue } from "@/lib/formatters";
+import { formatKpiDelta } from "@/lib/formatters";
 import { cn } from "@/lib/utils";
 
 function buildPath(values: number[], w: number, h: number): string {

--- a/apps/web/components/ui/calendar.tsx
+++ b/apps/web/components/ui/calendar.tsx
@@ -61,7 +61,6 @@ function Calendar({
   const defaultComponents = {
     Chevron: ({
       orientation,
-      ...rest
     }: {
       orientation?: "left" | "right" | "up" | "down";
       className?: string;

--- a/apps/web/tests/sectors-page-data.test.ts
+++ b/apps/web/tests/sectors-page-data.test.ts
@@ -7,22 +7,6 @@ import {
   loadSectorsPageData,
 } from "../lib/sectors-page-data.ts";
 
-const sampleDirectory = {
-  items: [
-    {
-      sector_name: "Energia",
-      sector_slug: "energia",
-      company_count: 12,
-      latest_year: 2024,
-      snapshot: {
-        roe: 0.18,
-        mg_ebit: 0.22,
-        mg_liq: 0.14,
-      },
-    },
-  ],
-};
-
 const latestSectorDetail = {
   sector_name: "Energia",
   sector_slug: "energia",


### PR DESCRIPTION
## Summary
- remove the existing web lint blockers that were failing `test-web`
- keep the scope inside `apps/web/**` so backend task #108 stays within lane boundaries
- adjust the companies directory client to reset loading state by remounting on request changes instead of calling `setState` synchronously inside an effect

## Validation
- npm run lint
- npm run typecheck
- npm run test:unit

## Parent task
- backend task #108

Closes #123
