### PR TITLE
perf(web): remove reaviz and standardize motion imports

### DIFF
--- a/apps/web/app/design-system/page.tsx
+++ b/apps/web/app/design-system/page.tsx
@@ -473,7 +473,7 @@ export default function DesignSystemPage() {
               </div>
             </Section>
 
-            <Section id="charts" title="Charts - reaviz">
+            <Section id="charts" title="Charts - lightweight SVG">
               <div className="space-y-10">
                 <div>
                   <p className="mb-3 font-mono text-xs text-muted-foreground">

--- a/apps/web/components/area-chart-medium.tsx
+++ b/apps/web/components/area-chart-medium.tsx
@@ -1,384 +1,467 @@
 'use client';
 
-import React, { useState } from 'react';
-import { motion } from 'framer-motion';
+import { useState } from 'react';
+import type { JSX } from 'react';
+
 import CountUp from 'react-countup';
-import {
-  AreaChart,
-  LinearXAxis,
-  LinearXAxisTickSeries,
-  LinearXAxisTickLabel,
-  LinearYAxis,
-  LinearYAxisTickSeries,
-  AreaSeries,
-  Area,
-  Gradient,
-  GradientStop,
-  GridlineSeries,
-  Gridline,
-} from 'reaviz';
+import { motion } from 'motion/react';
 
-// Type definitions
-interface ChartDataPoint {
-  key: Date;
-  data: number | null | undefined;
-}
+type TrendDirection = 'up' | 'down';
 
-interface ChartSeries {
+type SeriesPoint = {
+  date: Date;
+  value: number;
+};
+
+type ChartSeries = {
   key: string;
-  data: ChartDataPoint[];
-}
-
-interface ValidatedChartDataPoint {
-  key: Date;
-  data: number;
-}
-
-interface ValidatedChartSeries {
-  key: string;
-  data: ValidatedChartDataPoint[];
-}
-
-interface LegendItem {
-  name: string;
   color: string;
-}
+  points: SeriesPoint[];
+};
 
-interface TimePeriodOption {
-  value: string;
-  label: string;
-}
-
-interface IncidentStat {
+type IncidentStat = {
   id: string;
   title: string;
   count: number;
-  countFrom?: number;
+  countFrom: number;
   comparisonText: string;
   percentage: number;
-  trend: 'up' | 'down';
-  trendColor: string;
-  trendBgColor: string;
-  TrendIconSvg: React.FC<{ strokeColor: string }>;
-}
+  trend: TrendDirection;
+};
 
-interface DetailedMetric {
+type DetailedMetric = {
   id: string;
-  Icon: React.FC<{ className?: string; fill?: string }>;
+  icon: (props: { className?: string; fill?: string }) => JSX.Element;
   label: string;
   tooltip: string;
   value: string;
-  TrendIcon: React.FC<{ baseColor: string; strokeColor: string; className?: string }>;
-  trendBaseColor: string;
-  trendStrokeColor: string;
+  trend: TrendDirection;
+  trendColor: string;
   delay: number;
-}
+};
 
-// SVG Icon Components
-const DiamondAlertIcon: React.FC<{ className?: string; fill?: string }> = ({ className, fill = "#E84045" }) => (
-  <svg className={className} xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
-    <path d="M9.92844 1.25411C9.32947 1.25895 8.73263 1.49041 8.28293 1.94747L1.92062 8.41475C1.02123 9.32885 1.03336 10.8178 1.94748 11.7172L8.41476 18.0795C9.32886 18.9789 10.8178 18.9667 11.7172 18.0526L18.0795 11.5861C18.0798 11.5859 18.08 11.5856 18.0803 11.5853C18.979 10.6708 18.9667 9.18232 18.0526 8.28291L11.5853 1.92061C11.1283 1.47091 10.5274 1.24926 9.92844 1.25411ZM9.93901 2.49597C10.2155 2.49373 10.4926 2.59892 10.7089 2.81172L17.1762 9.17403C17.6087 9.59962 17.6139 10.2767 17.1884 10.7097L10.8261 17.1761C10.4005 17.6087 9.72379 17.614 9.29123 17.1884L2.82394 10.826C2.39139 10.4005 2.38613 9.72378 2.81174 9.29121L9.17404 2.82393C9.38684 2.60765 9.66256 2.4982 9.93901 2.49597ZM9.99028 5.40775C9.82481 5.41034 9.66711 5.47845 9.55178 5.59714C9.43645 5.71583 9.37289 5.87541 9.37505 6.04089V11.0409C9.37388 11.1237 9.38918 11.2059 9.42006 11.2828C9.45095 11.3596 9.4968 11.4296 9.55495 11.4886C9.6131 11.5476 9.6824 11.5944 9.75881 11.6264C9.83522 11.6583 9.91722 11.6748 10 11.6748C10.0829 11.6748 10.1649 11.6583 10.2413 11.6264C10.3177 11.5944 10.387 11.5476 10.4451 11.4886C10.5033 11.4296 10.5492 11.3596 10.58 11.2828C10.6109 11.2059 10.6262 11.1237 10.625 11.0409V6.04089C10.6261 5.95731 10.6105 5.87435 10.5789 5.79694C10.5474 5.71952 10.5006 5.64922 10.4415 5.59019C10.3823 5.53115 10.3119 5.48459 10.2344 5.45326C10.1569 5.42192 10.0739 5.40645 9.99028 5.40775ZM10 12.9159C9.77904 12.9159 9.56707 13.0037 9.41079 13.16C9.25451 13.3162 9.16672 13.5282 9.16672 13.7492C9.16672 13.9702 9.25451 14.1822 9.41079 14.3385C9.56707 14.4948 9.77904 14.5826 10 14.5826C10.2211 14.5826 10.433 14.4948 10.5893 14.3385C10.7456 14.1822 10.8334 13.9702 10.8334 13.7492C10.8334 13.5282 10.7456 13.3162 10.5893 13.16C10.433 13.0037 10.2211 12.9159 10 12.9159Z" fill={fill} />
-  </svg>
-);
+type PeriodKey = keyof typeof CHART_DATA_BY_PERIOD;
 
-const CircleAlertIcon: React.FC<{ className?: string; fill?: string }> = ({ className, fill = "#E84045" }) => (
-  <svg className={className} xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
-    <path d="M10.0001 1.66663C5.40511 1.66663 1.66675 5.40499 1.66675 9.99996C1.66675 14.5949 5.40511 18.3333 10.0001 18.3333C14.5951 18.3333 18.3334 14.5949 18.3334 9.99996C18.3334 5.40499 14.5951 1.66663 10.0001 1.66663ZM10.0001 2.91663C13.9195 2.91663 17.0834 6.08054 17.0834 9.99996C17.0834 13.9194 13.9195 17.0833 10.0001 17.0833C6.08066 17.0833 2.91675 13.9194 2.91675 9.99996C2.91675 6.08054 6.08066 2.91663 10.0001 2.91663ZM9.99032 5.82434C9.82470 5.82693 9.66688 5.89515 9.55152 6.01401C9.43616 6.13288 9.37271 6.29267 9.37508 6.45829V10.625C9.37391 10.7078 9.38921 10.79 9.42009 10.8669C9.45098 10.9437 9.49683 11.0137 9.55498 11.0726C9.61313 11.1316 9.68243 11.1785 9.75884 11.2104C9.83525 11.2424 9.91725 11.2589 10.0001 11.2589C10.0829 11.2589 10.1649 11.2424 10.2413 11.2104C10.3177 11.1785 10.387 11.1316 10.4452 11.0726C10.5033 11.0137 10.5492 10.9437 10.5801 10.8669C10.611 10.79 10.6263 10.7078 10.6251 10.625V6.45829C10.6263 6.37464 10.6107 6.29160 10.5792 6.21409C10.5477 6.13658 10.5010 6.06618 10.4418 6.00706C10.3826 5.94794 10.3121 5.90130 10.2346 5.86992C10.1570 5.83853 10.0740 5.82303 9.99032 5.82434ZM10.0001 12.5C9.77907 12.5 9.56711 12.5878 9.41083 12.7440C9.25455 12.9003 9.16675 13.1123 9.16675 13.3333C9.16675 13.5543 9.25455 13.7663 9.41083 13.9225C9.56711 14.0788 9.77907 14.1666 10.0001 14.1666C10.2211 14.1666 10.4331 14.0788 10.5893 13.9225C10.7456 13.7663 10.8334 13.5543 10.8334 13.3333C10.8334 13.1123 10.7456 12.9003 10.5893 12.7440C10.4331 12.5878 10.2211 12.5000 10.0001 12.5Z" fill={fill} />
-  </svg>
-);
-
-const TriangleAlertIcon: React.FC<{ className?: string; fill?: string }> = ({ className, fill = "#E84045" }) => (
-  <svg className={className} xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
-    <path d="M10.0001 2.10535C9.35241 2.10535 8.70472 2.42118 8.35459 3.05343L1.90440 14.7063C1.22414 15.9354 2.14514 17.5000 3.54990 17.5000H16.4511C17.8559 17.5000 18.7769 15.9354 18.0966 14.7063L11.6456 3.05343C11.2955 2.42118 10.6478 2.10535 10.0001 2.10535ZM10.0001 3.31222C10.2120 3.31222 10.4237 3.42739 10.5519 3.65889L17.0029 15.3117C17.2501 15.7585 16.9605 16.2500 16.4511 16.2500H3.54990C3.04051 16.2500 2.75090 15.7585 2.99815 15.3117L9.44834 3.65889C9.57655 3.42739 9.78821 3.31222 10.0001 3.31222ZM9.99033 6.65776C9.82472 6.66034 9.66690 6.72856 9.55154 6.84743C9.43618 6.96629 9.37272 7.12609 9.37510 7.29171V11.4584C9.37393 11.5412 9.38923 11.6234 9.42011 11.7003C9.45100 11.7771 9.49685 11.8471 9.55500 11.9061C9.61315 11.9650 9.68245 12.0119 9.75886 12.0438C9.83527 12.0758 9.91727 12.0923 10.0001 12.0923C10.0829 12.0923 10.1649 12.0758 10.2413 12.0438C10.3178 12.0119 10.3870 11.9650 10.4452 11.9061C10.5034 11.8471 10.5492 11.7771 10.5801 11.7003C10.6110 11.6234 10.6263 11.5412 10.6251 11.4584V7.29171C10.6263 7.20806 10.6107 7.12501 10.5792 7.04750C10.5477 6.96999 10.5010 6.89959 10.4418 6.84047C10.3826 6.78135 10.3121 6.73472 10.2346 6.70333C10.1570 6.67195 10.0740 6.65645 9.99033 6.65776ZM10.0001 13.3334C9.77909 13.3334 9.56712 13.4212 9.41084 13.5775C9.25456 13.7337 9.16677 13.9457 9.16677 14.1667C9.16677 14.3877 9.25456 14.5997 9.41084 14.7560C9.56712 14.9122 9.77909 15.0000 10.0001 15.0000C10.2211 15.0000 10.4331 14.9122 10.5894 14.7560C10.7456 14.5997 10.8334 14.3877 10.8334 14.1667C10.8334 13.9457 10.7456 13.7337 10.5894 13.5775C10.4331 13.4212 10.2211 13.3334 10.0001 13.3334Z" fill={fill} />
-  </svg>
-);
-
-const DetailedUpTrendIcon: React.FC<{ baseColor: string; strokeColor: string; className?: string }> = ({ baseColor, strokeColor, className }) => (
-  <svg className={className} width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <rect width="28" height="28" rx="14" fill={baseColor} fillOpacity="0.4" />
-    <path d="M9.50134 12.6111L14.0013 8.16663M14.0013 8.16663L18.5013 12.6111M14.0013 8.16663L14.0013 19.8333" stroke={strokeColor} strokeWidth="2" strokeLinecap="square" />
-  </svg>
-);
-
-const DetailedDownTrendIcon: React.FC<{ baseColor: string; strokeColor: string; className?: string }> = ({ baseColor, strokeColor, className }) => (
-  <svg className={className} width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <rect width="28" height="28" rx="14" fill={baseColor} fillOpacity="0.4" />
-    <path d="M18.4987 15.3889L13.9987 19.8334M13.9987 19.8334L9.49866 15.3889M13.9987 19.8334V8.16671" stroke={strokeColor} strokeWidth="2" strokeLinecap="square" />
-  </svg>
-);
-
-const SummaryUpArrowIcon: React.FC<{ strokeColor: string }> = ({ strokeColor }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" width="20" height="21" viewBox="0 0 20 21" fill="none">
-    <path d="M5.50134 9.11119L10.0013 4.66675M10.0013 4.66675L14.5013 9.11119M10.0013 4.66675L10.0013 16.3334" stroke={strokeColor} strokeWidth="2" strokeLinecap="square" />
-  </svg>
-);
-
-const SummaryDownArrowIcon: React.FC<{ strokeColor: string }> = ({ strokeColor }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" width="20" height="21" viewBox="0 0 20 21" fill="none">
-    <path d="M14.4987 11.8888L9.99866 16.3333M9.99866 16.3333L5.49866 11.8888M9.99866 16.3333V4.66658" stroke={strokeColor} strokeWidth="2" strokeLinecap="square" />
-  </svg>
-);
-
-
-// Data and Constants
-const LEGEND_ITEMS: LegendItem[] = [
-  { name: 'DLP', color: '#5B14C5' },
-  { name: 'Threat Intel', color: '#DAC5F9' },
-  { name: 'SysLog', color: '#B58BF3' },
-];
-
-const TIME_PERIOD_OPTIONS: TimePeriodOption[] = [
+const TIME_PERIOD_OPTIONS = [
   { value: 'last-7-days', label: 'Last 7 Days' },
   { value: 'last-30-days', label: 'Last 30 Days' },
   { value: 'last-90-days', label: 'Last 90 Days' },
-];
+] as const;
 
-const now = new Date();
-const generateDate = (offsetDays: number): Date => {
-  const date = new Date(now);
-  date.setDate(now.getDate() - offsetDays);
-  return date;
-};
+const SERIES_META = [
+  { key: 'DLP', color: '#5B14C5' },
+  { key: 'Threat Intel', color: '#DAC5F9' },
+  { key: 'SysLog', color: '#B58BF3' },
+] as const;
 
-const initialChartData: ChartSeries[] = [
-  {
-    key: 'DLP',
-    data: Array.from({ length: 7 }, (_, i) => ({ key: generateDate(6 - i), data: Math.floor(Math.random() * 50) + 20 })),
+const CHART_DATA_BY_PERIOD = {
+  'last-7-days': {
+    stepDays: 1,
+    values: {
+      DLP: [42, 47, 45, 50, 55, 53, 58],
+      'Threat Intel': [24, 21, 26, 28, 30, 29, 31],
+      SysLog: [30, 34, 32, 36, 39, 37, 41],
+    },
   },
-  {
-    key: 'Threat Intel', // Matches colorScheme order
-    data: Array.from({ length: 7 }, (_, i) => ({ key: generateDate(6 - i), data: Math.floor(Math.random() * 30) + 10 })),
+  'last-30-days': {
+    stepDays: 3,
+    values: {
+      DLP: [36, 38, 41, 45, 47, 50, 54, 52, 56, 60],
+      'Threat Intel': [19, 21, 20, 24, 26, 25, 28, 27, 30, 32],
+      SysLog: [22, 26, 29, 28, 31, 33, 35, 34, 37, 39],
+    },
   },
-  {
-    key: 'SysLog',
-    data: Array.from({ length: 7 }, (_, i) => ({ key: generateDate(6 - i), data: Math.floor(Math.random() * 40) + 15 })),
+  'last-90-days': {
+    stepDays: 7,
+    values: {
+      DLP: [28, 31, 35, 33, 37, 42, 46, 45, 49, 53, 58, 61],
+      'Threat Intel': [16, 18, 17, 19, 21, 23, 24, 26, 27, 29, 31, 33],
+      SysLog: [18, 22, 24, 27, 26, 29, 31, 33, 35, 34, 37, 40],
+    },
   },
-];
+} as const;
 
-const validateChartData = (data: ChartSeries[]): ValidatedChartSeries[] => {
-  return data.map(series => ({
-    ...series,
-    data: series.data.map(item => ({
-      ...item,
-      data: (typeof item.data !== 'number' || isNaN(item.data)) ? 0 : item.data,
-    })),
-  }));
-};
-
-const validatedChartData = validateChartData(initialChartData);
-
-const INCIDENT_STATS_DATA: IncidentStat[] = [
+const INCIDENT_STATS: IncidentStat[] = [
   {
     id: 'critical',
     title: 'Critical Incidents',
     count: 321,
-    countFrom: 0,
+    countFrom: 293,
     comparisonText: 'Compared to 293 last week',
     percentage: 12,
     trend: 'up',
-    trendColor: 'text-[#F08083]',
-    trendBgColor: 'bg-[rgb(232,64,69)]/40',
-    TrendIconSvg: SummaryUpArrowIcon,
   },
   {
     id: 'total',
     title: 'Total Incidents',
     count: 1120,
-    countFrom: 0,
+    countFrom: 1060,
     comparisonText: 'Compared to 1.06k last week',
     percentage: 4,
-    trend: 'down', // Assuming 4% is a reduction or positive trend, hence green
-    trendColor: 'text-[#40E5D1]',
-    trendBgColor: 'bg-[rgb(64,229,209)]/40',
-    TrendIconSvg: SummaryDownArrowIcon,
+    trend: 'down',
   },
 ];
 
-const DETAILED_METRICS_DATA: DetailedMetric[] = [
+function DiamondAlertIcon({
+  className,
+  fill = '#E84045',
+}: {
+  className?: string;
+  fill?: string;
+}) {
+  return (
+    <svg className={className} width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden>
+      <rect x="4" y="4" width="12" height="12" rx="3" transform="rotate(45 10 10)" fill={fill} />
+      <rect x="9.2" y="5.25" width="1.6" height="6.8" rx="0.8" fill="white" />
+      <circle cx="10" cy="14.2" r="1" fill="white" />
+    </svg>
+  );
+}
+
+function CircleAlertIcon({
+  className,
+  fill = '#E84045',
+}: {
+  className?: string;
+  fill?: string;
+}) {
+  return (
+    <svg className={className} width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden>
+      <circle cx="10" cy="10" r="8" fill={fill} />
+      <rect x="9.2" y="5" width="1.6" height="7" rx="0.8" fill="white" />
+      <circle cx="10" cy="14.2" r="1" fill="white" />
+    </svg>
+  );
+}
+
+function TriangleAlertIcon({
+  className,
+  fill = '#40E5D1',
+}: {
+  className?: string;
+  fill?: string;
+}) {
+  return (
+    <svg className={className} width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden>
+      <path d="M10 2.5 18 17H2L10 2.5Z" fill={fill} />
+      <rect x="9.2" y="7" width="1.6" height="5.8" rx="0.8" fill="#05211D" />
+      <circle cx="10" cy="14.8" r="1" fill="#05211D" />
+    </svg>
+  );
+}
+
+function TrendBadge({
+  direction,
+  color,
+}: {
+  direction: TrendDirection;
+  color: string;
+}) {
+  const isUp = direction === 'up';
+
+  return (
+    <span
+      className="inline-flex h-7 w-7 items-center justify-center rounded-full"
+      style={{
+        backgroundColor: isUp ? 'rgba(232,64,69,0.18)' : 'rgba(64,229,209,0.22)',
+        color,
+      }}
+      aria-hidden
+    >
+      <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+        {isUp ? (
+          <path d="M7 2.5 11 6.5 9.9 7.6 7.75 5.45V11.5h-1.5V5.45L4.1 7.6 3 6.5l4-4Z" fill="currentColor" />
+        ) : (
+          <path d="m7 11.5-4-4 1.1-1.1 2.15 2.15V2.5h1.5v6.05L9.9 6.4 11 7.5l-4 4Z" fill="currentColor" />
+        )}
+      </svg>
+    </span>
+  );
+}
+
+const DETAILED_METRICS: DetailedMetric[] = [
   {
     id: 'mttd',
-    Icon: DiamondAlertIcon,
+    icon: DiamondAlertIcon,
     label: 'Mean Time to Respond',
     tooltip: 'Mean Time to Respond',
     value: '6 Hours',
-    TrendIcon: DetailedUpTrendIcon,
-    trendBaseColor: '#E84045',
-    trendStrokeColor: '#F08083',
+    trend: 'up',
+    trendColor: '#F08083',
     delay: 0,
   },
   {
     id: 'irt',
-    Icon: CircleAlertIcon,
+    icon: CircleAlertIcon,
     label: 'Incident Response Time',
     tooltip: 'Incident Response Time',
     value: '4 Hours',
-    TrendIcon: DetailedUpTrendIcon,
-    trendBaseColor: '#E84045',
-    trendStrokeColor: '#F08083',
+    trend: 'up',
+    trendColor: '#F08083',
     delay: 0.05,
   },
   {
     id: 'ier',
-    Icon: TriangleAlertIcon,
+    icon: TriangleAlertIcon,
     label: 'Incident Escalation Rate',
     tooltip: 'Incident Escalation Rate',
     value: '10%',
-    TrendIcon: DetailedDownTrendIcon, // Assuming lower is better, green
-    trendBaseColor: '#40E5D1',
-    trendStrokeColor: '#40E5D1',
+    trend: 'down',
+    trendColor: '#40E5D1',
     delay: 0.1,
   },
 ];
 
+function buildPeriodSeries(period: PeriodKey): ChartSeries[] {
+  const preset = CHART_DATA_BY_PERIOD[period];
+  const longestSeriesLength = Math.max(...Object.values(preset.values).map((values) => values.length));
+  const now = new Date();
 
-const AdvancedIncidentReportCard: React.FC = () => {
-  const [selectedTimePeriod, setSelectedTimePeriod] = useState<string>(TIME_PERIOD_OPTIONS[0].value);
+  return SERIES_META.map((series) => {
+    const values = preset.values[series.key];
 
-  // In a real app, changing selectedTimePeriod would refetch/filter chartData and stats
-  // For this example, it only updates the select's value
+    return {
+      key: series.key,
+      color: series.color,
+      points: values.map((value, index) => {
+        const offset = (longestSeriesLength - 1 - index) * preset.stepDays;
+        const date = new Date(now);
+        date.setDate(now.getDate() - offset);
+
+        return { date, value };
+      }),
+    };
+  });
+}
+
+function formatShortDate(date: Date): string {
+  return date.toLocaleDateString('en-US', { month: 'numeric', day: 'numeric' });
+}
+
+function buildPath(points: { x: number; y: number }[]): string {
+  if (points.length === 0) {
+    return '';
+  }
+
+  return points
+    .map((point, index) => `${index === 0 ? 'M' : 'L'} ${point.x.toFixed(1)} ${point.y.toFixed(1)}`)
+    .join(' ');
+}
+
+function buildAreaPath(points: { x: number; y: number }[], baselineY: number): string {
+  if (points.length === 0) {
+    return '';
+  }
+
+  const linePath = buildPath(points);
+  const lastPoint = points[points.length - 1]!;
+  const firstPoint = points[0]!;
+
+  return `${linePath} L ${lastPoint.x.toFixed(1)} ${baselineY.toFixed(1)} L ${firstPoint.x.toFixed(1)} ${baselineY.toFixed(1)} Z`;
+}
+
+function IncidentAreaChart({ period }: { period: PeriodKey }) {
+  const series = buildPeriodSeries(period);
+  const firstSeries = series[0];
+
+  if (!firstSeries) {
+    return null;
+  }
+
+  const width = 760;
+  const height = 280;
+  const padding = { top: 18, right: 18, bottom: 30, left: 18 };
+  const innerWidth = width - padding.left - padding.right;
+  const innerHeight = height - padding.top - padding.bottom;
+  const allValues = series.flatMap((item) => item.points.map((point) => point.value));
+  const maxValue = Math.max(...allValues);
+  const minValue = 0;
+  const range = Math.max(maxValue - minValue, 1);
+  const step = firstSeries.points.length > 1 ? innerWidth / (firstSeries.points.length - 1) : innerWidth;
+  const baselineY = padding.top + innerHeight;
+
+  const toX = (index: number) => padding.left + index * step;
+  const toY = (value: number) => padding.top + innerHeight - ((value - minValue) / range) * innerHeight;
+
+  const gridValues = Array.from({ length: 4 }, (_, index) => minValue + ((maxValue - minValue) / 3) * index);
 
   return (
-    <>
-      <style jsx global>{`
-        :root {
-          --reaviz-tick-fill: #9A9AAF; /* Original light mode tick fill */
-          --reaviz-gridline-stroke: #7E7E8F75; /* Original light mode gridline */
-        }
-        .dark {
-          --reaviz-tick-fill: #A0AEC0; /* Lighter gray for dark mode */
-          --reaviz-gridline-stroke: rgba(74, 85, 104, 0.6); /* Darker, less opaque gridline */
-        }
-      `}</style>
-      <div className="flex flex-col justify-between pt-4 pb-4 bg-white dark:bg-black rounded-3xl shadow-[11px_21px_3px_rgba(0,0,0,0.06),14px_27px_7px_rgba(0,0,0,0.10),19px_38px_14px_rgba(0,0,0,0.13),27px_54px_27px_rgba(0,0,0,0.16),39px_78px_50px_rgba(0,0,0,0.20),55px_110px_86px_rgba(0,0,0,0.26)] w-full max-w-2xl min-h-[714px] overflow-hidden transition-colors duration-300">
-        {/* Header */}
-        <div className="flex justify-between items-center p-7 pt-6 pb-8">
-          <h3 className="text-3xl text-left font-bold text-gray-900 dark:text-white transition-colors duration-300">
-            Incident Report
-          </h3>
-          <select
-            value={selectedTimePeriod}
-            onChange={(e) => setSelectedTimePeriod(e.target.value)}
-            className="bg-gray-100 dark:bg-[#262631] text-gray-800 dark:text-white p-3 pt-2 pb-2 rounded-md focus:ring-2 focus:ring-blue-500 outline-none transition-colors duration-300"
-            aria-label="Select time period for incident report"
-          >
-            {TIME_PERIOD_OPTIONS.map(option => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </select>
-        </div>
-
-        {/* Legend */}
-        <div className="flex gap-8 w-full pl-8 pr-8 mb-4">
-          {LEGEND_ITEMS.map((item) => (
-            <div key={item.name} className="flex gap-2 items-center">
-              <div className="w-4 h-4" style={{ backgroundColor: item.color }} />
-              <span className="text-gray-500 dark:text-gray-400 text-xs transition-colors duration-300">{item.name}</span>
-            </div>
+    <motion.div
+      key={period}
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.24, ease: 'easeOut' }}
+      className="h-[280px] px-2"
+    >
+      <svg viewBox={`0 0 ${width} ${height}`} className="h-full w-full" preserveAspectRatio="none" aria-hidden>
+        <defs>
+          {series.map((item, index) => (
+            <linearGradient
+              key={item.key}
+              id={`incident-series-${index}`}
+              x1="0"
+              y1="0"
+              x2="0"
+              y2="1"
+            >
+              <stop offset="0%" stopColor={item.color} stopOpacity="0.34" />
+              <stop offset="100%" stopColor={item.color} stopOpacity="0.02" />
+            </linearGradient>
           ))}
-        </div>
+        </defs>
 
-        {/* Chart */}
-        <div className="reaviz-chart-container h-[280px] px-2"> {/* Adjusted height and added padding for axis labels */}
-          <AreaChart
-            height={280} // Explicit height for the chart
-            id="multi-series-interpolation-smooth"
-            data={validatedChartData}
-            xAxis={
-              <LinearXAxis
-                type="time"
-                tickSeries={
-                  <LinearXAxisTickSeries
-                    label={
-                      <LinearXAxisTickLabel
-                        format={v => new Date(v).toLocaleDateString('en-US', { month: 'numeric', day: 'numeric' })}
-                        fill="var(--reaviz-tick-fill)"
-                      />
-                    }
-                    tickSize={10} // Optimized tickSize
-                  />
-                }
-              />
-            }
-            yAxis={
-              <LinearYAxis
-                axisLine={null}
-                tickSeries={<LinearYAxisTickSeries line={null} label={null} tickSize={10} />} // Optimized tickSize
-              />
-            }
-            series={
-              <AreaSeries
-                type="grouped"
-                interpolation="smooth"
-                area={
-                  <Area
-                    gradient={
-                      <Gradient
-                        stops={[
-                          <GradientStop key={1} stopOpacity={0} />,
-                          <GradientStop key={2} offset="100%" stopOpacity={0.4} />,
-                        ]}
-                      />
-                    }
-                  />
-                }
-                colorScheme={['#5B14C5', '#DAC5F9', '#B58BF3']} // DLP, Threat Intel, SysLog
-              />
-            }
-            gridlines={<GridlineSeries line={<Gridline strokeColor="var(--reaviz-gridline-stroke)" />} />}
-          />
-        </div>
+        {gridValues.map((value) => {
+          const y = toY(value);
+          return (
+            <line
+              key={value}
+              x1={padding.left}
+              x2={width - padding.right}
+              y1={y}
+              y2={y}
+              stroke="rgba(126,126,143,0.32)"
+              strokeWidth="1"
+              strokeDasharray="4 6"
+            />
+          );
+        })}
 
-        {/* Summary Stats */}
-        <div className="flex flex-col sm:flex-row w-full pl-8 pr-8 justify-between pb-2 pt-8 gap-4 sm:gap-8">
-          {INCIDENT_STATS_DATA.map(stat => (
-            <div key={stat.id} className="flex flex-col gap-2 w-full sm:w-1/2">
-              <span className="text-xl text-gray-800 dark:text-gray-200 transition-colors duration-300">{stat.title}</span>
+        {series.map((item, index) => {
+          const points = item.points.map((point, pointIndex) => ({
+            x: toX(pointIndex),
+            y: toY(point.value),
+          }));
+
+          return (
+            <g key={item.key}>
+              <path d={buildAreaPath(points, baselineY)} fill={`url(#incident-series-${index})`} />
+              <path d={buildPath(points)} fill="none" stroke={item.color} strokeWidth="3" strokeLinejoin="round" />
+              {points.map((point, pointIndex) => (
+                <circle
+                  key={`${item.key}-${pointIndex}`}
+                  cx={point.x}
+                  cy={point.y}
+                  r="3.5"
+                  fill={item.color}
+                  stroke="white"
+                  strokeWidth="1.5"
+                />
+              ))}
+            </g>
+          );
+        })}
+
+        {firstSeries.points.map((point, index) => (
+          <text
+            key={point.date.toISOString()}
+            x={toX(index)}
+            y={height - 8}
+            textAnchor="middle"
+            fontSize="11"
+            fill="#9A9AAF"
+          >
+            {formatShortDate(point.date)}
+          </text>
+        ))}
+      </svg>
+    </motion.div>
+  );
+}
+
+const AdvancedIncidentReportCard = () => {
+  const [selectedTimePeriod, setSelectedTimePeriod] = useState<PeriodKey>('last-7-days');
+
+  return (
+    <div className="flex min-h-[714px] w-full max-w-2xl flex-col justify-between overflow-hidden rounded-3xl bg-white pt-4 pb-4 shadow-[11px_21px_3px_rgba(0,0,0,0.06),14px_27px_7px_rgba(0,0,0,0.10),19px_38px_14px_rgba(0,0,0,0.13),27px_54px_27px_rgba(0,0,0,0.16),39px_78px_50px_rgba(0,0,0,0.20),55px_110px_86px_rgba(0,0,0,0.26)] transition-colors duration-300 dark:bg-black">
+      <div className="flex items-center justify-between p-7 pt-6 pb-8">
+        <h3 className="text-left text-3xl font-bold text-gray-900 transition-colors duration-300 dark:text-white">
+          Incident Report
+        </h3>
+        <select
+          value={selectedTimePeriod}
+          onChange={(event) => setSelectedTimePeriod(event.target.value as PeriodKey)}
+          className="rounded-md bg-gray-100 p-3 pt-2 pb-2 text-gray-800 outline-none transition-colors duration-300 focus:ring-2 focus:ring-blue-500 dark:bg-[#262631] dark:text-white"
+          aria-label="Select time period for incident report"
+        >
+          {TIME_PERIOD_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="mb-4 flex w-full gap-8 px-8">
+        {SERIES_META.map((item) => (
+          <div key={item.key} className="flex items-center gap-2">
+            <div className="h-4 w-4" style={{ backgroundColor: item.color }} />
+            <span className="text-xs text-gray-500 transition-colors duration-300 dark:text-gray-400">{item.key}</span>
+          </div>
+        ))}
+      </div>
+
+      <IncidentAreaChart period={selectedTimePeriod} />
+
+      <div className="flex w-full flex-col justify-between gap-4 px-8 pt-8 pb-2 sm:flex-row sm:gap-8">
+        {INCIDENT_STATS.map((stat) => {
+          const trendColor = stat.trend === 'up' ? '#F08083' : '#40E5D1';
+
+          return (
+            <div key={stat.id} className="flex w-full flex-col gap-2 sm:w-1/2">
+              <span className="text-xl text-gray-800 transition-colors duration-300 dark:text-gray-200">
+                {stat.title}
+              </span>
               <div className="flex items-center gap-2">
                 <CountUp
-                  className="font-mono text-4xl font-semibold text-gray-900 dark:text-white transition-colors duration-300"
-                  start={stat.countFrom || 0}
+                  className="font-mono text-4xl font-semibold text-gray-900 transition-colors duration-300 dark:text-white"
+                  start={stat.countFrom}
                   end={stat.count}
                   duration={2.5}
                 />
-                <div className={`flex ${stat.trendBgColor} p-1 pl-2 pr-2 items-center rounded-full ${stat.trendColor}`}>
-                  <stat.TrendIconSvg strokeColor={stat.trendColor.startsWith('text-[#F08083]') ? '#F08083' : '#40E5D1'} />
-                  {stat.percentage}%
+                <div
+                  className="flex items-center gap-1 rounded-full p-1 pl-2 pr-2"
+                  style={{
+                    backgroundColor: stat.trend === 'up' ? 'rgba(232,64,69,0.18)' : 'rgba(64,229,209,0.22)',
+                    color: trendColor,
+                  }}
+                >
+                  <TrendBadge direction={stat.trend} color={trendColor} />
+                  <span className="text-sm font-medium">{stat.percentage}%</span>
                 </div>
               </div>
-              <span className="text-gray-500 dark:text-gray-400 text-sm transition-colors duration-300">
+              <span className="text-sm text-gray-500 transition-colors duration-300 dark:text-gray-400">
                 {stat.comparisonText}
               </span>
             </div>
-          ))}
-        </div>
-
-        {/* Detailed Metrics List */}
-        <div className="flex flex-col pl-8 pr-8 font-mono divide-y divide-gray-200 dark:divide-[#262631] transition-colors duration-300 mt-4">
-          {DETAILED_METRICS_DATA.map((metric) => (
-            <motion.div
-              key={metric.id}
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: metric.delay }}
-              className="flex w-full py-4 items-center gap-2"
-            >
-              <div className="flex flex-row gap-2 items-center text-base w-1/2 text-gray-500 dark:text-gray-400 transition-colors duration-300">
-                <metric.Icon fill={metric.id === 'ier' && metric.trendBaseColor === '#40E5D1' ? '#40E5D1' : '#E84045'} />
-                <span className="truncate" title={metric.tooltip}>
-                  {metric.label}
-                </span>
-              </div>
-              <div className="flex gap-2 w-1/2 justify-end items-center">
-                <span className="font-semibold text-xl text-gray-900 dark:text-white transition-colors duration-300">{metric.value}</span>
-                <metric.TrendIcon baseColor={metric.trendBaseColor} strokeColor={metric.trendStrokeColor} />
-              </div>
-            </motion.div>
-          ))}
-        </div>
+          );
+        })}
       </div>
-    </>
+
+      <div className="mt-4 flex flex-col divide-y divide-gray-200 px-8 font-mono transition-colors duration-300 dark:divide-[#262631]">
+        {DETAILED_METRICS.map((metric) => (
+          <motion.div
+            key={metric.id}
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: metric.delay }}
+            className="flex w-full items-center gap-2 py-4"
+          >
+            <div className="flex w-1/2 items-center gap-2 text-base text-gray-500 transition-colors duration-300 dark:text-gray-400">
+              <metric.icon fill={metric.trend === 'down' ? '#40E5D1' : '#E84045'} />
+              <span className="truncate" title={metric.tooltip}>
+                {metric.label}
+              </span>
+            </div>
+            <div className="flex w-1/2 items-center justify-end gap-2">
+              <span className="text-xl font-semibold text-gray-900 transition-colors duration-300 dark:text-white">
+                {metric.value}
+              </span>
+              <TrendBadge direction={metric.trend} color={metric.trendColor} />
+            </div>
+          </motion.div>
+        ))}
+      </div>
+    </div>
   );
 };
 

--- a/apps/web/components/companies/companies-directory-client.tsx
+++ b/apps/web/components/companies/companies-directory-client.tsx
@@ -30,6 +30,15 @@ type RequestState = {
   loading: boolean;
 };
 
+type CompaniesDirectoryClientContentProps = {
+  currentPage: number;
+  currentSearch: string;
+  currentSector: string | null;
+  pageSize: number;
+  requestHref: string;
+  viewMode: "rows" | "cards";
+};
+
 const DIRECTORY_LOAD_ERROR =
   "Nao foi possivel carregar o diretorio de empresas agora. Tente novamente em instantes.";
 
@@ -73,16 +82,32 @@ export function CompaniesDirectoryClient() {
     page: currentPage,
     pageSize,
   });
+
+  return (
+    <CompaniesDirectoryClientContent
+      key={requestHref}
+      currentPage={currentPage}
+      currentSearch={currentSearch}
+      currentSector={currentSector}
+      pageSize={pageSize}
+      requestHref={requestHref}
+      viewMode={viewMode}
+    />
+  );
+}
+
+function CompaniesDirectoryClientContent({
+  currentPage,
+  currentSearch,
+  currentSector,
+  pageSize,
+  requestHref,
+  viewMode,
+}: CompaniesDirectoryClientContentProps) {
   const [state, setState] = useState<RequestState>(INITIAL_STATE);
 
   useEffect(() => {
     const controller = new AbortController();
-
-    setState({
-      data: null,
-      requestError: null,
-      loading: true,
-    });
 
     void fetchCompaniesDirectoryData(requestHref, controller.signal)
       .then((data) => {

--- a/apps/web/components/delete-button.tsx
+++ b/apps/web/components/delete-button.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { AnimatePresence, motion, MotionConfig } from "framer-motion";
+import { AnimatePresence, motion, MotionConfig } from "motion/react";
 import { Check, Trash2, X } from "lucide-react";
 import { useState } from "react";
 

--- a/apps/web/components/financial-markets-table.tsx
+++ b/apps/web/components/financial-markets-table.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { motion, useReducedMotion } from "framer-motion";
+import { motion, useReducedMotion } from "motion/react";
 import { useTheme } from "next-themes";
 
 export interface MarketIndex {

--- a/apps/web/components/horizontal-bar-chart.tsx
+++ b/apps/web/components/horizontal-bar-chart.tsx
@@ -1,193 +1,203 @@
 'use client';
 
-import React from 'react';
 import type { JSX } from 'react';
-import {
-  BarChart,
-  LinearYAxis,
-  LinearYAxisTickSeries,
-  LinearYAxisTickLabel,
-  LinearXAxis,
-  LinearXAxisTickSeries,
-  BarSeries,
-  Bar,
-  GridlineSeries,
-  Gridline,
-} from 'reaviz';
-import { motion } from 'framer-motion';
 
-// Data Definitions and Validation
-interface ChartCategoryData {
+import { motion } from 'motion/react';
+
+type TrendDirection = 'up' | 'down';
+
+type CategoryData = {
   key: string;
-  data: number | null; // Allow null for raw data before validation
-}
+  value: number;
+  color: string;
+};
 
-const categoryDataRaw: ChartCategoryData[] = [
-  { key: 'Brute Force', data: 100 },
-  { key: 'Web Attack', data: 80 },
-  { key: 'Malware', data: 120 },
-  { key: 'Phishing', data: 90 },
-];
-
-// Validate and prepare chart data
-const validatedCategoryData = categoryDataRaw.map(item => ({
-  ...item,
-  data: (typeof item.data === 'number' && !isNaN(item.data)) ? item.data : 0,
-}));
-
-const chartColors = ['#9152EE', '#40D3F4', '#40E5D1', '#4C86FF'];
-
-interface MetricItem {
+type MetricItem = {
   id: string;
-  iconSvg: JSX.Element;
+  icon: (props: { className?: string; fill?: string }) => JSX.Element;
   label: string;
   value: string;
-  trendIconSvg: JSX.Element;
+  trend: TrendDirection;
   delay: number;
+};
+
+const CATEGORY_DATA: CategoryData[] = [
+  { key: 'Brute Force', value: 100, color: '#9152EE' },
+  { key: 'Web Attack', value: 80, color: '#40D3F4' },
+  { key: 'Malware', value: 120, color: '#40E5D1' },
+  { key: 'Phishing', value: 90, color: '#4C86FF' },
+];
+
+const MAX_CATEGORY_VALUE = Math.max(...CATEGORY_DATA.map((item) => item.value));
+
+function DiamondAlertIcon({
+  className,
+  fill = '#E84045',
+}: {
+  className?: string;
+  fill?: string;
+}) {
+  return (
+    <svg className={className} width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden>
+      <rect x="4" y="4" width="12" height="12" rx="3" transform="rotate(45 10 10)" fill={fill} />
+      <rect x="9.2" y="5.25" width="1.6" height="6.8" rx="0.8" fill="white" />
+      <circle cx="10" cy="14.2" r="1" fill="white" />
+    </svg>
+  );
 }
 
-const metrics: MetricItem[] = [
+function CircleAlertIcon({
+  className,
+  fill = '#E84045',
+}: {
+  className?: string;
+  fill?: string;
+}) {
+  return (
+    <svg className={className} width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden>
+      <circle cx="10" cy="10" r="8" fill={fill} />
+      <rect x="9.2" y="5" width="1.6" height="7" rx="0.8" fill="white" />
+      <circle cx="10" cy="14.2" r="1" fill="white" />
+    </svg>
+  );
+}
+
+function TriangleAlertIcon({
+  className,
+  fill = '#40E5D1',
+}: {
+  className?: string;
+  fill?: string;
+}) {
+  return (
+    <svg className={className} width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden>
+      <path d="M10 2.5 18 17H2L10 2.5Z" fill={fill} />
+      <rect x="9.2" y="7" width="1.6" height="5.8" rx="0.8" fill="#05211D" />
+      <circle cx="10" cy="14.8" r="1" fill="#05211D" />
+    </svg>
+  );
+}
+
+function TrendBadge({ direction }: { direction: TrendDirection }) {
+  const isUp = direction === 'up';
+
+  return (
+    <span
+      className={
+        isUp
+          ? 'inline-flex h-7 w-7 items-center justify-center rounded-full bg-[rgba(232,64,69,0.18)] text-[#F08083]'
+          : 'inline-flex h-7 w-7 items-center justify-center rounded-full bg-[rgba(64,229,209,0.22)] text-[#40E5D1]'
+      }
+      aria-hidden
+    >
+      <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+        {isUp ? (
+          <path d="M7 2.5 11 6.5 9.9 7.6 7.75 5.45V11.5h-1.5V5.45L4.1 7.6 3 6.5l4-4Z" fill="currentColor" />
+        ) : (
+          <path d="m7 11.5-4-4 1.1-1.1 2.15 2.15V2.5h1.5v6.05L9.9 6.4 11 7.5l-4 4Z" fill="currentColor" />
+        )}
+      </svg>
+    </span>
+  );
+}
+
+const METRICS: MetricItem[] = [
   {
     id: 'mttRespond',
-    iconSvg: (
-      <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
-        <path d="M9.92844 1.25411C9.32947 1.25895 8.73263 1.49041 8.28293 1.94747L1.92062 8.41475C1.02123 9.32885 1.03336 10.8178 1.94748 11.7172L8.41476 18.0795C9.32886 18.9789 10.8178 18.9667 11.7172 18.0526L18.0795 11.5861C18.0798 11.5859 18.08 11.5856 18.0803 11.5853C18.979 10.6708 18.9667 9.18232 18.0526 8.28291L11.5853 1.92061C11.1283 1.47091 10.5274 1.24926 9.92844 1.25411ZM9.93901 2.49597C10.2155 2.49373 10.4926 2.59892 10.7089 2.81172L17.1762 9.17403C17.6087 9.59962 17.6139 10.2767 17.1884 10.7097L10.8261 17.1761C10.4005 17.6087 9.72379 17.614 9.29123 17.1884L2.82394 10.826C2.39139 10.4005 2.38613 9.72378 2.81174 9.29121L9.17404 2.82393C9.38684 2.60765 9.66256 2.4982 9.93901 2.49597ZM9.99028 5.40775C9.82481 5.41034 9.66711 5.47845 9.55178 5.59714C9.43645 5.71583 9.37289 5.87541 9.37505 6.04089V11.0409C9.37388 11.1237 9.38918 11.2059 9.42006 11.2828C9.45095 11.3596 9.4968 11.4296 9.55495 11.4886C9.6131 11.5476 9.6824 11.5944 9.75881 11.6264C9.83522 11.6583 9.91722 11.6748 10 11.6748C10.0829 11.6748 10.1649 11.6583 10.2413 11.6264C10.3177 11.5944 10.387 11.5476 10.4451 11.4886C10.5033 11.4296 10.5492 11.3596 10.58 11.2828C10.6109 11.2059 10.6262 11.1237 10.625 11.0409V6.04089C10.6261 5.95731 10.6105 5.87435 10.5789 5.79694C10.5474 5.71952 10.5006 5.64922 10.4415 5.59019C10.3823 5.53115 10.3119 5.48459 10.2344 5.45326C10.1569 5.42192 10.0739 5.40645 9.99028 5.40775ZM10 12.9159C9.77904 12.9159 9.56707 13.0037 9.41079 13.16C9.25451 13.3162 9.16672 13.5282 9.16672 13.7492C9.16672 13.9702 9.25451 14.1822 9.41079 14.3385C9.56707 14.4948 9.77904 14.5826 10 14.5826C10.2211 14.5826 10.433 14.4948 10.5893 14.3385C10.7456 14.1822 10.8334 13.9702 10.8334 13.7492C10.8334 13.5282 10.7456 13.3162 10.5893 13.16C10.433 13.0037 10.2211 12.9159 10 12.9159Z" fill="#E84045" />
-      </svg>
-    ),
+    icon: DiamondAlertIcon,
     label: 'Mean Time to Respond',
     value: '6 Hours',
-    trendIconSvg: (
-      <svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <rect width="28" height="28" rx="14" fill="#E84045" fillOpacity="0.4" />
-        <path d="M9.50134 12.6111L14.0013 8.16663M14.0013 8.16663L18.5013 12.6111M14.0013 8.16663L14.0013 19.8333" stroke="#F08083" strokeWidth="2" strokeLinecap="square" />
-      </svg>
-    ),
+    trend: 'up',
     delay: 0,
   },
   {
     id: 'incidentResponseTime',
-    iconSvg: (
-      <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
-        <path d="M10.0001 1.66663C5.40511 1.66663 1.66675 5.40499 1.66675 9.99996C1.66675 14.5949 5.40511 18.3333 10.0001 18.3333C14.5951 18.3333 18.3334 14.5949 18.3334 9.99996C18.3334 5.40499 14.5951 1.66663 10.0001 1.66663ZM10.0001 2.91663C13.9195 2.91663 17.0834 6.08054 17.0834 9.99996C17.0834 13.9194 13.9195 17.0833 10.0001 17.0833C6.08066 17.0833 2.91675 13.9194 2.91675 9.99996C2.91675 6.08054 6.08066 2.91663 10.0001 2.91663ZM9.99032 5.82434C9.8247 5.82693 9.66688 5.89515 9.55152 6.01401C9.43616 6.13288 9.37271 6.29267 9.37508 6.45829V10.625C9.37391 10.7078 9.38921 10.79 9.42009 10.8669C9.45098 10.9437 9.49683 11.0137 9.55498 11.0726C9.61313 11.1316 9.68243 11.1785 9.75884 11.2104C9.83525 11.2424 9.91725 11.2589 10.0001 11.2589C10.0829 11.2589 10.1649 11.2424 10.2413 11.2104C10.3177 11.1785 10.387 11.1316 10.4452 11.0726C10.5033 11.0137 10.5492 10.9437 10.5801 10.8669C10.611 10.79 10.6263 10.7078 10.6251 10.625V6.45829C10.6263 6.37464 10.6107 6.2916 10.5792 6.21409C10.5477 6.13658 10.501 6.06618 10.4418 6.00706C10.3826 5.94794 10.3121 5.9013 10.2346 5.86992C10.157 5.83853 10.074 5.82303 9.99032 5.82434ZM10.0001 12.5C9.77907 12.5 9.56711 12.5878 9.41083 12.744C9.25455 12.9003 9.16675 13.1123 9.16675 13.3333C9.16675 13.5543 9.25455 13.7663 9.41083 13.9225C9.56711 14.0788 9.77907 14.1666 10.0001 14.1666C10.2211 14.1666 10.4331 14.0788 10.5893 13.9225C10.7456 13.7663 10.8334 13.5543 10.8334 13.3333C10.8334 13.1123 10.7456 12.9003 10.5893 12.744C10.4331 12.5878 10.2211 12.5 10.0001 12.5Z" fill="#E84045" />
-      </svg>
-    ),
+    icon: CircleAlertIcon,
     label: 'Incident Response Time',
     value: '4 Hours',
-    trendIconSvg: (
-      <svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <rect width="28" height="28" rx="14" fill="#E84045" fillOpacity="0.4" />
-        <path d="M9.50134 12.6111L14.0013 8.16663M14.0013 8.16663L18.5013 12.6111M14.0013 8.16663L14.0013 19.8333" stroke="#F08083" strokeWidth="2" strokeLinecap="square" />
-      </svg>
-    ),
+    trend: 'up',
     delay: 0.05,
   },
   {
     id: 'incidentEscalationRate',
-    iconSvg: (
-      <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
-        <path d="M10.0001 2.10535C9.35241 2.10535 8.70472 2.42118 8.35459 3.05343L1.9044 14.7063C1.22414 15.9354 2.14514 17.5 3.5499 17.5H16.4511C17.8559 17.5 18.7769 15.9354 18.0966 14.7063L11.6456 3.05343C11.2955 2.42118 10.6478 2.10535 10.0001 2.10535ZM10.0001 3.31222C10.212 3.31222 10.4237 3.42739 10.5519 3.65889L17.0029 15.3117C17.2501 15.7585 16.9605 16.25 16.4511 16.25H3.5499C3.04051 16.25 2.7509 15.7585 2.99815 15.3117L9.44834 3.65889C9.57655 3.42739 9.78821 3.31222 10.0001 3.31222ZM9.99033 6.65776C9.82472 6.66034 9.6669 6.72856 9.55154 6.84743C9.43618 6.96629 9.37272 7.12609 9.3751 7.29171V11.4584C9.37393 11.5412 9.38923 11.6234 9.42011 11.7003C9.451 11.7771 9.49685 11.8471 9.555 11.9061C9.61315 11.965 9.68245 12.0119 9.75886 12.0438C9.83527 12.0758 9.91727 12.0923 10.0001 12.0923C10.0829 12.0923 10.1649 12.0758 10.2413 12.0438C10.3178 12.0119 10.387 11.965 10.4452 11.9061C10.5034 11.8471 10.5492 11.7771 10.5801 11.7003C10.611 11.6234 10.6263 11.5412 10.6251 11.4584V7.29171C10.6263 7.20806 10.6107 7.12501 10.5792 7.0475C10.5477 6.96999 10.501 6.89959 10.4418 6.84047C10.3826 6.78135 10.3121 6.73472 10.2346 6.70333C10.157 6.67195 10.074 6.65645 9.99033 6.65776ZM10.0001 13.3334C9.77909 13.3334 9.56712 13.4212 9.41084 13.5775C9.25456 13.7337 9.16677 13.9457 9.16677 14.1667C9.16677 14.3877 9.25456 14.5997 9.41084 14.756C9.56712 14.9122 9.77909 15 10.0001 15C10.2211 15 10.4331 14.9122 10.5894 14.756C10.7456 14.5997 10.8334 14.3877 10.8334 14.1667C10.8334 13.9457 10.7456 13.7337 10.5894 13.5775C10.4331 13.4212 10.2211 13.3334 10.0001 13.3334Z" fill="#E84045" />
-      </svg>
-    ),
+    icon: TriangleAlertIcon,
     label: 'Incident Escalation Rate',
     value: '10%',
-    trendIconSvg: (
-      <svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <rect width="28" height="28" rx="14" fill="#40E5D1" fillOpacity="0.4" />
-        <path d="M18.4987 15.3889L13.9987 19.8334M13.9987 19.8334L9.49866 15.3889M13.9987 19.8334V8.16671" stroke="#40E5D1" strokeWidth="2" strokeLinecap="square" />
-      </svg>
-    ),
+    trend: 'down',
     delay: 0.1,
   },
 ];
 
-function IncidentSummaryCard(): JSX.Element {
+function ChartBar({ item, index }: { item: CategoryData; index: number }) {
+  const width = `${(item.value / MAX_CATEGORY_VALUE) * 100}%`;
+
   return (
-    <div className="flex flex-col pt-4 pb-4 bg-white dark:bg-black rounded-3xl shadow-[11px_21px_3px_rgba(0,0,0,0.06),14px_27px_7px_rgba(0,0,0,0.10),19px_38px_14px_rgba(0,0,0,0.13),27px_54px_27px_rgba(0,0,0,0.16),39px_78px_50px_rgba(0,0,0,0.20),55px_110px_86px_rgba(0,0,0,0.26)] w-[375px] h-[560px] overflow-hidden transition-colors duration-300">
-      <h3 className="text-3xl text-left p-7 pt-6 pb-8 font-bold text-neutral-800 dark:text-white">
-        Incident Report
-      </h3>
-      <div className="flex-grow px-4 h-[200px]"> {/* Explicit height for chart container */}
-        <BarChart
-          id="horizontal-incident-summary-chart"
-          height={200} // Explicit height for the chart itself
-          data={validatedCategoryData}
-          yAxis={
-            <LinearYAxis
-              type="category"
-              tickSeries={
-                <LinearYAxisTickSeries
-                  label={
-                    <LinearYAxisTickLabel
-                      format={(text: string) => (text.length > 5 ? `${text.slice(0, 5)}...` : text)}
-                      fill="#9A9AAF" // Dark/light theme compatible color
-                    />
-                  }
-                />
-              }
-            />
-          }
-          xAxis={
-            <LinearXAxis
-              type="value"
-              axisLine={null}
-              tickSeries={
-                <LinearXAxisTickSeries
-                  label={null}
-                  line={null}
-                  tickSize={10} // Optimized tickSize
-                />
-              }
-            />
-          }
-          series={
-            <BarSeries
-              layout="horizontal"
-              bar={
-                <Bar
-                  glow={{
-                    blur: 20,
-                    opacity: 0.5,
-                  }}
-                  gradient={null}
-                />
-              }
-              colorScheme={chartColors}
-              padding={0.2}
-            />
-          }
-          gridlines={
-            <GridlineSeries
-              line={<Gridline strokeColor="#7E7E8F75" />} // Specific color for gridlines
-            />
-          }
+    <motion.div
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: 0.05 * index }}
+      className="space-y-2"
+    >
+      <div className="flex items-center justify-between gap-3 text-xs uppercase tracking-[0.18em] text-neutral-500 dark:text-[#9A9AAF]">
+        <span>{item.key}</span>
+        <span className="font-mono text-[0.72rem]">{item.value}</span>
+      </div>
+      <div className="h-3 overflow-hidden rounded-full bg-neutral-200 dark:bg-[#1A1A23]">
+        <motion.div
+          initial={{ width: 0 }}
+          animate={{ width }}
+          transition={{ delay: 0.08 * index, duration: 0.4, ease: 'easeOut' }}
+          className="h-full rounded-full"
+          style={{ backgroundColor: item.color }}
         />
       </div>
-      <div className="flex flex-col pl-8 pr-8 pt-8 font-mono divide-y divide-neutral-200 dark:divide-[#262631]">
-        {metrics.map(metric => (
+    </motion.div>
+  );
+}
+
+function IncidentSummaryCard(): JSX.Element {
+  return (
+    <div className="flex h-[560px] w-[375px] flex-col overflow-hidden rounded-3xl bg-white pt-4 pb-4 shadow-[11px_21px_3px_rgba(0,0,0,0.06),14px_27px_7px_rgba(0,0,0,0.10),19px_38px_14px_rgba(0,0,0,0.13),27px_54px_27px_rgba(0,0,0,0.16),39px_78px_50px_rgba(0,0,0,0.20),55px_110px_86px_rgba(0,0,0,0.26)] transition-colors duration-300 dark:bg-black">
+      <h3 className="px-7 pt-6 pb-8 text-left text-3xl font-bold text-neutral-800 dark:text-white">
+        Incident Report
+      </h3>
+
+      <div className="flex-grow px-6">
+        <div className="rounded-[1.5rem] border border-neutral-200/80 bg-neutral-50/90 p-5 dark:border-[#1F1F29] dark:bg-[#101018]">
+          <div className="mb-4 flex items-center justify-between">
+            <span className="text-xs font-semibold uppercase tracking-[0.24em] text-neutral-500 dark:text-[#9A9AAF]">
+              Threat mix
+            </span>
+            <span className="rounded-full border border-neutral-200 px-2.5 py-1 text-[0.7rem] font-medium text-neutral-500 dark:border-[#262631] dark:text-[#9A9AAF]">
+              Placeholder demo
+            </span>
+          </div>
+          <div className="space-y-4">
+            {CATEGORY_DATA.map((item, index) => (
+              <ChartBar key={item.key} item={item} index={index} />
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-col divide-y divide-neutral-200 px-8 pt-8 font-mono dark:divide-[#262631]">
+        {METRICS.map((metric) => (
           <motion.div
             key={metric.id}
-            initial={{
-              opacity: 0,
-              y: 20,
-            }}
-            animate={{
-              opacity: 1,
-              y: 0,
-            }}
-            transition={{
-              delay: metric.delay,
-            }}
-            className="flex w-full pb-4 pt-4 items-center gap-2"
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: metric.delay }}
+            className="flex w-full items-center gap-2 pt-4 pb-4"
           >
-            <div className="flex flex-row gap-2 items-center text-base w-1/2 text-neutral-500 dark:text-[#9A9AAF]">
-              {metric.iconSvg}
+            <div className="flex w-1/2 items-center gap-2 text-base text-neutral-500 dark:text-[#9A9AAF]">
+              <metric.icon />
               <span className="truncate" title={metric.label}>
                 {metric.label}
               </span>
             </div>
-            <div className="flex gap-2 w-1/2 justify-end items-center">
-              <span className="font-semibold text-xl text-neutral-800 dark:text-white">{metric.value}</span>
-              {metric.trendIconSvg}
+            <div className="flex w-1/2 items-center justify-end gap-2">
+              <span className="text-xl font-semibold text-neutral-800 dark:text-white">{metric.value}</span>
+              <TrendBadge direction={metric.trend} />
             </div>
           </motion.div>
         ))}

--- a/apps/web/components/leads-data-table.tsx
+++ b/apps/web/components/leads-data-table.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
+import { motion, AnimatePresence, useReducedMotion } from "motion/react";
 import { useTheme } from "next-themes";
 import { ChevronDown, MoreHorizontal } from "lucide-react";
 

--- a/apps/web/components/server-management-table.tsx
+++ b/apps/web/components/server-management-table.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, motion } from "motion/react";
 import {
   MonitorCog,
   Pause,

--- a/apps/web/components/ui/animated-dropdown.tsx
+++ b/apps/web/components/ui/animated-dropdown.tsx
@@ -12,7 +12,7 @@ import React from 'react'
  */
 import { useState, useRef, FC, ReactNode } from 'react'
 import { ChevronDown } from 'lucide-react'
-import { AnimatePresence, motion } from 'framer-motion'
+import { AnimatePresence, motion } from 'motion/react'
 import { clsx, type ClassValue } from 'clsx'
 import { twMerge } from 'tailwind-merge'
 function cn(...inputs: ClassValue[]) { return twMerge(clsx(inputs)) }

--- a/apps/web/components/ui/interactive-hover-button.tsx
+++ b/apps/web/components/ui/interactive-hover-button.tsx
@@ -10,7 +10,7 @@
  */
 import React, { useState } from 'react'
 import { ArrowRight, Check } from 'lucide-react'
-import { AnimatePresence, motion, type HTMLMotionProps } from 'framer-motion'
+import { AnimatePresence, motion, type HTMLMotionProps } from 'motion/react'
 import { clsx, type ClassValue } from 'clsx'
 import { twMerge } from 'tailwind-merge'
 function cn(...inputs: ClassValue[]) { return twMerge(clsx(inputs)) }

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -20,7 +20,6 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
-        "framer-motion": "^12.38.0",
         "lucide-react": "^1.7.0",
         "motion": "^12.38.0",
         "next": "16.2.2",
@@ -29,7 +28,6 @@
         "react-countup": "^6.5.3",
         "react-day-picker": "^9.14.0",
         "react-dom": "19.2.4",
-        "reaviz": "^16.1.2",
         "shadcn": "^4.2.0",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0"
@@ -924,21 +922,6 @@
       "dependencies": {
         "@floating-ui/core": "^1.7.5",
         "@floating-ui/utils": "^0.2.11"
-      }
-    },
-    "node_modules/@floating-ui/react": {
-      "version": "0.27.19",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.19.tgz",
-      "integrity": "sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/react-dom": "^2.1.8",
-        "@floating-ui/utils": "^0.2.11",
-        "tabbable": "^6.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=17.0.0",
-        "react-dom": ">=17.0.0"
       }
     },
     "node_modules/@floating-ui/react-dom": {
@@ -3044,32 +3027,6 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
-    "node_modules/@reaviz/react-use-fuzzy": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@reaviz/react-use-fuzzy/-/react-use-fuzzy-1.0.3.tgz",
-      "integrity": "sha512-ON5RxiI0r9zNpEKHvxqT8zz3iI4kzc37NzB4t8lfXSWwCEkpzxWY9TB2JAdYp9LC3UW2tN9zxdMnaNBLz4atTw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "fuse.js": "^6.6.2",
-        "react": ">= 16"
-      }
-    },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.18.0.tgz",
-      "integrity": "sha512-xuglR2rBVHA5UsI8h8UbX4VJ470PtGCf5Vpswh7p2ukaqBGFTnsfzxUBetoWBWymHMxbIG0Cmx7Y9qDZzr648w==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -3480,21 +3437,6 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@types/d3": {
-      "version": "3.5.53",
-      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-3.5.53.tgz",
-      "integrity": "sha512-8yKQA9cAS6+wGsJpBysmnhlaaxlN42Qizqkw+h2nILSlS+MAG2z4JdO6p+PJrJ+ACvimkmLJL281h157e52psQ==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-cloud": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-cloud/-/d3-cloud-1.2.9.tgz",
-      "integrity": "sha512-5EWJvnlCrqTThGp8lYHx+DL00sOjx2HTlXH1WRe93k5pfOIhPQaL63NttaKYIbT7bTXp/USiunjNS/N4ipttIQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3": "^3"
       }
     },
     "node_modules/@types/estree": {
@@ -4148,16 +4090,6 @@
         "win32"
       ]
     },
-    "node_modules/@upsetjs/venn.js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
-      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
-      "license": "MIT",
-      "optionalDependencies": {
-        "d3-selection": "^3.0.0",
-        "d3-transition": "^3.0.1"
-      }
-    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -4558,15 +4490,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/big-integer": {
-      "version": "1.6.52",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
-      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
-      "license": "Unlicense",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -4590,12 +4513,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/body-scroll-lock-upgrade": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/body-scroll-lock-upgrade/-/body-scroll-lock-upgrade-1.1.0.tgz",
-      "integrity": "sha512-nnfVAS+tB7CS9RaksuHVTpgHWHF7fE/ptIBJnwZrMqImIvWJF1OGcLnMpBhC6qhkx9oelvyxmWXwmIJXCV98Sw==",
-      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.13",
@@ -4771,12 +4688,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/chroma-js": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-3.2.0.tgz",
-      "integrity": "sha512-os/OippSlX1RlWWr+QDPcGUZs0uoqr32urfxESG9U93lhUfbnlyckte84Q8P1UQY/qth983AS1JONKmLS4T0nw==",
-      "license": "(BSD-3-Clause AND Apache-2.0)"
-    },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
@@ -4788,12 +4699,6 @@
       "funding": {
         "url": "https://polar.sh/cva"
       }
-    },
-    "node_modules/classnames": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
-      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
-      "license": "MIT"
     },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
@@ -5053,19 +4958,6 @@
       "integrity": "sha512-QQpZx7oYxsR+OeITlZe46fY/OQjV11oBqjY8wgIXzLU2jIz8GzOrbMhqKLysGY8bWI3T1ZNrYkwGzKb4JNgyzg==",
       "license": "MIT"
     },
-    "node_modules/coverup": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/coverup/-/coverup-0.1.1.tgz",
-      "integrity": "sha512-Q2Fs0v3M4eMNfj0TGaFb4Oh0yuaQj9EhQbEKtFhD3Tm4HZt1Zn7TrBKX14gVEO9aeWP8KnF2/qrh7fr/rvbcXw==",
-      "deprecated": "No longer maintained",
-      "license": "MIT"
-    },
-    "node_modules/create-global-state-hook": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/create-global-state-hook/-/create-global-state-hook-0.0.2.tgz",
-      "integrity": "sha512-+1gRNwtuSQIC9lQQngfcY1VARKs6R32KJjI1bFrsp0W5MbauupRW/uQF0f+ElXx8xMmuEK9wl5zqAslzj6GvCA==",
-      "license": "MIT"
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5098,244 +4990,6 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
-    },
-    "node_modules/ctrl-keys": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/ctrl-keys/-/ctrl-keys-1.0.6.tgz",
-      "integrity": "sha512-fENSKrbIfvX83uHxruP3S/9GizirvgT66vHhgKHOCTVHK+22Xpud/vttg5c5IifRl+6Gom/GjE+ZSXJKf0DMTA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/d3-array": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
-      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-      "license": "ISC",
-      "dependencies": {
-        "internmap": "1 - 2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-cloud": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/d3-cloud/-/d3-cloud-1.2.9.tgz",
-      "integrity": "sha512-leL1GLneC9ZQtnV+6TGWrNlGfI1WX7S2arcTv2vae12DaXo5wjm6GBCkskXbrDlyOymd/A75Pyj1H37MW4BZ/Q==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-dispatch": "^1.0.3"
-      }
-    },
-    "node_modules/d3-color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-dispatch": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
-      "integrity": "sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-ease": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
-      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-format": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
-      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-geo": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
-      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2.5.0 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-hierarchy": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
-      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-interpolate": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-color": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
-      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-sankey": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
-      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-array": "1 - 2",
-        "d3-shape": "^1.2.0"
-      }
-    },
-    "node_modules/d3-sankey/node_modules/d3-array": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
-      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "internmap": "^1.0.0"
-      }
-    },
-    "node_modules/d3-sankey/node_modules/d3-path": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
-      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-sankey/node_modules/d3-shape": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
-      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-path": "1"
-      }
-    },
-    "node_modules/d3-sankey/node_modules/internmap": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
-      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
-      "license": "ISC"
-    },
-    "node_modules/d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2.10.0 - 3",
-        "d3-format": "1 - 3",
-        "d3-interpolate": "1.2.0 - 3",
-        "d3-time": "2.1.1 - 3",
-        "d3-time-format": "2 - 4"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-selection": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
-      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-shape": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
-      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-path": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
-      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time-format": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
-      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-time": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-timer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
-      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-transition": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
-      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "d3-color": "1 - 3",
-        "d3-dispatch": "1 - 3",
-        "d3-ease": "1 - 3",
-        "d3-interpolate": "1 - 3",
-        "d3-timer": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "d3-selection": "2 - 3"
-      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -5647,12 +5301,6 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.332.tgz",
       "integrity": "sha512-7OOtytmh/rINMLwaFTbcMVvYXO3AUm029X0LcyfYk0B557RlPkdpTpnH9+htMlfu5dKwOmT0+Zs2Aw+lnn6TeQ==",
       "license": "ISC"
-    },
-    "node_modules/ellipsize": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/ellipsize/-/ellipsize-0.6.2.tgz",
-      "integrity": "sha512-zB4m5iEETalVrrP8RzcF0Qzqyw3MkUQ4R43NiczRAp0Hpp0+0bRdwKnoaFXyJoVJCipm2/3xc7Hkg0OOAorUPw==",
-      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -6638,30 +6286,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/focus-trap": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
-      "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
-      "license": "MIT",
-      "dependencies": {
-        "tabbable": "^6.4.0"
-      }
-    },
-    "node_modules/focus-trap-react": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-10.3.1.tgz",
-      "integrity": "sha512-PN4Ya9xf9nyj/Nd9VxBNMuD7IrlRbmaG6POAQ8VLqgtc6IY/Ln1tYakow+UIq4fihYYYFM70/2oyidE6bbiPgw==",
-      "license": "MIT",
-      "dependencies": {
-        "focus-trap": "^7.6.1",
-        "tabbable": "^6.2.0"
-      },
-      "peerDependencies": {
-        "prop-types": "^15.8.1",
-        "react": ">=16.3.0",
-        "react-dom": ">=16.3.0"
-      }
-    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -6801,15 +6425,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/fuse.js": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
-      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/fuzzysort": {
@@ -7148,12 +6763,6 @@
         "hermes-estree": "0.25.1"
       }
     },
-    "node_modules/highlight-words-core": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/highlight-words-core/-/highlight-words-core-1.2.3.tgz",
-      "integrity": "sha512-m1O9HW3/GNHxzSIXWw1wCNXXsgLlxrP0OI6+ycGUhiUHkikqW3OrwVHz+lxeNBe5yqLESdIcj8PowHQ2zLvUvQ==",
-      "license": "MIT"
-    },
     "node_modules/hono": {
       "version": "4.12.12",
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
@@ -7194,15 +6803,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/human-format": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/human-format/-/human-format-1.2.1.tgz",
-      "integrity": "sha512-o5Ldz62VWR5lYUZ8aVQaLKiN37NsHnmk3xjMoUjza3mGkk8MvMofgZT0T6HKSCKSJIir+AWk9Dx8KhxvZAUgCg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/human-signals": {
@@ -7285,21 +6885,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/internmap": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/invert-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/invert-color/-/invert-color-2.0.0.tgz",
-      "integrity": "sha512-9s6IATlhOAr0/0MPUpLdMpk81ixIu8IqwPwORssXBauFT/4ff/iyEOcojd0UYuPwkDbJvL1+blIZGhqVIaAm5Q==",
-      "license": "MIT"
     },
     "node_modules/ip-address": {
       "version": "10.1.0",
@@ -8442,6 +8027,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -8495,12 +8081,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/memoize-one": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.3.tgz",
-      "integrity": "sha512-QmpUu4KqDmX0plH4u+tf0riMc1KHE1+lw95cMrLlXQAFOx/xnBtwhZ52XJxd9X2O6kwKBqX32kmhbhlobD0cuw==",
-      "license": "MIT"
     },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
@@ -8722,12 +8302,6 @@
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
-    },
-    "node_modules/name-initials": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/name-initials/-/name-initials-0.1.3.tgz",
-      "integrity": "sha512-UJcpCmyftGuZ7I46dqOw776VvH3VqHhAM7ma4eyY0t52FahFv/VhmDqSeekwSZFXyK9HLg9MXmb9udeOJ3YtCA==",
-      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -9404,15 +8978,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/pluralize": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
-      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -9527,6 +9092,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -9616,52 +9182,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/reablocks": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/reablocks/-/reablocks-9.4.1.tgz",
-      "integrity": "sha512-WiicdjqkgZeJZGQop9fWLafEeaYVaVOse3o7Z+Y3YGDuMcxkmkBS3qQvCDVGNW6DZvSGN3cQuaTE8Wa4G9BTcQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@floating-ui/react": "^0.27.16",
-        "@reaviz/react-use-fuzzy": "^1.0.3",
-        "body-scroll-lock-upgrade": "^1.1.0",
-        "chroma-js": "^3.1.2",
-        "classnames": "^2.5.1",
-        "coverup": "^0.1.1",
-        "create-global-state-hook": "^0.0.2",
-        "ctrl-keys": "^1.0.6",
-        "date-fns": "^4.1.0",
-        "ellipsize": "^0.6.2",
-        "focus-trap-react": "^10.3.1",
-        "fuse.js": "^6.6.2",
-        "human-format": "^1.2.1",
-        "motion": "^12.23.12",
-        "name-initials": "^0.1.3",
-        "pluralize": "^8.0.0",
-        "react-fast-compare": "^3.2.2",
-        "react-highlight-words": "^0.21.0",
-        "react-textarea-autosize": "^8.5.9",
-        "tailwind-merge": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=22",
-        "npm": ">=10.8.2"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/reablocks/node_modules/tailwind-merge": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.1.tgz",
-      "integrity": "sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/dcastil"
-      }
-    },
     "node_modules/react": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
@@ -9717,29 +9237,11 @@
         "react": "^19.2.4"
       }
     },
-    "node_modules/react-fast-compare": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
-      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
-      "license": "MIT"
-    },
-    "node_modules/react-highlight-words": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/react-highlight-words/-/react-highlight-words-0.21.0.tgz",
-      "integrity": "sha512-SdWEeU9fIINArEPO1rO5OxPyuhdEKZQhHzZZP1ie6UeXQf+CjycT1kWaB+9bwGcVbR0NowuHK3RqgqNg6bgBDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "highlight-words-core": "^1.2.0",
-        "memoize-one": "^4.0.0"
-      },
-      "peerDependencies": {
-        "react": "^0.14.0 || ^15.0.0 || ^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
-      }
-    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-remove-scroll": {
@@ -9809,90 +9311,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-textarea-autosize": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.9.tgz",
-      "integrity": "sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "use-composed-ref": "^1.3.0",
-        "use-latest": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/reaviz": {
-      "version": "16.1.2",
-      "resolved": "https://registry.npmjs.org/reaviz/-/reaviz-16.1.2.tgz",
-      "integrity": "sha512-w79c7e1jYKZgY1MQ9RDkF/r5lzAX51nIpX+j926m0G0Gs+v8FkE3HWbN2CqhGF4vBZdbPkmc1tLhg5jqcJcpBw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@floating-ui/dom": "^1.7.4",
-        "@types/d3-cloud": "^1.2.9",
-        "@upsetjs/venn.js": "^2.0.0",
-        "big-integer": "^1.6.52",
-        "chroma-js": "^3.1.2",
-        "classnames": "^2.5.1",
-        "d3-array": "^3.2.4",
-        "d3-cloud": "^1.2.7",
-        "d3-format": "^3.1.0",
-        "d3-geo": "^3.1.1",
-        "d3-hierarchy": "^3.1.2",
-        "d3-interpolate": "^3.0.1",
-        "d3-sankey": "^0.12.3",
-        "d3-scale": "^4.0.2",
-        "d3-shape": "^3.2.0",
-        "d3-time": "^3.1.0",
-        "ellipsize": "^0.6.2",
-        "human-format": "^1.2.1",
-        "invert-color": "^2.0.0",
-        "motion": "^12.23.12",
-        "reablocks": "^9.2.2",
-        "react-fast-compare": "^3.2.2",
-        "reaviz-data-utils": "^1.0.0",
-        "safe-identifier": "^0.4.2",
-        "transformation-matrix": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/reaviz/node_modules/date-fns": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
-      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
-      }
-    },
-    "node_modules/reaviz/node_modules/reaviz-data-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/reaviz-data-utils/-/reaviz-data-utils-1.0.0.tgz",
-      "integrity": "sha512-I1sUNF8E1fuV4XZwEnh5M9vEUlbyM5rWW3EO53hLUWHTzc43ScTVWbs9LncSTvL93GmwW+sVeotLzDq1WRz0Rw==",
-      "license": "ISC",
-      "dependencies": {
-        "big-integer": "^1.6.52",
-        "d3-array": "^3.2.4",
-        "date-fns": "^3.6.0"
-      },
-      "optionalDependencies": {
-        "@rollup/rollup-linux-x64-gnu": "4.18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.3.1"
       }
     },
     "node_modules/recast": {
@@ -10134,12 +9552,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/safe-identifier": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/safe-identifier/-/safe-identifier-0.4.2.tgz",
-      "integrity": "sha512-6pNbSMW6OhAi9j+N8V+U715yBQsaWJ7eyEUaOrawX+isg5ZxhUlV1NipNtgaKHmFGiABwt+ZF04Ii+3Xjkg+8w==",
-      "license": "ISC"
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -11033,15 +10445,6 @@
         "node": ">=16"
       }
     },
-    "node_modules/transformation-matrix": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/transformation-matrix/-/transformation-matrix-3.1.0.tgz",
-      "integrity": "sha512-oYubRWTi2tYFHAL2J8DLvPIqIYcYZ0fSOi2vmSy042Ho4jBW2ce6VP7QfD44t65WQz6bw5w1Pk22J7lcUpaTKA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/chrvadala"
-      }
-    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -11418,51 +10821,6 @@
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/use-composed-ref": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.4.0.tgz",
-      "integrity": "sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/use-isomorphic-layout-effect": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz",
-      "integrity": "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/use-latest": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.3.0.tgz",
-      "integrity": "sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "use-isomorphic-layout-effect": "^1.1.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,7 +24,6 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
-    "framer-motion": "^12.38.0",
     "lucide-react": "^1.7.0",
     "motion": "^12.38.0",
     "next": "16.2.2",
@@ -33,7 +32,6 @@
     "react-countup": "^6.5.3",
     "react-day-picker": "^9.14.0",
     "react-dom": "19.2.4",
-    "reaviz": "^16.1.2",
     "shadcn": "^4.2.0",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0"


### PR DESCRIPTION
## Summary
- remove the direct `reaviz` dependency and replace the two `/design-system` chart demos with lightweight SVG/HTML implementations
- standardize all local animation imports on `motion/react` and drop the direct `framer-motion` dependency from `package.json`
- keep `/empresas` lint-safe by remounting the client loader per `requestHref`, avoiding the synchronous `setState` inside `useEffect`

## Evidence
- baseline `.next/static/chunks` total: `2241115` bytes across `40` files
- final `.next/static/chunks` total: `1726306` bytes across `38` files
- `node_modules/reaviz`: removed (`Test-Path node_modules\\reaviz` -> `False`)
- note: `motion@12.38.0` still carries `framer-motion@12.38.0` transitively; this PR removes the duplicate direct dependency and standardizes imports, but cannot eliminate that transitive package without changing Motion itself

## Validation
- `npm run typecheck`
- `npm run test:unit`
- `npm run lint` (warnings only; no errors)
- `npm run build`

Closes #106