### PR TITLE
perf(dashboard): cache shared CVMReadService in Streamlit

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -31,7 +31,7 @@ st.set_page_config(
 
 import pandas as pd
 
-from src.read_service import CVMReadService
+from dashboard.services import get_read_service
 from src.startup import StartupReport, collect_startup_report, format_startup_report
 from dashboard.components.search_bar import render_sidebar
 from dashboard.tabs import demonstracoes, download, visao_geral
@@ -51,7 +51,7 @@ st.markdown(
 
 @st.cache_data(ttl=600, show_spinner="Carregando demonstracoes...")
 def load_statements(cd_cvm: int, years: tuple[int, ...]) -> dict[str, pd.DataFrame]:
-    read_service = CVMReadService()
+    read_service = get_read_service()
     years_list = list(years)
     return {
         stmt: read_service.get_statement_dataframe(cd_cvm, years_list, stmt)
@@ -61,13 +61,13 @@ def load_statements(cd_cvm: int, years: tuple[int, ...]) -> dict[str, pd.DataFra
 
 @st.cache_data(ttl=600, show_spinner="Calculando KPIs...")
 def load_kpis(cd_cvm: int, years: tuple[int, ...]) -> pd.DataFrame:
-    bundle = CVMReadService().get_kpi_bundle(cd_cvm, list(years))
+    bundle = get_read_service().get_kpi_bundle(cd_cvm, list(years))
     return bundle.annual_dataframe()
 
 
 @st.cache_data(ttl=600, show_spinner="Calculando KPIs trimestrais...")
 def load_quarterly_kpis(cd_cvm: int, years: tuple[int, ...]) -> pd.DataFrame:
-    bundle = CVMReadService().get_kpi_bundle(cd_cvm, list(years))
+    bundle = get_read_service().get_kpi_bundle(cd_cvm, list(years))
     return bundle.quarterly_dataframe()
 
 

--- a/dashboard/components/search_bar.py
+++ b/dashboard/components/search_bar.py
@@ -16,12 +16,12 @@ if _PROJECT_ROOT not in sys.path:
 import streamlit as st
 import pandas as pd
 
-from src.read_service import CVMReadService
+from dashboard.services import get_read_service
 
 
 @st.cache_data(ttl=300)
 def _load_companies(search: str) -> pd.DataFrame:
-    return CVMReadService().search_companies_df(search)
+    return get_read_service().search_companies_df(search)
 
 
 def render_sidebar() -> tuple[dict | None, list[int], bool]:
@@ -73,7 +73,7 @@ def render_sidebar() -> tuple[dict | None, list[int], bool]:
     cd_cvm = int(row["cd_cvm"])
 
     # Metadados da empresa selecionada
-    read_service = CVMReadService()
+    read_service = get_read_service()
     company_info = read_service.get_company_info_dict(cd_cvm)
     available_years = read_service.get_available_years(cd_cvm)
 

--- a/dashboard/services.py
+++ b/dashboard/services.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import streamlit as st
+
+_PROJECT_ROOT = str(Path(__file__).resolve().parent.parent)
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+from src.read_service import CVMReadService
+
+
+@st.cache_resource
+def get_read_service() -> CVMReadService:
+    # The dashboard is read-only, so one shared read service per process is sufficient.
+    return CVMReadService()

--- a/tests/test_dashboard_services.py
+++ b/tests/test_dashboard_services.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from dashboard import services
+
+
+def test_get_read_service_reuses_single_cached_instance(monkeypatch):
+    created_instances = []
+
+    class FakeReadService:
+        def __init__(self):
+            created_instances.append(self)
+
+    monkeypatch.setattr(services, "CVMReadService", FakeReadService)
+    services.get_read_service.clear()
+    try:
+        first = services.get_read_service()
+        second = services.get_read_service()
+    finally:
+        services.get_read_service.clear()
+
+    assert first is second
+    assert created_instances == [first]


### PR DESCRIPTION
## Summary
- add a shared `@st.cache_resource` factory for the dashboard read service
- replace direct `CVMReadService()` construction in dashboard app and sidebar codepaths
- add a targeted unit test that confirms the cached factory reuses a single instance

## Verification
- `pytest tests/test_dashboard_services.py tests/test_read_service.py`
- `python -c "import dashboard.app; import dashboard.components.search_bar; print('imports-ok')"`

## Notes
- `dashboard/app.py` is classified as `critical-runtime`, so this PR starts as draft per policy
- the shared helper avoids an awkward import dependency between `dashboard/app.py` and `dashboard/components/search_bar.py`

Closes #107
