### PR TITLE
perf(backend): cache /companies/filters and /sectors/{slug}, eliminate sector over-fetch

### DIFF
--- a/apps/api/app/routes/companies.py
+++ b/apps/api/app/routes/companies.py
@@ -36,6 +36,7 @@ from src.read_service import CVMReadService
 router = APIRouter(tags=["companies"])
 
 COMPANY_DIRECTORY_CACHE_CONTROL = "public, max-age=300, stale-while-revalidate=3600"
+COMPANY_FILTERS_CACHE_CONTROL = "public, max-age=3600, stale-while-revalidate=86400"
 COMPANY_INFO_CACHE_CONTROL = "public, max-age=3600"
 COMPANY_YEARS_CACHE_CONTROL = "public, max-age=86400, stale-while-revalidate=604800"
 COMPANY_DATA_CACHE_CONTROL = "public, max-age=600"
@@ -81,9 +82,11 @@ def list_companies(
 )
 def get_company_filters(
     request: Request,
+    response: Response,
     service: CVMReadService = Depends(get_read_service),
 ) -> CompanyFiltersPayload:
     ensure_api_ready(get_settings(request))
+    _apply_cache_headers(response, COMPANY_FILTERS_CACHE_CONTROL)
     return present_company_filters(service.get_company_filters())
 
 

--- a/apps/api/app/routes/sectors.py
+++ b/apps/api/app/routes/sectors.py
@@ -22,6 +22,7 @@ from src.read_service import CVMReadService
 router = APIRouter(tags=["sectors"])
 
 SECTOR_DIRECTORY_CACHE_CONTROL = "public, max-age=3600, stale-while-revalidate=86400"
+SECTOR_DETAIL_CACHE_CONTROL = "public, max-age=3600, stale-while-revalidate=86400"
 
 
 def _apply_cache_headers(response: Response, cache_control: str) -> None:
@@ -55,6 +56,7 @@ def list_sectors(
 def get_sector_detail(
     sector_slug: str,
     request: Request,
+    response: Response,
     year: int | None = Depends(optional_year_dependency),
     service: CVMReadService = Depends(get_read_service),
 ) -> SectorDetailPayload:
@@ -67,4 +69,5 @@ def get_sector_detail(
     if detail is None:
         raise NotFoundError(f"Setor '{sector_slug}' nao encontrado.")
 
+    _apply_cache_headers(response, SECTOR_DETAIL_CACHE_CONTROL)
     return present_sector_detail(detail)

--- a/apps/api/tests/test_api_contract.py
+++ b/apps/api/tests/test_api_contract.py
@@ -128,6 +128,8 @@ def test_companies_empty_search_returns_paginated_directory(client: TestClient):
             "public, max-age=600",
         ),
         ("/sectors", None, "public, max-age=3600, stale-while-revalidate=86400"),
+        ("/sectors/energia", None, "public, max-age=3600, stale-while-revalidate=86400"),
+        ("/companies/filters", None, "public, max-age=3600, stale-while-revalidate=86400"),
     ],
 )
 def test_cacheable_endpoints_expose_cache_headers(

--- a/docs/V2_API_CONTRACT.md
+++ b/docs/V2_API_CONTRACT.md
@@ -110,6 +110,11 @@ Resposta exemplo:
 }
 ```
 
+Regras do endpoint:
+- headers de cache:
+  - `Cache-Control: public, max-age=3600, stale-while-revalidate=86400`
+  - `Vary: Origin`
+
 ### `GET /sectors`
 
 Uso:
@@ -186,6 +191,9 @@ Regras do endpoint:
 - `companies` sai ordenado por `roe DESC`, depois `company_name ASC`, com `null` no fim
 - `yearly_overview` agrega `roe`, `mg_ebit` e `mg_liq` por ano, ignorando valores ausentes
 - `companies` do `selected_year` continuam presentes mesmo quando as metricas do ano vierem `null`
+- headers de cache (apenas em respostas 200; 404/422 nao recebem header):
+  - `Cache-Control: public, max-age=3600, stale-while-revalidate=86400`
+  - `Vary: Origin`
 
 ### `GET /companies/{cd_cvm}`
 

--- a/src/query_layer.py
+++ b/src/query_layer.py
@@ -215,6 +215,47 @@ class CVMQueryLayer:
         df = pd.read_sql(sql, self.engine, params={"sector_name": str(sector_name)})
         return [int(year) for year in df["REPORT_YEAR"].tolist()]
 
+    def get_sector_years_map(self) -> dict[str, list[int]]:
+        """Returns sector_name → sorted list of years with annual data, for all sectors at once."""
+        sql = text(
+            f"""
+            SELECT DISTINCT {_CANONICAL_SECTOR_SQL} AS sector_name, fr."REPORT_YEAR"
+            FROM financial_reports fr
+            JOIN companies c ON c.cd_cvm = fr."CD_CVM"
+            WHERE fr."PERIOD_LABEL" = CAST(fr."REPORT_YEAR" AS TEXT)
+            ORDER BY sector_name, fr."REPORT_YEAR"
+            """
+        )
+        df = pd.read_sql(sql, self.engine)
+        result: dict[str, list[int]] = {}
+        for _, row in df.iterrows():
+            result.setdefault(str(row["sector_name"]), []).append(int(row["REPORT_YEAR"]))
+        return result
+
+    def get_sector_companies(self, sector_name: str) -> tuple[pd.DataFrame, int]:
+        """Returns (df[cd_cvm, company_name, ticker_b3], total_count) for a sector.
+
+        Lighter than get_companies_directory_page(page_size=None): no LEFT JOIN to
+        financial_reports, no aggregation columns.
+        """
+        params = {"sector_name": str(sector_name)}
+        count_sql = text(
+            f"SELECT COUNT(*) AS total_items FROM companies c WHERE {_CANONICAL_SECTOR_SQL} = :sector_name"
+        )
+        total_items = int(
+            pd.read_sql(count_sql, self.engine, params=params).iloc[0]["total_items"]
+        )
+        rows_sql = text(
+            f"""
+            SELECT c.cd_cvm, c.company_name, COALESCE(c.ticker_b3, '') AS ticker_b3
+            FROM companies c
+            WHERE {_CANONICAL_SECTOR_SQL} = :sector_name
+            ORDER BY c.company_name ASC
+            """
+        )
+        df = pd.read_sql(rows_sql, self.engine, params=params)
+        return df.reset_index(drop=True), total_items
+
     @slow_query_warn(threshold_ms=200)
     def get_sector_metric_rows(
         self,

--- a/src/read_service.py
+++ b/src/read_service.py
@@ -182,15 +182,14 @@ class CVMReadService:
 
     def list_sectors(self) -> SectorDirectoryDTO:
         sectors_df = self.query_layer.get_available_company_sectors()
-        companies_df = self.query_layer.get_companies()
+        sector_years = self.query_layer.get_sector_years_map()
         metric_rows = self.query_layer.get_sector_metric_rows()
         yearly = self._aggregate_sector_yearly_metrics(metric_rows)
 
         items: list[SectorDirectoryItemDTO] = []
         for _, row in sectors_df.iterrows():
             sector_name = str(row["sector_name"])
-            sector_companies = companies_df[companies_df["sector_name"] == sector_name]
-            available_years = self._extract_years_from_company_rows(sector_companies)
+            available_years = sector_years.get(sector_name, [])
             latest_year = max(available_years) if available_years else None
             snapshot_row = None
             if latest_year is not None and not yearly.empty:
@@ -225,12 +224,7 @@ class CVMReadService:
         if resolved_sector_name is None:
             return None
 
-        company_rows, total_items = self.query_layer.get_companies_directory_page(
-            search="",
-            sector_name=resolved_sector_name,
-            page=1,
-            page_size=None,
-        )
+        company_rows, total_items = self.query_layer.get_sector_companies(resolved_sector_name)
         if company_rows.empty:
             return None
 


### PR DESCRIPTION
## Summary

- **Cache headers**: `GET /companies/filters` and `GET /sectors/{slug}` now return `Cache-Control: public, max-age=3600, stale-while-revalidate=86400` + `Vary: Origin`. Headers are applied after 404/422 guards so only 200 responses are cached.
- **Eliminate `list_sectors()` over-fetch**: replaced `get_companies()` (full-table `get_companies_directory_page(page_size=None)` + `get_company_years_map()` for every company) with a new `get_sector_years_map()` — a single lightweight query that returns all sector→years pairs in one shot.
- **Eliminate `get_sector_detail()` over-fetch**: replaced `get_companies_directory_page(page_size=None, sector_name=…)` (heavy LEFT JOIN + GROUP BY on `financial_reports`) with a new `get_sector_companies()` — a simple `SELECT` on the `companies` table only. `get_company_years_map()` continues to run as before.
- **Tests**: extended `test_cacheable_endpoints_expose_cache_headers` with 2 new entries; 74/74 tests pass.
- **Docs**: cache policies documented in `docs/V2_API_CONTRACT.md`.

## Compatibilidade

additive-only — sem breaking changes no payload publico. Apenas headers de resposta adicionados (`Cache-Control`, `Vary`) e queries internas simplificadas. Nenhum campo removido ou renomeado nos contratos existentes.

## Test plan

- [x] `pytest apps/api/tests/test_api_contract.py -v` → 74/74 passed
- [x] New cache header entries for `/sectors/energia` and `/companies/filters` pass
- [x] All existing sector directory, sector detail, and company filter tests unaffected (no payload change)

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)