### PR TITLE
feat(backend): add GET /companies/suggestions for autocomplete

### DIFF
--- a/apps/api/app/presenters.py
+++ b/apps/api/app/presenters.py
@@ -10,6 +10,7 @@ from src.contracts import (
     CompanyFiltersDTO,
     CompanyInfoDTO,
     CompanySearchResult,
+    CompanySuggestionDTO,
     HealthSnapshot,
     KPIBundle,
     RankedRefreshQueueResult,
@@ -92,6 +93,17 @@ class CompanyDirectoryPagePayload(BaseModel):
     items: list[CompanySearchResultPayload]
     pagination: CompanyDirectoryPaginationPayload
     applied_filters: CompanyDirectoryAppliedFiltersPayload
+
+
+class CompanySuggestionPayload(BaseModel):
+    cd_cvm: int
+    company_name: str
+    ticker_b3: str | None = None
+    sector_slug: str
+
+
+class CompanySuggestionsPayload(BaseModel):
+    items: list[CompanySuggestionPayload]
 
 
 class CompanySectorFilterPayload(BaseModel):
@@ -298,6 +310,12 @@ def present_company_directory_page(dto: CompanyDirectoryPage) -> CompanyDirector
     payload = dto.to_dict()
     payload["items"] = [item.model_dump() for item in present_company_search(list(dto.items))]
     return CompanyDirectoryPagePayload(**payload)
+
+
+def present_company_suggestions(items: tuple[CompanySuggestionDTO, ...]) -> CompanySuggestionsPayload:
+    return CompanySuggestionsPayload(
+        items=[CompanySuggestionPayload(**item.to_dict()) for item in items]
+    )
 
 
 def present_company_filters(dto: CompanyFiltersDTO) -> CompanyFiltersPayload:

--- a/apps/api/app/routes/companies.py
+++ b/apps/api/app/routes/companies.py
@@ -18,6 +18,7 @@ from apps.api.app.presenters import (
     CompanyDirectoryPagePayload,
     CompanyFiltersPayload,
     CompanyInfoPayload,
+    CompanySuggestionsPayload,
     KPIBundlePayload,
     RankedRefreshQueuePayload,
     RefreshDispatchPayload,
@@ -26,6 +27,7 @@ from apps.api.app.presenters import (
     present_company_directory_page,
     present_company_filters,
     present_company_info,
+    present_company_suggestions,
     present_kpis,
     present_ranked_refresh_queue,
     present_statement,
@@ -37,6 +39,7 @@ router = APIRouter(tags=["companies"])
 
 COMPANY_DIRECTORY_CACHE_CONTROL = "public, max-age=300, stale-while-revalidate=3600"
 COMPANY_FILTERS_CACHE_CONTROL = "public, max-age=3600, stale-while-revalidate=86400"
+COMPANY_SUGGESTIONS_CACHE_CONTROL = "public, max-age=60, stale-while-revalidate=300"
 COMPANY_INFO_CACHE_CONTROL = "public, max-age=3600"
 COMPANY_YEARS_CACHE_CONTROL = "public, max-age=86400, stale-while-revalidate=604800"
 COMPANY_DATA_CACHE_CONTROL = "public, max-age=600"
@@ -88,6 +91,24 @@ def get_company_filters(
     ensure_api_ready(get_settings(request))
     _apply_cache_headers(response, COMPANY_FILTERS_CACHE_CONTROL)
     return present_company_filters(service.get_company_filters())
+
+
+@router.get(
+    "/companies/suggestions",
+    response_model=CompanySuggestionsPayload,
+    summary="Retorna sugestoes de empresas para autocomplete.",
+)
+def get_company_suggestions(
+    request: Request,
+    response: Response,
+    q: str = Query(default="", description="Texto de busca livre (nome, ticker ou codigo CVM)."),
+    limit: int = Query(default=6, ge=1, le=20, description="Numero maximo de sugestoes retornadas."),
+    service: CVMReadService = Depends(get_read_service),
+) -> CompanySuggestionsPayload:
+    ensure_api_ready(get_settings(request))
+    _apply_cache_headers(response, COMPANY_SUGGESTIONS_CACHE_CONTROL)
+    items = service.suggest_companies(q=q, limit=limit)
+    return present_company_suggestions(items)
 
 
 @router.get(

--- a/apps/api/tests/test_api_contract.py
+++ b/apps/api/tests/test_api_contract.py
@@ -130,6 +130,8 @@ def test_companies_empty_search_returns_paginated_directory(client: TestClient):
         ("/sectors", None, "public, max-age=3600, stale-while-revalidate=86400"),
         ("/sectors/energia", None, "public, max-age=3600, stale-while-revalidate=86400"),
         ("/companies/filters", None, "public, max-age=3600, stale-while-revalidate=86400"),
+        ("/companies/suggestions", None, "public, max-age=60, stale-while-revalidate=300"),
+        ("/companies/suggestions", {"q": "petro"}, "public, max-age=60, stale-while-revalidate=300"),
     ],
 )
 def test_cacheable_endpoints_expose_cache_headers(
@@ -212,6 +214,74 @@ def test_companies_filters_returns_canonical_sector_options(client: TestClient):
         {"sector_name": "Materiais Basicos", "sector_slug": "materiais-basicos", "company_count": 1},
         {"sector_name": "Saneamento", "sector_slug": "saneamento", "company_count": 1},
     ]
+
+
+def test_company_suggestions_empty_query_returns_items_alphabetically(client: TestClient):
+    response = client.get("/companies/suggestions")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert "items" in payload
+    names = [item["company_name"] for item in payload["items"]]
+    assert names == sorted(names)
+
+
+def test_company_suggestions_payload_has_minimal_fields_only(client: TestClient):
+    response = client.get("/companies/suggestions", params={"q": "petro"})
+
+    assert response.status_code == 200
+    items = response.json()["items"]
+    assert len(items) == 1
+    item = items[0]
+    assert set(item.keys()) == {"cd_cvm", "company_name", "ticker_b3", "sector_slug"}
+    assert item["cd_cvm"] == 9512
+    assert item["company_name"] == "PETROBRAS"
+    assert item["ticker_b3"] == "PETR4"
+    assert item["sector_slug"] == "energia"
+
+
+def test_company_suggestions_filters_by_ticker(client: TestClient):
+    response = client.get("/companies/suggestions", params={"q": "vale3"})
+
+    assert response.status_code == 200
+    items = response.json()["items"]
+    assert len(items) == 1
+    assert items[0]["company_name"] == "VALE"
+
+
+def test_company_suggestions_exact_ticker_ranks_first(client: TestClient):
+    response = client.get("/companies/suggestions", params={"q": "petr4"})
+
+    assert response.status_code == 200
+    items = response.json()["items"]
+    assert len(items) >= 1
+    assert items[0]["cd_cvm"] == 9512
+
+
+def test_company_suggestions_respects_limit(client: TestClient):
+    response = client.get("/companies/suggestions", params={"limit": 2})
+
+    assert response.status_code == 200
+    assert len(response.json()["items"]) <= 2
+
+
+def test_company_suggestions_returns_empty_for_no_match(client: TestClient):
+    response = client.get("/companies/suggestions", params={"q": "xxxxnomatch"})
+
+    assert response.status_code == 200
+    assert response.json()["items"] == []
+
+
+def test_company_suggestions_rejects_limit_above_max(client: TestClient):
+    response = client.get("/companies/suggestions", params={"limit": 21})
+
+    assert response.status_code == 422
+
+
+def test_company_suggestions_rejects_limit_below_min(client: TestClient):
+    response = client.get("/companies/suggestions", params={"limit": 0})
+
+    assert response.status_code == 422
 
 
 def test_sectors_returns_directory_with_latest_year_and_snapshot(client: TestClient):

--- a/docs/V2_API_CONTRACT.md
+++ b/docs/V2_API_CONTRACT.md
@@ -115,6 +115,48 @@ Regras do endpoint:
   - `Cache-Control: public, max-age=3600, stale-while-revalidate=86400`
   - `Vary: Origin`
 
+### `GET /companies/suggestions?q=&limit=`
+
+Uso:
+- endpoint dedicado para autocomplete; retorna apenas os campos minimos necessarios para widgets de sugestao
+- substitui o fluxo que usava `GET /companies?search=...&page_size=6` no hot path do frontend
+
+Parametros:
+- `q` (string, default `""`): texto livre de busca por nome, ticker ou codigo CVM
+- `limit` (int, default `6`, min `1`, max `20`): numero maximo de sugestoes retornadas
+
+Ranking das sugestoes:
+1. ticker exato (case-insensitive)
+2. prefixo do nome da empresa
+3. prefixo do ticker
+4. qualquer correspondencia por `LIKE %q%`
+
+DTO de saida:
+- `src.contracts.CompanySuggestionDTO`
+
+Resposta exemplo:
+
+```json
+{
+  "items": [
+    {
+      "cd_cvm": 9512,
+      "company_name": "PETROBRAS",
+      "ticker_b3": "PETR4",
+      "sector_slug": "energia"
+    }
+  ]
+}
+```
+
+Regras do endpoint:
+- payload retorna apenas `cd_cvm`, `company_name`, `ticker_b3`, `sector_slug` — sem `anos_disponiveis`, `has_financial_data`, nem metricas de cobertura
+- `ticker_b3` e `null` quando a empresa nao possui ticker cadastrado
+- resposta vazia (`items: []`) quando nenhuma empresa corresponde a `q`; nunca 404
+- headers de cache:
+  - `Cache-Control: public, max-age=60, stale-while-revalidate=300`
+  - `Vary: Origin`
+
 ### `GET /sectors`
 
 Uso:

--- a/src/contracts.py
+++ b/src/contracts.py
@@ -229,6 +229,17 @@ class CompanyFiltersDTO:
 
 
 @dataclass(frozen=True)
+class CompanySuggestionDTO:
+    cd_cvm: int
+    company_name: str
+    ticker_b3: str | None
+    sector_slug: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
 class SectorSnapshotDTO:
     roe: float | None
     mg_ebit: float | None

--- a/src/query_layer.py
+++ b/src/query_layer.py
@@ -232,6 +232,54 @@ class CVMQueryLayer:
             result.setdefault(str(row["sector_name"]), []).append(int(row["REPORT_YEAR"]))
         return result
 
+    def get_company_suggestions(self, q: str, limit: int) -> pd.DataFrame:
+        """Returns up to `limit` companies ranked by relevance to query `q`.
+
+        Ranking: exact ticker > name prefix > ticker prefix > contains match.
+        Empty `q` returns the first `limit` companies alphabetically.
+        """
+        normalized = q.strip().lower()
+        if not normalized:
+            sql = text(
+                f"""
+                SELECT c.cd_cvm, c.company_name,
+                       COALESCE(c.ticker_b3, '') AS ticker_b3,
+                       {_CANONICAL_SECTOR_SQL} AS sector_name
+                FROM companies c
+                ORDER BY c.company_name ASC
+                LIMIT :limit
+                """
+            )
+            return pd.read_sql(sql, self.engine, params={"limit": int(limit)}).reset_index(drop=True)
+
+        sql = text(
+            f"""
+            SELECT c.cd_cvm, c.company_name,
+                   COALESCE(c.ticker_b3, '') AS ticker_b3,
+                   {_CANONICAL_SECTOR_SQL} AS sector_name
+            FROM companies c
+            WHERE
+                LOWER(c.company_name) LIKE :contains
+                OR LOWER(COALESCE(c.ticker_b3, '')) LIKE :contains
+                OR CAST(c.cd_cvm AS TEXT) LIKE :contains
+            ORDER BY
+                CASE
+                    WHEN LOWER(COALESCE(c.ticker_b3, '')) = :exact   THEN 0
+                    WHEN LOWER(c.company_name)             LIKE :prefix THEN 1
+                    WHEN LOWER(COALESCE(c.ticker_b3, '')) LIKE :prefix THEN 2
+                    ELSE 3
+                END ASC,
+                c.company_name ASC
+            LIMIT :limit
+            """
+        )
+        return pd.read_sql(sql, self.engine, params={
+            "contains": f"%{normalized}%",
+            "prefix": f"{normalized}%",
+            "exact": normalized,
+            "limit": int(limit),
+        }).reset_index(drop=True)
+
     def get_sector_companies(self, sector_name: str) -> tuple[pd.DataFrame, int]:
         """Returns (df[cd_cvm, company_name, ticker_b3], total_count) for a sector.
 

--- a/src/read_service.py
+++ b/src/read_service.py
@@ -17,6 +17,7 @@ from src.contracts import (
     CompanyInfoDTO,
     CompanySectorFilterOption,
     CompanySearchResult,
+    CompanySuggestionDTO,
     HealthSnapshot,
     KPIBundle,
     RankedRefreshQueueItem,
@@ -176,6 +177,18 @@ class CVMReadService:
             for _, row in df.iterrows()
         )
         return CompanyFiltersDTO(sectors=sectors)
+
+    def suggest_companies(self, q: str, limit: int) -> tuple[CompanySuggestionDTO, ...]:
+        df = self.query_layer.get_company_suggestions(q=q, limit=limit)
+        return tuple(
+            CompanySuggestionDTO(
+                cd_cvm=int(row["cd_cvm"]),
+                company_name=str(row["company_name"]),
+                ticker_b3=str(row["ticker_b3"]) if row["ticker_b3"] else None,
+                sector_slug=sector_slugify(str(row["sector_name"])),
+            )
+            for _, row in df.iterrows()
+        )
 
     def resolve_sector_slug(self, sector_slug: str | None) -> str | None:
         return self._resolve_sector_slug(sector_slug)


### PR DESCRIPTION
## Contexto

Closes #133

O fluxo de autocomplete do frontend (`company-search-hero`, `compare-selector`) hoje passa por `GET /companies?search=...&pageSize=6`, que carrega o payload completo do diretório (12 campos, JOIN com `financial_reports`, agregações). Este PR introduz um endpoint dedicado e leve.

## O que muda

- `GET /companies/suggestions?q=&limit=` — novo endpoint de autocomplete
- Payload mínimo: apenas `cd_cvm`, `company_name`, `ticker_b3`, `sector_slug`
- Ranking por relevância: ticker exato > prefixo de nome > prefixo de ticker > contains
- Cache: `public, max-age=60, stale-while-revalidate=300`
- `limit` default `6`, máximo `20`, mínimo `1`
- 10 novos testes de contrato; total 84/84 passando

## Arquivos modificados

- `src/contracts.py` — `CompanySuggestionDTO`
- `src/query_layer.py` — `get_company_suggestions()`
- `src/read_service.py` — `suggest_companies()`
- `apps/api/app/presenters.py` — `CompanySuggestionPayload`, `CompanySuggestionsPayload`, `present_company_suggestions()`
- `apps/api/app/routes/companies.py` — `GET /companies/suggestions`
- `apps/api/tests/test_api_contract.py` — 10 novos testes
- `docs/V2_API_CONTRACT.md` — contrato documentado

## Compatibilidade

Mudança **additive-only**: endpoint novo (`GET /companies/suggestions`), sem alteração de payloads, schemas, ou endpoints existentes.
Nenhum campo, rota, ou tipo público foi removido ou modificado.