### PR TITLE
[Task #135] Render /empresas server-first

### DIFF
--- a/apps/web/app/empresas/page.tsx
+++ b/apps/web/app/empresas/page.tsx
@@ -2,9 +2,11 @@ import { Suspense } from "react";
 import type { Metadata } from "next";
 
 import {
-  CompaniesDirectoryClient,
+  CompaniesDirectoryPageContent,
   CompaniesDirectoryLoadingState,
 } from "@/components/companies/companies-directory-client";
+import { readCompaniesDirectoryQueryFromRecord } from "@/lib/companies-directory-query";
+import { loadCompaniesPageData } from "@/lib/companies-page-data";
 
 export const metadata: Metadata = {
   title: "Empresas",
@@ -12,12 +14,37 @@ export const metadata: Metadata = {
     "Diretorio publico e paginado de empresas com dados financeiros ja processados na base CVM Analytics.",
 };
 
-export const revalidate = 3600;
+export const revalidate = 300;
 
-export default function EmpresasPage() {
+type EmpresasPageProps = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default function EmpresasPage({ searchParams }: EmpresasPageProps) {
   return (
     <Suspense fallback={<CompaniesDirectoryLoadingState />}>
-      <CompaniesDirectoryClient />
+      <EmpresasPageContent searchParams={searchParams} />
     </Suspense>
+  );
+}
+
+async function EmpresasPageContent({ searchParams }: EmpresasPageProps) {
+  const directoryQuery = readCompaniesDirectoryQueryFromRecord(await searchParams);
+  const data = await loadCompaniesPageData({
+    search: directoryQuery.search,
+    sector: directoryQuery.sector,
+    page: directoryQuery.page,
+    pageSize: directoryQuery.pageSize,
+  });
+
+  return (
+    <CompaniesDirectoryPageContent
+      data={data}
+      page={directoryQuery.page}
+      pageSize={directoryQuery.pageSize}
+      search={directoryQuery.search}
+      sector={directoryQuery.sector}
+      viewMode={directoryQuery.viewMode}
+    />
   );
 }

--- a/apps/web/components/companies/companies-directory-client.tsx
+++ b/apps/web/components/companies/companies-directory-client.tsx
@@ -1,8 +1,4 @@
-"use client";
-
 import Link from "next/link";
-import { useEffect, useState } from "react";
-import { useSearchParams } from "next/navigation";
 
 import { CompanyDirectoryFilters } from "@/components/companies/company-directory-filters";
 import { CompanyDirectoryList } from "@/components/companies/company-directory-list";
@@ -15,127 +11,28 @@ import {
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { buttonVariants } from "@/components/ui/button";
 import {
-  buildCompaniesDirectoryApiHref,
-  COMPANIES_DIRECTORY_PAGE_SIZE,
-  readCompaniesDirectoryQuery,
+  type CompaniesDirectoryQueryState,
 } from "@/lib/companies-directory-query";
 import { formatCompactInteger } from "@/lib/formatters";
 import type { CompaniesPageData } from "@/lib/companies-page-data";
 import { mergeSearchParams } from "@/lib/search-params";
 import { cn } from "@/lib/utils";
 
-type RequestState = {
-  data: CompaniesPageData | null;
-  requestError: string | null;
-  loading: boolean;
-};
-
-type CompaniesDirectoryClientContentProps = Pick<
-  ReturnType<typeof readCompaniesDirectoryQuery>,
+type CompaniesDirectoryPageContentProps = Pick<
+  CompaniesDirectoryQueryState,
   "page" | "pageSize" | "search" | "sector" | "viewMode"
 > & {
-  requestHref: string;
+  data: CompaniesPageData;
 };
 
-const DIRECTORY_LOAD_ERROR =
-  "Nao foi possivel carregar o diretorio de empresas agora. Tente novamente em instantes.";
-
-const INITIAL_STATE: RequestState = {
-  data: null,
-  requestError: null,
-  loading: true,
-};
-
-async function fetchCompaniesDirectoryData(
-  href: string,
-  signal: AbortSignal,
-): Promise<CompaniesPageData> {
-  const response = await fetch(href, {
-    cache: "no-store",
-    headers: {
-      Accept: "application/json",
-    },
-    signal,
-  });
-
-  if (!response.ok) {
-    throw new Error(DIRECTORY_LOAD_ERROR);
-  }
-
-  return (await response.json()) as CompaniesPageData;
-}
-
-export function CompaniesDirectoryClient() {
-  const searchParams = useSearchParams();
-  const directoryQuery = readCompaniesDirectoryQuery(
-    searchParams,
-    COMPANIES_DIRECTORY_PAGE_SIZE,
-  );
-  const requestHref = buildCompaniesDirectoryApiHref({
-    search: directoryQuery.search,
-    sector: directoryQuery.sector,
-    page: directoryQuery.page,
-    pageSize: directoryQuery.pageSize,
-  });
-
-  return (
-    <CompaniesDirectoryClientContent
-      key={requestHref}
-      requestHref={requestHref}
-      page={directoryQuery.page}
-      pageSize={directoryQuery.pageSize}
-      search={directoryQuery.search}
-      sector={directoryQuery.sector}
-      viewMode={directoryQuery.viewMode}
-    />
-  );
-}
-
-function CompaniesDirectoryClientContent({
+export function CompaniesDirectoryPageContent({
   page: currentPage,
   pageSize,
   search: currentSearch,
   sector: currentSector,
   viewMode,
-  requestHref,
-}: CompaniesDirectoryClientContentProps) {
-  const [state, setState] = useState<RequestState>(INITIAL_STATE);
-
-  useEffect(() => {
-    const controller = new AbortController();
-
-    void fetchCompaniesDirectoryData(requestHref, controller.signal)
-      .then((data) => {
-        if (controller.signal.aborted) {
-          return;
-        }
-
-        setState({
-          data,
-          requestError: null,
-          loading: false,
-        });
-      })
-      .catch((error) => {
-        if (controller.signal.aborted) {
-          return;
-        }
-
-        setState({
-          data: null,
-          requestError:
-            error instanceof Error && error.message ? error.message : DIRECTORY_LOAD_ERROR,
-          loading: false,
-        });
-      });
-
-    return () => controller.abort();
-  }, [requestHref]);
-
-  if (state.loading && !state.data) {
-    return <CompaniesDirectoryLoadingState />;
-  }
-
+  data,
+}: CompaniesDirectoryPageContentProps) {
   const retryParams = new URLSearchParams();
   if (currentSearch) {
     retryParams.set("busca", currentSearch);
@@ -152,7 +49,7 @@ function CompaniesDirectoryClientContent({
   const retryQuery = retryParams.toString();
   const retryHref = retryQuery ? `/empresas?${retryQuery}` : "/empresas";
 
-  if (!state.data?.directory) {
+  if (!data.directory) {
     return (
       <PageShell density="relaxed" className="max-w-4xl">
         <SurfaceCard tone="hero" padding="hero" className="space-y-6">
@@ -165,8 +62,7 @@ function CompaniesDirectoryClientContent({
           <Alert className="rounded-[1.75rem] border border-destructive/25 bg-destructive/6 px-5 py-5 text-left">
             <AlertTitle>Falha controlada da listagem</AlertTitle>
             <AlertDescription>
-              {state.requestError ??
-                state.data?.directoryError ??
+              {data.directoryError ??
                 "Nao foi possivel carregar o diretorio de empresas agora. Tente novamente em instantes."}
             </AlertDescription>
           </Alert>
@@ -192,7 +88,7 @@ function CompaniesDirectoryClientContent({
     );
   }
 
-  const { directory, directoryError, filters, filtersError } = state.data;
+  const { directory, directoryError, filters, filtersError } = data;
   const currentParamsStr = mergeSearchParams("", {
     busca: currentSearch || null,
     setor: currentSector,

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -203,9 +203,12 @@ const UNCACHED_API_READ: ApiReadRequestInit = {
 };
 
 // Keep these frontend data-cache TTLs aligned with the backend Cache-Control
-// contract delivered by task #103.
+// contract delivered by the API layer.
 const COMPANY_DIRECTORY_API_READ: ApiReadRequestInit = {
   next: { revalidate: 300 },
+};
+const COMPANY_FILTERS_API_READ: ApiReadRequestInit = {
+  next: { revalidate: 3600 },
 };
 const COMPANY_INFO_API_READ: ApiReadRequestInit = {
   next: { revalidate: 3600 },
@@ -717,7 +720,7 @@ export async function fetchCompanyFilters(): Promise<CompanyFiltersResponse> {
   return (await apiFetch<CompanyFiltersResponse>(
     "/companies/filters",
     {
-      request: UNCACHED_API_READ,
+      request: COMPANY_FILTERS_API_READ,
       validate: isCompanyFiltersResponse,
       invalidResponseMessage: "A API retornou filtros de empresas invalidos.",
     },

--- a/apps/web/lib/companies-directory-query.ts
+++ b/apps/web/lib/companies-directory-query.ts
@@ -1,4 +1,4 @@
-import { coercePositiveInt } from "./search-params.ts";
+import { coercePositiveInt, getFirstParam } from "./search-params.ts";
 
 export const COMPANIES_DIRECTORY_PAGE_SIZE = 20;
 
@@ -30,6 +30,22 @@ export function readCompaniesDirectoryQuery(
     pageSize,
     viewMode: searchParams.get("view") === "cards" ? "cards" : "rows",
   };
+}
+
+export function readCompaniesDirectoryQueryFromRecord(
+  searchParamsRecord: Record<string, string | string[] | undefined>,
+  pageSize = COMPANIES_DIRECTORY_PAGE_SIZE,
+): CompaniesDirectoryQueryState {
+  const searchParams = new URLSearchParams();
+
+  Object.entries(searchParamsRecord).forEach(([key, value]) => {
+    const firstValue = getFirstParam(value);
+    if (firstValue !== undefined) {
+      searchParams.set(key, firstValue);
+    }
+  });
+
+  return readCompaniesDirectoryQuery(searchParams, pageSize);
 }
 
 export function buildCompaniesDirectoryApiHref(

--- a/apps/web/tests/api-client.test.ts
+++ b/apps/web/tests/api-client.test.ts
@@ -77,6 +77,34 @@ test("fetchCompanyFilters maps upstream 5xx responses to upstream_unavailable", 
   }
 });
 
+test("fetchCompanyFilters opts into the backend-aligned revalidate window", async () => {
+  let capturedInit: RequestInit | undefined;
+  const restore = withFetchMock((async (_input, init) => {
+    capturedInit = init;
+
+    return new Response(
+      JSON.stringify({
+        sectors: [],
+      }),
+      {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+        },
+      },
+    );
+  }) as FetchMock);
+
+  try {
+    await fetchCompanyFilters();
+
+    assert.equal(capturedInit?.cache, undefined);
+    assert.deepEqual(capturedInit?.next, { revalidate: 3600 });
+  } finally {
+    restore();
+  }
+});
+
 test("fetchCompanies opts into the backend-aligned revalidate window", async () => {
   let capturedInit: RequestInit | undefined;
   const restore = withFetchMock((async (_input, init) => {

--- a/apps/web/tests/companies-page-data.test.ts
+++ b/apps/web/tests/companies-page-data.test.ts
@@ -5,6 +5,7 @@ import { ApiClientError } from "../lib/api.ts";
 import {
   buildCompaniesDirectoryApiHref,
   readCompaniesDirectoryQuery,
+  readCompaniesDirectoryQueryFromRecord,
 } from "../lib/companies-directory-query.ts";
 import { loadCompaniesPageData } from "../lib/companies-page-data.ts";
 
@@ -78,6 +79,23 @@ test("readCompaniesDirectoryQuery normalizes search params for the client loader
   const query = new URLSearchParams("busca=%20PETR4%20&setor=energia&pagina=0&view=cards");
 
   const result = readCompaniesDirectoryQuery(query);
+
+  assert.deepEqual(result, {
+    search: "PETR4",
+    sector: "energia",
+    page: 1,
+    pageSize: 20,
+    viewMode: "cards",
+  });
+});
+
+test("readCompaniesDirectoryQueryFromRecord keeps the first app-router param value", () => {
+  const result = readCompaniesDirectoryQueryFromRecord({
+    busca: [" PETR4 ", "VALE3"],
+    setor: "energia",
+    pagina: "0",
+    view: "cards",
+  });
 
   assert.deepEqual(result, {
     search: "PETR4",


### PR DESCRIPTION
Closes #135

## Summary
- move /empresas to server-first data loading so the initial HTML ships directory data and filters from the page server component
- keep only the URL-changing controls as client islands and stop depending on client bootstrap for the initial directory render
- align etchCompanyFilters() with the backend cache contract and cover the new query parsing/cache behavior in unit tests

## Validation
- npm run test:unit
- npm run typecheck
- npm run lint
- npm run build