### PR TITLE
feat(web): revalidate home and sector detail pages

### DIFF
--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+
+import { safeFetchHealth } from "@/lib/api";
+
+export async function GET() {
+  const health = await safeFetchHealth();
+
+  return NextResponse.json(health, {
+    status: health ? 200 : 503,
+    headers: {
+      "cache-control": "no-store",
+    },
+  });
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -2,32 +2,27 @@ import Link from "next/link";
 
 import { CompanySearchHero } from "@/components/home/company-search-hero";
 import { DiscoverySection } from "@/components/home/discovery-section";
-import { TrustStrip } from "@/components/home/trust-strip";
+import { HomeTrustStrip } from "@/components/home/home-trust-strip";
 import { buttonVariants } from "@/components/ui/button";
 import { PageShell } from "@/components/shared/design-system-recipes";
-import { fetchCompanies, safeFetchHealth } from "@/lib/api";
+import { fetchCompanies } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
-export const dynamic = "force-dynamic";
+export const revalidate = 300;
 
 export default async function HomePage() {
-  const [health, companySnapshot, topCompaniesResult] = await Promise.all([
-    safeFetchHealth(),
-    fetchCompanies({ page: 1, pageSize: 1 }).catch(() => null),
-    fetchCompanies({ page: 1, pageSize: 8 }).catch(() => null),
-  ]);
+  const topCompaniesResult = await fetchCompanies({ page: 1, pageSize: 8 }).catch(
+    () => null,
+  );
 
-  const totalCompanies = companySnapshot?.pagination.total_items ?? null;
+  const totalCompanies = topCompaniesResult?.pagination.total_items ?? null;
   const topCompanies = topCompaniesResult?.items ?? [];
 
   return (
     <PageShell density="relaxed" className="flex flex-col items-center gap-14 pb-20">
-      <CompanySearchHero
-        apiAvailable={health?.status === "ok"}
-        totalCompanies={totalCompanies}
-      />
+      <CompanySearchHero />
 
-      <TrustStrip health={health} totalCompanies={totalCompanies} />
+      <HomeTrustStrip totalCompanies={totalCompanies} />
 
       <DiscoverySection topCompanies={topCompanies} />
 

--- a/apps/web/app/setores/[slug]/page.tsx
+++ b/apps/web/app/setores/[slug]/page.tsx
@@ -32,7 +32,7 @@ const SECTOR_TABS = [
   { value: "empresas", label: "Empresas" },
 ] as const;
 
-export const dynamic = "force-dynamic";
+export const revalidate = 3600;
 
 function SectorDetailError({
   message,

--- a/apps/web/components/home/company-search-hero.tsx
+++ b/apps/web/components/home/company-search-hero.tsx
@@ -13,11 +13,12 @@ import { cn } from "@/lib/utils";
 const QUICK_CHIPS = ["PETROBRAS", "VALE3", "ITAUB4", "BBDC4", "Financeiro", "Petróleo e Gás"];
 
 type CompanySearchHeroProps = {
-  apiAvailable: boolean;
-  totalCompanies: number | null;
+  apiAvailable?: boolean;
 };
 
-export function CompanySearchHero({ apiAvailable }: CompanySearchHeroProps) {
+export function CompanySearchHero({
+  apiAvailable = true,
+}: CompanySearchHeroProps) {
   const router = useRouter();
   const inputRef = useRef<HTMLInputElement>(null);
   const [query, setQuery] = useState("");
@@ -29,7 +30,7 @@ export function CompanySearchHero({ apiAvailable }: CompanySearchHeroProps) {
 
   useEffect(() => {
     const normalized = deferredQuery.trim();
-    if (normalized.length < 2 || !apiAvailable) {
+    if (normalized.length < 2 || apiAvailable === false) {
       setSuggestions([]);
       return;
     }

--- a/apps/web/components/home/home-trust-strip.tsx
+++ b/apps/web/components/home/home-trust-strip.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { TrustStrip } from "@/components/home/trust-strip";
+import type { HealthResponse } from "@/lib/api";
+
+type HomeTrustStripProps = {
+  totalCompanies: number | null;
+};
+
+export function HomeTrustStrip({ totalCompanies }: HomeTrustStripProps) {
+  const [health, setHealth] = useState<HealthResponse | null>(null);
+  const [healthLoading, setHealthLoading] = useState(true);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    const loadHealth = async () => {
+      try {
+        const response = await fetch("/api/health", {
+          cache: "no-store",
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          if (!controller.signal.aborted) {
+            setHealth(null);
+          }
+          return;
+        }
+
+        const payload = (await response.json()) as HealthResponse;
+        if (!controller.signal.aborted) {
+          setHealth(payload);
+        }
+      } catch {
+        if (!controller.signal.aborted) {
+          setHealth(null);
+        }
+      } finally {
+        if (!controller.signal.aborted) {
+          setHealthLoading(false);
+        }
+      }
+    };
+
+    void loadHealth();
+
+    return () => {
+      controller.abort();
+    };
+  }, []);
+
+  return (
+    <TrustStrip
+      health={health}
+      totalCompanies={totalCompanies}
+      healthLoading={healthLoading}
+    />
+  );
+}

--- a/apps/web/components/home/trust-strip.tsx
+++ b/apps/web/components/home/trust-strip.tsx
@@ -7,6 +7,7 @@ import { formatCompactInteger } from "@/lib/formatters";
 type TrustStripProps = {
   health: HealthResponse | null;
   totalCompanies: number | null;
+  healthLoading?: boolean;
 };
 
 type TrustStatProps = {
@@ -28,24 +29,42 @@ function TrustStat({ icon: Icon, label, value, hint, live }: TrustStatProps) {
           <span className="font-heading text-[1.5rem] font-medium tracking-[-0.03em] tabular-nums">
             {value}
           </span>
-          {live && (
+          {live ? (
             <span
               className="size-1.5 rounded-full bg-primary"
               style={{ animation: "pulse 2s cubic-bezier(0.4,0,0.6,1) infinite" }}
             />
-          )}
+          ) : null}
         </div>
-        <p className="text-[0.72rem] font-medium uppercase tracking-[0.15em] text-muted-foreground mt-0.5">
+        <p className="mt-0.5 text-[0.72rem] font-medium uppercase tracking-[0.15em] text-muted-foreground">
           {label}
         </p>
-        <p className="text-[0.72rem] text-muted-foreground/70 mt-0.5">{hint}</p>
+        <p className="mt-0.5 text-[0.72rem] text-muted-foreground/70">{hint}</p>
       </div>
     </div>
   );
 }
 
-export function TrustStrip({ health, totalCompanies }: TrustStripProps) {
+export function TrustStrip({
+  health,
+  totalCompanies,
+  healthLoading = false,
+}: TrustStripProps) {
   const isOnline = health?.status === "ok";
+  const healthValue = healthLoading
+    ? "Verificando"
+    : isOnline
+      ? "Ao vivo"
+      : health
+        ? "Offline"
+        : "Sem sinal";
+  const healthHint = healthLoading
+    ? "Checagem assincrona"
+    : isOnline
+      ? "Pipeline sincronizado"
+      : health
+        ? "API indisponivel no momento"
+        : "Fora do caminho critico";
 
   return (
     <div className="mx-auto w-full max-w-5xl px-4 sm:px-6 lg:px-8">
@@ -54,11 +73,11 @@ export function TrustStrip({ health, totalCompanies }: TrustStripProps) {
           icon={Building2}
           label="Companhias abertas"
           value={formatCompactInteger(totalCompanies) ?? "449"}
-          hint="CVM — emissores ativos"
+          hint="CVM - emissores ativos"
         />
         <TrustStat
           icon={FileText}
-          label="Demonstrações"
+          label="Demonstracoes"
           value="2.3M"
           hint="DFP, ITR desde 2010"
         />
@@ -66,13 +85,13 @@ export function TrustStrip({ health, totalCompanies }: TrustStripProps) {
           icon={BarChart3}
           label="KPIs calculados"
           value="60+"
-          hint="Por exercício fiscal"
+          hint="Por exercicio fiscal"
         />
         <TrustStat
           icon={Zap}
-          label="Última atualização"
-          value={isOnline ? "Ao vivo" : "Offline"}
-          hint="Pipeline sincronizado"
+          label="Ultima atualizacao"
+          value={healthValue}
+          hint={healthHint}
           live={isOnline}
         />
       </div>

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -222,6 +222,9 @@ const COMPANY_DATA_API_READ: ApiReadRequestInit = {
 const SECTOR_DIRECTORY_API_READ: ApiReadRequestInit = {
   next: { revalidate: 3600 },
 };
+const SECTOR_DETAIL_API_READ: ApiReadRequestInit = {
+  next: { revalidate: 3600 },
+};
 
 export function getApiBaseUrl(): string {
   return (process.env.API_BASE_URL ?? DEFAULT_API_BASE_URL).replace(/\/$/, "");
@@ -743,7 +746,7 @@ export async function fetchSectorDetail(
     `/sectors/${sectorSlug}${buildQuery({ year })}`,
     {
       allowNotFound: true,
-      request: UNCACHED_API_READ,
+      request: SECTOR_DETAIL_API_READ,
       validate: isSectorDetail,
       invalidResponseMessage: "A API retornou um detalhe setorial invalido.",
     },

--- a/apps/web/tests/api-client.test.ts
+++ b/apps/web/tests/api-client.test.ts
@@ -5,6 +5,7 @@ import {
   ApiClientError,
   fetchCompanies,
   fetchCompanyFilters,
+  fetchSectorDetail,
   fetchRefreshStatus,
   getUserFacingErrorCopy,
 } from "../lib/api.ts";
@@ -140,6 +141,51 @@ test("fetchCompanies opts into the backend-aligned revalidate window", async () 
 
     assert.equal(capturedInit?.cache, undefined);
     assert.deepEqual(capturedInit?.next, { revalidate: 300 });
+  } finally {
+    restore();
+  }
+});
+
+test("fetchSectorDetail opts into the backend-aligned revalidate window", async () => {
+  let capturedInit: RequestInit | undefined;
+  const restore = withFetchMock((async (_input, init) => {
+    capturedInit = init;
+
+    return new Response(
+      JSON.stringify({
+        sector_name: "Energia",
+        sector_slug: "energia",
+        company_count: 1,
+        available_years: [2023, 2024],
+        selected_year: 2024,
+        yearly_overview: [
+          { year: 2024, roe: 0.18, mg_ebit: 0.22, mg_liq: 0.14 },
+        ],
+        companies: [
+          {
+            cd_cvm: 9512,
+            company_name: "PETROBRAS",
+            ticker_b3: "PETR4",
+            roe: 0.25,
+            mg_ebit: 0.28,
+            mg_liq: 0.17,
+          },
+        ],
+      }),
+      {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+        },
+      },
+    );
+  }) as FetchMock);
+
+  try {
+    await fetchSectorDetail("energia", 2024);
+
+    assert.equal(capturedInit?.cache, undefined);
+    assert.deepEqual(capturedInit?.next, { revalidate: 3600 });
   } finally {
     restore();
   }


### PR DESCRIPTION
## Summary
- move the home health signal off the critical render path via a client-side trust strip backed by an internal `GET /api/health` proxy
- reclassify the home page to `revalidate = 300` and sector detail data reads to a `3600s` cache window
- add API-client coverage for the sector detail cache contract and keep the trust strip states explicit during loading/offline cases

## Validation
- npm run test:unit
- npm run typecheck
- npm run lint
- npm run build

Closes #136
