### PR TITLE
Ops-quality: add performance baseline guardrails

### DIFF
--- a/.github/workflows/perf-guardrails.yml
+++ b/.github/workflows/perf-guardrails.yml
@@ -1,0 +1,49 @@
+name: Perf Guardrails
+
+on:
+  push:
+    branches:
+      - main
+      - "task/**"
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+
+jobs:
+  perf-guardrails:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: apps/web/package-lock.json
+
+      - name: Install root dependencies
+        run: python -m pip install -r requirements.txt
+
+      - name: Install API dependencies
+        run: python -m pip install -r apps/api/requirements-dev.txt
+
+      - name: Install web dependencies
+        run: npm ci --prefix apps/web
+
+      - name: Run performance guardrails
+        run: >
+          python scripts/perf_guardrail.py check
+          --baseline docs/perf/performance_baseline.json
+          --report perf-guardrail-report.json
+
+      - name: Upload guardrail report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-guardrail-report
+          path: perf-guardrail-report.json

--- a/docs/perf/performance_baseline.json
+++ b/docs/perf/performance_baseline.json
@@ -1,0 +1,222 @@
+{
+  "generated_at": "2026-04-21T11:59:35Z",
+  "web": {
+    "framework": {
+      "name": "Next.js",
+      "version": "16.2.2"
+    },
+    "routes": {
+      "/": {
+        "rendering_mode": "static",
+        "revalidate_seconds": 300,
+        "first_load_uncompressed_js_bytes": 594365,
+        "first_load_chunk_count": 11,
+        "guardrail": {
+          "required_rendering_mode": "static",
+          "required_revalidate_seconds": 300,
+          "max_first_load_uncompressed_js_bytes": 644365
+        }
+      },
+      "/empresas": {
+        "rendering_mode": "dynamic",
+        "revalidate_seconds": null,
+        "first_load_uncompressed_js_bytes": 742622,
+        "first_load_chunk_count": 13,
+        "guardrail": {
+          "required_rendering_mode": "dynamic",
+          "required_revalidate_seconds": null,
+          "max_first_load_uncompressed_js_bytes": 802031
+        }
+      },
+      "/empresas/[cd_cvm]": {
+        "rendering_mode": "dynamic",
+        "revalidate_seconds": null,
+        "first_load_uncompressed_js_bytes": 627869,
+        "first_load_chunk_count": 12,
+        "guardrail": {
+          "required_rendering_mode": "dynamic",
+          "required_revalidate_seconds": null,
+          "max_first_load_uncompressed_js_bytes": 678098
+        }
+      },
+      "/comparar": {
+        "rendering_mode": "dynamic",
+        "revalidate_seconds": null,
+        "first_load_uncompressed_js_bytes": 620241,
+        "first_load_chunk_count": 11,
+        "guardrail": {
+          "required_rendering_mode": "dynamic",
+          "required_revalidate_seconds": null,
+          "max_first_load_uncompressed_js_bytes": 670241
+        }
+      },
+      "/setores": {
+        "rendering_mode": "static",
+        "revalidate_seconds": 3600,
+        "first_load_uncompressed_js_bytes": 571480,
+        "first_load_chunk_count": 11,
+        "guardrail": {
+          "required_rendering_mode": "static",
+          "required_revalidate_seconds": 3600,
+          "max_first_load_uncompressed_js_bytes": 621480
+        }
+      },
+      "/setores/[slug]": {
+        "rendering_mode": "dynamic",
+        "revalidate_seconds": null,
+        "first_load_uncompressed_js_bytes": 616355,
+        "first_load_chunk_count": 12,
+        "guardrail": {
+          "required_rendering_mode": "dynamic",
+          "required_revalidate_seconds": null,
+          "max_first_load_uncompressed_js_bytes": 666355
+        }
+      }
+    }
+  },
+  "api": {
+    "dataset": {
+      "companies": 449,
+      "annual_years": [
+        2019,
+        2020,
+        2021,
+        2022,
+        2023,
+        2024
+      ],
+      "rows_note": "Synthetic benchmark dataset seeded via scripts/benchmark_read_paths.py"
+    },
+    "endpoints": {
+      "GET /companies": {
+        "method": "GET",
+        "path": "/companies",
+        "params": {},
+        "median_ms": 22.04,
+        "p95_ms": 65.67,
+        "min_ms": 20.9,
+        "max_ms": 65.67,
+        "guardrail": {
+          "max_median_ms": 38.57,
+          "max_p95_ms": 124.77
+        }
+      },
+      "GET /companies/filters": {
+        "method": "GET",
+        "path": "/companies/filters",
+        "params": {},
+        "median_ms": 27.02,
+        "p95_ms": 28.17,
+        "min_ms": 26.55,
+        "max_ms": 28.17,
+        "guardrail": {
+          "max_median_ms": 47.28,
+          "max_p95_ms": 53.52
+        }
+      },
+      "GET /companies/suggestions?q=emp": {
+        "method": "GET",
+        "path": "/companies/suggestions",
+        "params": {
+          "q": "emp"
+        },
+        "median_ms": 3.71,
+        "p95_ms": 4.3,
+        "min_ms": 3.46,
+        "max_ms": 4.3,
+        "guardrail": {
+          "max_median_ms": 15.0,
+          "max_p95_ms": 25.0
+        }
+      },
+      "GET /companies/1000": {
+        "method": "GET",
+        "path": "/companies/1000",
+        "params": {},
+        "median_ms": 3.18,
+        "p95_ms": 3.36,
+        "min_ms": 2.79,
+        "max_ms": 3.36,
+        "guardrail": {
+          "max_median_ms": 15.0,
+          "max_p95_ms": 25.0
+        }
+      },
+      "GET /companies/1000/years": {
+        "method": "GET",
+        "path": "/companies/1000/years",
+        "params": {},
+        "median_ms": 3.71,
+        "p95_ms": 4.07,
+        "min_ms": 3.31,
+        "max_ms": 4.07,
+        "guardrail": {
+          "max_median_ms": 15.0,
+          "max_p95_ms": 25.0
+        }
+      },
+      "GET /companies/1000/statements?stmt=DRE&years=2023,2024": {
+        "method": "GET",
+        "path": "/companies/1000/statements",
+        "params": {
+          "stmt": "DRE",
+          "years": "2023,2024"
+        },
+        "median_ms": 9.24,
+        "p95_ms": 9.81,
+        "min_ms": 8.7,
+        "max_ms": 9.81,
+        "guardrail": {
+          "max_median_ms": 16.17,
+          "max_p95_ms": 25.0
+        }
+      },
+      "GET /companies/1000/kpis?years=2023,2024": {
+        "method": "GET",
+        "path": "/companies/1000/kpis",
+        "params": {
+          "years": "2023,2024"
+        },
+        "median_ms": 22.61,
+        "p95_ms": 23.46,
+        "min_ms": 22.18,
+        "max_ms": 23.46,
+        "guardrail": {
+          "max_median_ms": 39.57,
+          "max_p95_ms": 44.57
+        }
+      },
+      "GET /sectors": {
+        "method": "GET",
+        "path": "/sectors",
+        "params": {},
+        "median_ms": 125.24,
+        "p95_ms": 166.27,
+        "min_ms": 121.74,
+        "max_ms": 166.27,
+        "guardrail": {
+          "max_median_ms": 219.17,
+          "max_p95_ms": 315.91
+        }
+      },
+      "GET /sectors/energia": {
+        "method": "GET",
+        "path": "/sectors/energia",
+        "params": {},
+        "median_ms": 68.6,
+        "p95_ms": 72.18,
+        "min_ms": 67.66,
+        "max_ms": 72.18,
+        "guardrail": {
+          "max_median_ms": 120.05,
+          "max_p95_ms": 137.14
+        }
+      }
+    }
+  },
+  "metadata": {
+    "owner_lane": "ops-quality",
+    "issue": 138,
+    "purpose": "Baseline and light guardrails for main web routes and hot API endpoints."
+  }
+}

--- a/docs/perf/performance_guardrails.md
+++ b/docs/perf/performance_guardrails.md
@@ -1,0 +1,71 @@
+# Performance Guardrails
+
+Issue: `#138`
+Owner lane: `ops-quality`
+
+This repository now keeps a lightweight, repeatable baseline for:
+
+- main product web routes:
+  `/`, `/empresas`, `/empresas/[cd_cvm]`, `/comparar`, `/setores`, `/setores/[slug]`
+- hot API endpoints behind those routes:
+  `/companies`, `/companies/filters`, `/companies/suggestions`, `/companies/{cd_cvm}`,
+  `/companies/{cd_cvm}/years`, `/companies/{cd_cvm}/statements`,
+  `/companies/{cd_cvm}/kpis`, `/sectors`, `/sectors/{slug}`
+
+## What is measured
+
+### Web
+
+- rendering mode from `next build` (`static` vs `dynamic`)
+- `revalidate_seconds` from `.next/prerender-manifest.json`
+- `first_load_uncompressed_js_bytes` per route from `.next/diagnostics/route-bundle-stats.json`
+
+### API
+
+- in-process HTTP latency against a synthetic 449-company SQLite dataset
+- median and p95 for the hot endpoints listed above
+
+The API harness is intentionally synthetic and local. It is good for regression detection inside CI, not for production SLO claims.
+
+## Source of truth
+
+- Baseline + budgets: [performance_baseline.json](./performance_baseline.json)
+- Collector/checker: [`scripts/perf_guardrail.py`](../../scripts/perf_guardrail.py)
+- Existing deeper query benchmark: [benchmark_read_paths.md](./benchmark_read_paths.md)
+
+## How to run locally
+
+From the repo root:
+
+```powershell
+python -m pip install -r requirements.txt
+python -m pip install -r apps/api/requirements-dev.txt
+npm ci --prefix apps/web
+python scripts/perf_guardrail.py check --baseline docs/perf/performance_baseline.json
+```
+
+To refresh the baseline after an intentional performance change:
+
+```powershell
+python scripts/perf_guardrail.py capture --output docs/perf/performance_baseline.json
+```
+
+## Guardrail policy
+
+- Rendering mode changes are blocked unless the baseline is updated intentionally.
+- Revalidate changes for static routes are blocked unless the baseline is updated intentionally.
+- Web bundle growth is allowed only up to the per-route ceiling stored in the baseline JSON.
+- API latency is allowed only up to the per-endpoint `max_median_ms` and `max_p95_ms` ceilings stored in the baseline JSON.
+
+These budgets are intentionally light. They are meant to catch meaningful regressions, not micro-variations.
+
+## When to refresh the baseline
+
+Refresh `docs/perf/performance_baseline.json` only when:
+
+- a route intentionally changes rendering mode
+- a static route intentionally changes `revalidate`
+- a deliberate product change legitimately increases route JS
+- an approved backend change legitimately shifts the hot endpoint latency envelope
+
+If the baseline is refreshed, include the reason in the PR body and update issue evidence.

--- a/scripts/benchmark_read_paths.py
+++ b/scripts/benchmark_read_paths.py
@@ -54,7 +54,7 @@ STMT_ACCOUNTS = {
 ANNUAL_YEARS = list(range(2019, 2025))
 
 
-def _build_engine() -> object:
+def build_synthetic_benchmark_engine() -> object:
     engine = create_engine(
         "sqlite:///:memory:",
         connect_args={"check_same_thread": False},
@@ -63,7 +63,7 @@ def _build_engine() -> object:
     return engine
 
 
-def _seed(engine) -> None:
+def seed_synthetic_benchmark_data(engine) -> None:
     rng = random.Random(42)
     company_rows = []
     for i in range(N_COMPANIES):
@@ -322,9 +322,9 @@ def run(runs: int, phase: str) -> None:
     print(f"  dataset: {N_COMPANIES} companies  ~{N_COMPANIES * len(ANNUAL_YEARS) * 15:,} fr rows")
     print(f"{'='*78}\n")
 
-    engine = _build_engine()
+    engine = build_synthetic_benchmark_engine()
     print("Seeding synthetic data…", end=" ", flush=True)
-    _seed(engine)
+    seed_synthetic_benchmark_data(engine)
     print("done.\n")
 
     print(f"{'Query':<52} {'Timings':>40}")

--- a/scripts/perf_guardrail.py
+++ b/scripts/perf_guardrail.py
@@ -1,0 +1,462 @@
+#!/usr/bin/env python3
+"""
+Repeatable performance snapshot + guardrail checks for the main web routes and API endpoints.
+
+Usage:
+    python scripts/perf_guardrail.py capture --output docs/perf/performance_baseline.json
+    python scripts/perf_guardrail.py check --baseline docs/perf/performance_baseline.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from apps.api.app.main import create_app  # noqa: E402
+from scripts.benchmark_read_paths import (  # noqa: E402
+    ANNUAL_YEARS,
+    N_COMPANIES,
+    seed_synthetic_benchmark_data,
+)
+from src.database import init_db_tables  # noqa: E402
+from src.read_service import CVMReadService  # noqa: E402
+from src.settings import build_settings  # noqa: E402
+
+WEB_APP_DIR = ROOT / "apps" / "web"
+DEFAULT_BASELINE_PATH = ROOT / "docs" / "perf" / "performance_baseline.json"
+TARGET_WEB_ROUTES = (
+    "/",
+    "/empresas",
+    "/empresas/[cd_cvm]",
+    "/comparar",
+    "/setores",
+    "/setores/[slug]",
+)
+API_ENDPOINT_SPECS = (
+    {
+        "id": "GET /companies",
+        "method": "GET",
+        "path": "/companies",
+        "params": {},
+    },
+    {
+        "id": "GET /companies/filters",
+        "method": "GET",
+        "path": "/companies/filters",
+        "params": {},
+    },
+    {
+        "id": "GET /companies/suggestions?q=emp",
+        "method": "GET",
+        "path": "/companies/suggestions",
+        "params": {"q": "emp"},
+    },
+    {
+        "id": "GET /companies/1000",
+        "method": "GET",
+        "path": "/companies/1000",
+        "params": {},
+    },
+    {
+        "id": "GET /companies/1000/years",
+        "method": "GET",
+        "path": "/companies/1000/years",
+        "params": {},
+    },
+    {
+        "id": "GET /companies/1000/statements?stmt=DRE&years=2023,2024",
+        "method": "GET",
+        "path": "/companies/1000/statements",
+        "params": {"stmt": "DRE", "years": "2023,2024"},
+    },
+    {
+        "id": "GET /companies/1000/kpis?years=2023,2024",
+        "method": "GET",
+        "path": "/companies/1000/kpis",
+        "params": {"years": "2023,2024"},
+    },
+    {
+        "id": "GET /sectors",
+        "method": "GET",
+        "path": "/sectors",
+        "params": {},
+    },
+    {
+        "id": "GET /sectors/energia",
+        "method": "GET",
+        "path": "/sectors/energia",
+        "params": {},
+    },
+)
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _run(command: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+    executable = command[0]
+    if os.name == "nt" and not executable.lower().endswith(".cmd"):
+        executable = f"{executable}.cmd"
+    resolved = shutil.which(executable) or shutil.which(command[0]) or executable
+    completed = subprocess.run(
+        [resolved, *command[1:]],
+        cwd=str(cwd),
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"Command failed ({' '.join(command)}) in {cwd}\n"
+            f"stdout:\n{completed.stdout}\n"
+            f"stderr:\n{completed.stderr}"
+        )
+    return completed
+
+
+def _parse_route_table(build_stdout: str) -> dict[str, dict[str, Any]]:
+    route_prefixes = {"\u250c", "\u251c", "\u2514"}
+    static_symbol = "\u25cb"
+    dynamic_symbol = "\u0192"
+    table: dict[str, dict[str, Any]] = {}
+    for raw_line in build_stdout.splitlines():
+        line = raw_line.rstrip()
+        if not line or line[:1] not in route_prefixes:
+            continue
+        parts = line.split()
+        if len(parts) < 3:
+            continue
+        symbol = parts[1]
+        route = parts[2]
+        if not route.startswith("/"):
+            continue
+        if symbol not in {static_symbol, dynamic_symbol}:
+            continue
+        table[route] = {
+            "rendering_mode": "static" if symbol == static_symbol else "dynamic",
+        }
+    return table
+
+
+def _json_load(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def collect_web_snapshot() -> dict[str, Any]:
+    build = _run(["npm", "run", "build"], cwd=WEB_APP_DIR)
+    route_table = _parse_route_table(build.stdout)
+    bundle_stats = {
+        item["route"]: item
+        for item in _json_load(WEB_APP_DIR / ".next" / "diagnostics" / "route-bundle-stats.json")
+    }
+    prerender_manifest = _json_load(WEB_APP_DIR / ".next" / "prerender-manifest.json")
+    framework = _json_load(WEB_APP_DIR / ".next" / "diagnostics" / "framework.json")
+
+    routes: dict[str, Any] = {}
+    for route in TARGET_WEB_ROUTES:
+        if route not in route_table:
+            raise RuntimeError(f"Route {route} not found in next build output.")
+        if route not in bundle_stats:
+            raise RuntimeError(f"Route {route} not found in route-bundle-stats.json.")
+        prerender = prerender_manifest.get("routes", {}).get(route, {})
+        routes[route] = {
+            "rendering_mode": route_table[route]["rendering_mode"],
+            "revalidate_seconds": prerender.get("initialRevalidateSeconds"),
+            "first_load_uncompressed_js_bytes": int(
+                bundle_stats[route]["firstLoadUncompressedJsBytes"]
+            ),
+            "first_load_chunk_count": len(bundle_stats[route]["firstLoadChunkPaths"]),
+        }
+
+    return {
+        "framework": framework,
+        "routes": routes,
+    }
+
+
+def _percentile(values: list[float], percentile: float) -> float:
+    if not values:
+        raise ValueError("Cannot compute percentile for empty sample.")
+    sorted_values = sorted(values)
+    index = max(0, min(len(sorted_values) - 1, math.ceil(len(sorted_values) * percentile) - 1))
+    return float(sorted_values[index])
+
+
+def _time_request(
+    client: TestClient,
+    *,
+    method: str,
+    path: str,
+    params: dict[str, str],
+    runs: int,
+    warmups: int,
+) -> dict[str, float]:
+    for _ in range(warmups):
+        response = client.request(method, path, params=params)
+        if response.status_code != 200:
+            raise RuntimeError(f"Warmup failed for {method} {path}: status={response.status_code}")
+
+    timings: list[float] = []
+    for _ in range(runs):
+        started_at = time.perf_counter()
+        response = client.request(method, path, params=params)
+        elapsed_ms = (time.perf_counter() - started_at) * 1000
+        if response.status_code != 200:
+            raise RuntimeError(f"Benchmark failed for {method} {path}: status={response.status_code}")
+        timings.append(elapsed_ms)
+
+    return {
+        "median_ms": round(statistics.median(timings), 2),
+        "p95_ms": round(_percentile(timings, 0.95), 2),
+        "min_ms": round(min(timings), 2),
+        "max_ms": round(max(timings), 2),
+    }
+
+
+def collect_api_snapshot(*, runs: int, warmups: int) -> dict[str, Any]:
+    with tempfile.TemporaryDirectory(prefix="perf-guardrail-") as tmp_dir:
+        temp_root = Path(tmp_dir)
+        settings = build_settings(project_root=temp_root)
+        settings.paths.db_path.parent.mkdir(parents=True, exist_ok=True)
+        service = CVMReadService(settings=settings)
+        init_db_tables(service.engine)
+        seed_synthetic_benchmark_data(service.engine)
+
+        app = create_app(settings=settings, read_service=service)
+        endpoints: dict[str, Any] = {}
+        with TestClient(app) as client:
+            for spec in API_ENDPOINT_SPECS:
+                endpoints[spec["id"]] = {
+                    "method": spec["method"],
+                    "path": spec["path"],
+                    "params": spec["params"],
+                    **_time_request(
+                        client,
+                        method=spec["method"],
+                        path=spec["path"],
+                        params=spec["params"],
+                        runs=runs,
+                        warmups=warmups,
+                    ),
+                }
+        service.engine.dispose()
+
+    return {
+        "dataset": {
+            "companies": N_COMPANIES,
+            "annual_years": [int(year) for year in ANNUAL_YEARS],
+            "rows_note": "Synthetic benchmark dataset seeded via scripts/benchmark_read_paths.py",
+        },
+        "endpoints": endpoints,
+    }
+
+
+def capture_snapshot(*, api_runs: int, api_warmups: int) -> dict[str, Any]:
+    web_snapshot = collect_web_snapshot()
+    api_snapshot = collect_api_snapshot(runs=api_runs, warmups=api_warmups)
+    return {
+        "generated_at": _now_iso(),
+        "web": {
+            "framework": web_snapshot["framework"],
+            "routes": web_snapshot["routes"],
+        },
+        "api": api_snapshot,
+    }
+
+
+def _default_guardrail_snapshot(snapshot: dict[str, Any]) -> dict[str, Any]:
+    guardrailed = json.loads(json.dumps(snapshot))
+    for _, data in guardrailed["web"]["routes"].items():
+        baseline_bytes = int(data["first_load_uncompressed_js_bytes"])
+        data["guardrail"] = {
+            "required_rendering_mode": data["rendering_mode"],
+            "required_revalidate_seconds": data["revalidate_seconds"],
+            "max_first_load_uncompressed_js_bytes": baseline_bytes + max(50_000, int(baseline_bytes * 0.08)),
+        }
+    for _, data in guardrailed["api"]["endpoints"].items():
+        median = float(data["median_ms"])
+        p95 = float(data["p95_ms"])
+        data["guardrail"] = {
+            "max_median_ms": round(max(15.0, median * 1.75), 2),
+            "max_p95_ms": round(max(25.0, p95 * 1.9), 2),
+        }
+    guardrailed["metadata"] = {
+        "owner_lane": "ops-quality",
+        "issue": 138,
+        "purpose": "Baseline and light guardrails for main web routes and hot API endpoints.",
+    }
+    return guardrailed
+
+
+def _compare_web(baseline: dict[str, Any], current: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
+    for route, expected in baseline["web"]["routes"].items():
+        actual = current["web"]["routes"].get(route)
+        if actual is None:
+            failures.append(f"Missing web route in current snapshot: {route}")
+            continue
+        guardrail = expected["guardrail"]
+        if actual["rendering_mode"] != guardrail["required_rendering_mode"]:
+            failures.append(
+                f"Web route {route} changed rendering mode: "
+                f"{actual['rendering_mode']} != {guardrail['required_rendering_mode']}"
+            )
+        if actual.get("revalidate_seconds") != guardrail["required_revalidate_seconds"]:
+            failures.append(
+                f"Web route {route} changed revalidate_seconds: "
+                f"{actual.get('revalidate_seconds')} != {guardrail['required_revalidate_seconds']}"
+            )
+        if actual["first_load_uncompressed_js_bytes"] > guardrail["max_first_load_uncompressed_js_bytes"]:
+            failures.append(
+                f"Web route {route} exceeded JS budget: "
+                f"{actual['first_load_uncompressed_js_bytes']} > "
+                f"{guardrail['max_first_load_uncompressed_js_bytes']}"
+            )
+    return failures
+
+
+def _compare_api(baseline: dict[str, Any], current: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
+    for endpoint_id, expected in baseline["api"]["endpoints"].items():
+        actual = current["api"]["endpoints"].get(endpoint_id)
+        if actual is None:
+            failures.append(f"Missing API endpoint in current snapshot: {endpoint_id}")
+            continue
+        guardrail = expected["guardrail"]
+        if float(actual["median_ms"]) > float(guardrail["max_median_ms"]):
+            failures.append(
+                f"API endpoint {endpoint_id} exceeded median budget: "
+                f"{actual['median_ms']} > {guardrail['max_median_ms']}"
+            )
+        if float(actual["p95_ms"]) > float(guardrail["max_p95_ms"]):
+            failures.append(
+                f"API endpoint {endpoint_id} exceeded p95 budget: "
+                f"{actual['p95_ms']} > {guardrail['max_p95_ms']}"
+            )
+    return failures
+
+
+def check_snapshot(
+    *,
+    baseline_path: Path,
+    api_runs: int,
+    api_warmups: int,
+) -> dict[str, Any]:
+    resolved_baseline_path = baseline_path.resolve()
+    baseline = _json_load(resolved_baseline_path)
+    current = capture_snapshot(api_runs=api_runs, api_warmups=api_warmups)
+    failures = _compare_web(baseline, current) + _compare_api(baseline, current)
+    try:
+        baseline_display = str(resolved_baseline_path.relative_to(ROOT))
+    except ValueError:
+        baseline_display = str(resolved_baseline_path)
+    return {
+        "generated_at": _now_iso(),
+        "baseline_path": baseline_display,
+        "passed": not failures,
+        "failures": failures,
+        "baseline": baseline,
+        "current": current,
+    }
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def _print_capture(snapshot: dict[str, Any]) -> None:
+    print("Web routes")
+    for route, data in snapshot["web"]["routes"].items():
+        print(
+            f"  {route:<18} mode={data['rendering_mode']:<7} "
+            f"revalidate={data['revalidate_seconds']!s:<5} "
+            f"first_load_js={data['first_load_uncompressed_js_bytes']}"
+        )
+    print("\nAPI endpoints")
+    for endpoint_id, data in snapshot["api"]["endpoints"].items():
+        print(
+            f"  {endpoint_id:<52} median={data['median_ms']:>6}ms "
+            f"p95={data['p95_ms']:>6}ms"
+        )
+
+
+def _print_check(report: dict[str, Any]) -> None:
+    status = "PASS" if report["passed"] else "FAIL"
+    print(f"Perf guardrail: {status}")
+    if report["failures"]:
+        print("Failures:")
+        for failure in report["failures"]:
+            print(f"  - {failure}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Performance baseline + guardrail tooling")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    capture_parser = subparsers.add_parser("capture", help="Capture current snapshot and write a baseline file")
+    capture_parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_BASELINE_PATH,
+        help="Where to write the captured baseline JSON.",
+    )
+    capture_parser.add_argument("--api-runs", type=int, default=5, help="Timed runs per API endpoint.")
+    capture_parser.add_argument("--api-warmups", type=int, default=1, help="Warmup runs per API endpoint.")
+
+    check_parser = subparsers.add_parser("check", help="Capture current snapshot and check against a baseline")
+    check_parser.add_argument(
+        "--baseline",
+        type=Path,
+        default=DEFAULT_BASELINE_PATH,
+        help="Baseline JSON file with expected budgets and rendering modes.",
+    )
+    check_parser.add_argument("--api-runs", type=int, default=5, help="Timed runs per API endpoint.")
+    check_parser.add_argument("--api-warmups", type=int, default=1, help="Warmup runs per API endpoint.")
+    check_parser.add_argument(
+        "--report",
+        type=Path,
+        help="Optional JSON report path for the current check result.",
+    )
+
+    args = parser.parse_args()
+
+    if args.command == "capture":
+        snapshot = capture_snapshot(api_runs=args.api_runs, api_warmups=args.api_warmups)
+        baseline = _default_guardrail_snapshot(snapshot)
+        _write_json(args.output, baseline)
+        _print_capture(baseline)
+        print(f"\nWrote baseline to {args.output}")
+        return 0
+
+    report = check_snapshot(
+        baseline_path=args.baseline,
+        api_runs=args.api_runs,
+        api_warmups=args.api_warmups,
+    )
+    if args.report:
+        _write_json(args.report, report)
+    _print_check(report)
+    return 0 if report["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add \scripts/perf_guardrail.py\ to capture/check bundle, rendering mode and hot endpoint latency
- version the current baseline in \docs/perf/performance_baseline.json\ and document refresh policy in \docs/perf/performance_guardrails.md\
- add \.github/workflows/perf-guardrails.yml\ so the guardrail runs on PRs/pushes and uploads a JSON report artifact

## Validation
- python scripts/perf_guardrail.py capture --output docs/perf/performance_baseline.json
- python scripts/perf_guardrail.py check --baseline docs/perf/performance_baseline.json --report perf-guardrail-report.json
- python -m py_compile scripts/perf_guardrail.py scripts/benchmark_read_paths.py

Closes #138