### PR TITLE
feat(web): restore company freshness and period presets

### DIFF
--- a/apps/web/app/empresas/[cd_cvm]/page.tsx
+++ b/apps/web/app/empresas/[cd_cvm]/page.tsx
@@ -6,9 +6,9 @@ import { CompanyDetailTracker } from "@/components/company/company-detail-tracke
 import { CompanyHeader } from "@/components/company/company-header";
 import { CompanyNoDataPage } from "@/components/company/company-no-data";
 import { CompanyOverview } from "@/components/company/company-overview";
+import { CompanyPeriodPreset } from "@/components/company/company-period-preset";
 import { CompanyStatementsLazy } from "@/components/company/company-statements-lazy";
 import { CompanyUrlTabs } from "@/components/company/company-url-tabs";
-import { CompanyYearSelector } from "@/components/company/company-year-selector";
 import {
   InfoChip,
   PageShell,
@@ -171,16 +171,11 @@ export default async function EmpresaDetailPage({
 
       <CompanyHeader company={company} selectedYears={selectedYears} />
 
-      <div className="flex flex-wrap items-center gap-3 px-1">
-        <span className="text-xs uppercase tracking-[0.24em] text-muted-foreground">
-          Periodo
-        </span>
-        <CompanyYearSelector
-          pathname={pathname}
-          availableYears={availableYears}
-          selectedYears={selectedYears}
-        />
-      </div>
+      <CompanyPeriodPreset
+        pathname={pathname}
+        availableYears={availableYears}
+        selectedYears={selectedYears}
+      />
 
       <CompanyUrlTabs
         pathname={pathname}

--- a/apps/web/components/company/company-freshness-card.tsx
+++ b/apps/web/components/company/company-freshness-card.tsx
@@ -1,22 +1,135 @@
 import { CompanyRequestRefreshLazy } from "@/components/company/company-request-refresh-lazy";
+import { SurfaceCard } from "@/components/shared/design-system-recipes";
+import {
+  fetchCompanyFreshness,
+  getUserFacingErrorMessage,
+} from "@/lib/api";
 
 type CompanyFreshnessCardProps = {
   cdCvm: number;
 };
 
-export function CompanyFreshnessCard({ cdCvm }: CompanyFreshnessCardProps) {
+const RELATIVE_TIME_FORMATTER = new Intl.RelativeTimeFormat("pt-BR", {
+  numeric: "auto",
+});
+
+const ABSOLUTE_TIME_FORMATTER = new Intl.DateTimeFormat("pt-BR", {
+  day: "2-digit",
+  month: "2-digit",
+  year: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+});
+
+function formatRelative(dateIso: string): string | null {
+  const target = new Date(dateIso);
+  if (Number.isNaN(target.getTime())) {
+    return null;
+  }
+
+  const diffSeconds = Math.round((Date.now() - target.getTime()) / 1000);
+  const absSeconds = Math.abs(diffSeconds);
+
+  if (absSeconds < 60) {
+    return RELATIVE_TIME_FORMATTER.format(-diffSeconds, "second");
+  }
+
+  const minutes = Math.round(diffSeconds / 60);
+  if (Math.abs(minutes) < 60) {
+    return RELATIVE_TIME_FORMATTER.format(-minutes, "minute");
+  }
+
+  const hours = Math.round(minutes / 60);
+  if (Math.abs(hours) < 24) {
+    return RELATIVE_TIME_FORMATTER.format(-hours, "hour");
+  }
+
+  const days = Math.round(hours / 24);
+  if (Math.abs(days) < 30) {
+    return RELATIVE_TIME_FORMATTER.format(-days, "day");
+  }
+
+  const months = Math.round(days / 30);
+  if (Math.abs(months) < 12) {
+    return RELATIVE_TIME_FORMATTER.format(-months, "month");
+  }
+
+  const years = Math.round(months / 12);
+  return RELATIVE_TIME_FORMATTER.format(-years, "year");
+}
+
+function formatAbsolute(dateIso: string): string | null {
+  const target = new Date(dateIso);
+  if (Number.isNaN(target.getTime())) {
+    return null;
+  }
+
+  return ABSOLUTE_TIME_FORMATTER.format(target);
+}
+
+export async function CompanyFreshnessCard({
+  cdCvm,
+}: CompanyFreshnessCardProps) {
+  let freshness = null;
+  let fetchError: string | null = null;
+
+  try {
+    freshness = await fetchCompanyFreshness(cdCvm);
+  } catch (error) {
+    fetchError = getUserFacingErrorMessage(error);
+  }
+
+  const lastSuccessAt = freshness?.last_success_at ?? null;
+  const sourceLabel = freshness?.source_scope ?? "CVM (DFP / ITR)";
+  const relativeLabel = lastSuccessAt ? formatRelative(lastSuccessAt) : null;
+  const absoluteLabel = lastSuccessAt ? formatAbsolute(lastSuccessAt) : null;
+
   return (
-    <div
-      className="rounded-[1.25rem] border p-5"
-      style={{
-        borderColor: "color-mix(in oklch, var(--chart-1) 25%, transparent)",
-        background: "color-mix(in oklch, var(--chart-1) 5%, var(--card))",
-      }}
-    >
-      <p className="mb-3 text-[0.72rem] font-medium uppercase tracking-[0.18em] text-muted-foreground">
-        Atualização
-      </p>
+    <SurfaceCard tone="inset" padding="md" className="space-y-4">
+      <div className="space-y-2">
+        <p className="text-xs uppercase tracking-[0.22em] text-muted-foreground">
+          Atualizacao dos dados
+        </p>
+        <h3 className="font-heading text-xl tracking-[-0.02em] text-foreground">
+          Dispare uma nova leitura da CVM
+        </h3>
+        <p className="text-sm leading-6 text-muted-foreground">
+          Use este CTA quando precisar dos demonstrativos mais recentes
+          divulgados pela CVM.
+        </p>
+      </div>
+
+      <dl className="grid gap-2.5 text-sm">
+        <div className="flex items-baseline justify-between gap-3">
+          <dt className="text-muted-foreground">Ultima leitura</dt>
+          <dd
+            className="text-right font-medium text-foreground"
+            title={absoluteLabel ?? undefined}
+          >
+            {relativeLabel ?? "Sem leitura previa"}
+          </dd>
+        </div>
+        {absoluteLabel ? (
+          <div className="flex items-baseline justify-between gap-3">
+            <dt className="text-muted-foreground">Data exata</dt>
+            <dd className="text-right tabular-nums text-foreground/78">
+              {absoluteLabel}
+            </dd>
+          </div>
+        ) : null}
+        <div className="flex items-baseline justify-between gap-3">
+          <dt className="text-muted-foreground">Fonte</dt>
+          <dd className="text-right text-foreground">{sourceLabel}</dd>
+        </div>
+      </dl>
+
+      {fetchError ? (
+        <p className="text-xs leading-5 text-destructive">
+          Status indisponivel: {fetchError}
+        </p>
+      ) : null}
+
       <CompanyRequestRefreshLazy cdCvm={cdCvm} />
-    </div>
+    </SurfaceCard>
   );
 }

--- a/apps/web/components/company/company-period-preset.tsx
+++ b/apps/web/components/company/company-period-preset.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { startTransition, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+import { CompanyYearSelector } from "@/components/company/company-year-selector";
+import { Button } from "@/components/ui/button";
+import { mergeSearchParams, serializeYears } from "@/lib/search-params";
+import { track } from "@/lib/track";
+
+type PresetValue = "3a" | "5a" | "all" | "custom";
+
+type CompanyPeriodPresetProps = {
+  pathname: string;
+  availableYears: number[];
+  selectedYears: number[];
+};
+
+const PRESET_OPTIONS: Array<{
+  value: PresetValue;
+  label: string;
+  minYears?: number;
+}> = [
+  { value: "3a", label: "3A", minYears: 3 },
+  { value: "5a", label: "5A", minYears: 5 },
+  { value: "all", label: "Todos" },
+  { value: "custom", label: "Personalizado" },
+];
+
+function arraysEqual(left: number[], right: number[]): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  return left.every((value, index) => value === right[index]);
+}
+
+function getLastNYears(years: number[], count: number): number[] {
+  return years.slice(Math.max(0, years.length - count));
+}
+
+function detectPreset(
+  availableYears: number[],
+  selectedYears: number[],
+): PresetValue {
+  if (arraysEqual(availableYears, selectedYears)) {
+    return "all";
+  }
+
+  if (
+    availableYears.length >= 3 &&
+    arraysEqual(getLastNYears(availableYears, 3), selectedYears)
+  ) {
+    return "3a";
+  }
+
+  if (
+    availableYears.length >= 5 &&
+    arraysEqual(getLastNYears(availableYears, 5), selectedYears)
+  ) {
+    return "5a";
+  }
+
+  return "custom";
+}
+
+function resolvePresetYears(
+  preset: Exclude<PresetValue, "custom">,
+  availableYears: number[],
+): number[] {
+  switch (preset) {
+    case "3a":
+      return getLastNYears(availableYears, 3);
+    case "5a":
+      return getLastNYears(availableYears, 5);
+    case "all":
+      return availableYears;
+  }
+}
+
+export function CompanyPeriodPreset({
+  pathname,
+  availableYears,
+  selectedYears,
+}: CompanyPeriodPresetProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const derivedPreset = detectPreset(availableYears, selectedYears);
+  const [customLocked, setCustomLocked] = useState(derivedPreset === "custom");
+  const activePreset: PresetValue = customLocked ? "custom" : derivedPreset;
+
+  function applyPreset(nextPreset: PresetValue) {
+    if (nextPreset === "custom") {
+      setCustomLocked(true);
+      return;
+    }
+
+    setCustomLocked(false);
+    const nextYears = resolvePresetYears(nextPreset, availableYears);
+
+    if (arraysEqual(nextYears, selectedYears)) {
+      return;
+    }
+
+    const query = mergeSearchParams(searchParams.toString(), {
+      anos: serializeYears(nextYears),
+    });
+
+    track("company_years_changed", {
+      years: nextYears.join(","),
+      preset: nextPreset,
+    });
+
+    startTransition(() => {
+      router.push(`${pathname}?${query}`);
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-center gap-3 px-1">
+        <span className="text-xs uppercase tracking-[0.24em] text-muted-foreground">
+          Periodo
+        </span>
+        <div className="flex flex-wrap gap-2">
+          {PRESET_OPTIONS.map((option) => {
+            const active = option.value === activePreset;
+            const disabled =
+              option.minYears !== undefined &&
+              availableYears.length < option.minYears;
+
+            return (
+              <Button
+                key={option.value}
+                type="button"
+                variant={active ? "secondary" : "outline"}
+                size="sm"
+                className="rounded-full px-4"
+                disabled={disabled}
+                onClick={() => applyPreset(option.value)}
+              >
+                {option.label}
+              </Button>
+            );
+          })}
+        </div>
+      </div>
+
+      {activePreset === "custom" ? (
+        <div className="px-1">
+          <CompanyYearSelector
+            pathname={pathname}
+            availableYears={availableYears}
+            selectedYears={selectedYears}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -848,3 +848,19 @@ export async function fetchRefreshStatus(
     },
   )) as RefreshStatusItem[];
 }
+
+export async function fetchCompanyFreshness(
+  cdCvm: number,
+): Promise<RefreshStatusItem | null> {
+  const items = (await apiFetch<RefreshStatusItem[]>(
+    `/refresh-status${buildQuery({ cd_cvm: cdCvm })}`,
+    {
+      request: UNCACHED_API_READ,
+      validate: isRefreshStatusList,
+      invalidResponseMessage:
+        "A API retornou um status invalido para a companhia.",
+    },
+  )) as RefreshStatusItem[];
+
+  return items[0] ?? null;
+}


### PR DESCRIPTION
## Summary
- replace the company detail year-chip toolbar with preset controls for `3A`, `5A`, `Todos` and `Personalizado`
- restore the freshness card so it shows the latest successful CVM refresh timestamp while keeping the existing on-demand refresh CTA
- add a dedicated `fetchCompanyFreshness` helper against `GET /refresh-status` for the server-rendered right rail card

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run build`

Closes #148