### PR TITLE
feat(web): wire real light/dark theme toggle

### DIFF
--- a/apps/web/app/design-system/page.tsx
+++ b/apps/web/app/design-system/page.tsx
@@ -9,7 +9,6 @@ import { Accordion, AccordionItem, AccordionPanel, AccordionTrigger } from "@/co
 import ContentTooltipDemo from "@/components/contemt-tooltip";
 import { NativeDelete } from "@/components/delete-button";
 import { InteractiveMenu } from "@/components/modern-mobile-menu";
-import { Providers } from "@/components/providers";
 import {
   InfoChip,
   SectionHeading,
@@ -277,7 +276,7 @@ function Section({
 
 export default function DesignSystemPage() {
   return (
-    <Providers>
+    <>
       {/* eslint-disable-next-line @next/next/no-page-custom-font */}
       <link
         rel="stylesheet"
@@ -809,6 +808,6 @@ export default function DesignSystemPage() {
           </div>
         </main>
       </div>
-    </Providers>
+    </>
   );
 }

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import type { Metadata } from "next";
 import { IBM_Plex_Mono, Manrope, Space_Grotesk } from "next/font/google";
 
+import { Providers } from "@/components/providers";
 import { SiteFooter } from "@/components/shared/site-footer";
 import { SiteHeader } from "@/components/shared/site-header";
 import "./globals.css";
@@ -46,16 +47,18 @@ export default function RootLayout({ children }: RootLayoutProps) {
       className={`${bodyFont.variable} ${headingFont.variable} ${monoFont.variable} h-full antialiased`}
     >
       <body className="min-h-full bg-background text-foreground">
-        <div className="relative flex min-h-screen flex-col overflow-x-hidden">
-          <div className="pointer-events-none absolute inset-x-0 top-0 -z-30 h-[28rem] overflow-hidden sm:h-[34rem] lg:h-[39rem]">
-            <div className="absolute inset-0 bg-background" />
+        <Providers>
+          <div className="relative flex min-h-screen flex-col overflow-x-hidden">
+            <div className="pointer-events-none absolute inset-x-0 top-0 -z-30 h-[28rem] overflow-hidden sm:h-[34rem] lg:h-[39rem]">
+              <div className="absolute inset-0 bg-background" />
+            </div>
+            <div className="pointer-events-none absolute inset-x-0 top-0 -z-20 h-[30rem] bg-[radial-gradient(circle_at_top_left,_rgba(183,110,44,0.12),_transparent_28%),radial-gradient(circle_at_top_right,_rgba(19,71,52,0.12),_transparent_26%),linear-gradient(180deg,_rgba(14,16,15,0.18)_0%,_rgba(14,16,15,0.08)_46%,_rgba(14,16,15,0)_100%)] sm:h-[36rem] lg:h-[41rem]" />
+            <div className="pointer-events-none absolute inset-0 -z-10 bg-[linear-gradient(rgba(33,39,33,0.03)_1px,transparent_1px),linear-gradient(90deg,rgba(33,39,33,0.03)_1px,transparent_1px)] bg-[size:52px_52px] [mask-image:linear-gradient(to_bottom,white_20%,transparent_95%)]" />
+            <SiteHeader />
+            <main className="flex-1">{children}</main>
+            <SiteFooter />
           </div>
-          <div className="pointer-events-none absolute inset-x-0 top-0 -z-20 h-[30rem] bg-[radial-gradient(circle_at_top_left,_rgba(183,110,44,0.12),_transparent_28%),radial-gradient(circle_at_top_right,_rgba(19,71,52,0.12),_transparent_26%),linear-gradient(180deg,_rgba(14,16,15,0.18)_0%,_rgba(14,16,15,0.08)_46%,_rgba(14,16,15,0)_100%)] sm:h-[36rem] lg:h-[41rem]" />
-          <div className="pointer-events-none absolute inset-0 -z-10 bg-[linear-gradient(rgba(33,39,33,0.03)_1px,transparent_1px),linear-gradient(90deg,rgba(33,39,33,0.03)_1px,transparent_1px)] bg-[size:52px_52px] [mask-image:linear-gradient(to_bottom,white_20%,transparent_95%)]" />
-          <SiteHeader />
-          <main className="flex-1">{children}</main>
-          <SiteFooter />
-        </div>
+        </Providers>
       </body>
     </html>
   );

--- a/apps/web/components/providers.tsx
+++ b/apps/web/components/providers.tsx
@@ -5,7 +5,12 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
-    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+    <ThemeProvider
+      attribute="class"
+      defaultTheme="system"
+      enableSystem
+      disableTransitionOnChange
+    >
       <TooltipProvider>
         {children}
       </TooltipProvider>

--- a/apps/web/components/shared/site-header.tsx
+++ b/apps/web/components/shared/site-header.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 
+import ThemeToggle from "@/components/toggle-theme";
 import { buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -56,8 +57,9 @@ export function SiteHeader() {
           )}
         </nav>
 
-        <div className="hidden items-center gap-3 lg:flex">
-          <span className="text-xs uppercase tracking-[0.26em] text-muted-foreground">
+        <div className="flex items-center gap-3">
+          <ThemeToggle className="rounded-full border border-border/65 bg-background/78 px-2 py-1 shadow-sm shadow-black/5" />
+          <span className="hidden text-xs uppercase tracking-[0.26em] text-muted-foreground lg:inline">
             Slice publico V2
           </span>
         </div>

--- a/apps/web/components/toggle-theme.tsx
+++ b/apps/web/components/toggle-theme.tsx
@@ -1,49 +1,82 @@
 "use client";
 
-import { useId, useState } from "react";
+import { useId, useSyncExternalStore } from "react";
+import { useTheme } from "next-themes";
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
 import { MoonIcon, SunIcon } from "lucide-react";
 
-const SwitchToggleThemeDemo = () => {
+type ThemeToggleProps = {
+  className?: string;
+};
+
+const subscribe = () => () => {};
+const getClientSnapshot = () => true;
+const getServerSnapshot = () => false;
+
+const ThemeToggle = ({ className }: ThemeToggleProps) => {
   const id = useId();
-  const [isDark, setIsDark] = useState(true);
+  const { resolvedTheme, setTheme } = useTheme();
+  const mounted = useSyncExternalStore(
+    subscribe,
+    getClientSnapshot,
+    getServerSnapshot,
+  );
+
+  const isDark = mounted && resolvedTheme === "dark";
+
+  const handleThemeChange = (nextDark: boolean) => {
+    if (!mounted) {
+      return;
+    }
+
+    setTheme(nextDark ? "dark" : "light");
+  };
 
   return (
-    <div className="group inline-flex items-center gap-2">
-      <span
+    <div className={cn("group inline-flex items-center gap-2", className)}>
+      <button
+        type="button"
         id={`${id}-light`}
         className={cn(
-          "cursor-pointer text-left text-sm font-medium",
+          "cursor-pointer rounded-full p-1 text-left text-sm font-medium transition-colors disabled:cursor-default disabled:opacity-70",
           isDark && "text-foreground/50",
         )}
         aria-controls={id}
-        onClick={() => setIsDark(false)}
+        aria-label="Ativar tema claro"
+        aria-pressed={mounted && !isDark}
+        onClick={() => handleThemeChange(false)}
+        disabled={!mounted}
       >
         <SunIcon className="size-4" aria-hidden="true" />
-      </span>
+      </button>
 
       <Switch
         id={id}
         checked={isDark}
-        onCheckedChange={setIsDark}
+        onCheckedChange={handleThemeChange}
         aria-labelledby={`${id}-light ${id}-dark`}
-        aria-label="Toggle between dark and light mode"
+        aria-label="Alternar entre tema claro e escuro"
+        disabled={!mounted}
       />
 
-      <span
+      <button
+        type="button"
         id={`${id}-dark`}
         className={cn(
-          "cursor-pointer text-right text-sm font-medium",
+          "cursor-pointer rounded-full p-1 text-right text-sm font-medium transition-colors disabled:cursor-default disabled:opacity-70",
           isDark || "text-foreground/50",
         )}
         aria-controls={id}
-        onClick={() => setIsDark(true)}
+        aria-label="Ativar tema escuro"
+        aria-pressed={mounted && isDark}
+        onClick={() => handleThemeChange(true)}
+        disabled={!mounted}
       >
         <MoonIcon className="size-4" aria-hidden="true" />
-      </span>
+      </button>
     </div>
   );
 };
 
-export default SwitchToggleThemeDemo;
+export default ThemeToggle;


### PR DESCRIPTION
## Summary
- move the web ThemeProvider to the root layout so light/dark classes apply across the full app
- connect the existing Toggle Theme - larsen66 component to 
ext-themes and persist the chosen mode
- expose the toggle in the main header and remove the redundant nested provider from /design-system

## Validation
- 
pm run lint
- 
pm run typecheck
- 
pm run build
- local smoke on http://127.0.0.1:3100 confirming html.light -> html.dark -> html.light and localStorage.theme

Closes #150