### PR TITLE
feat(master): enable on-demand bootstrap for unknown companies

### DIFF
--- a/apps/api/app/dependencies.py
+++ b/apps/api/app/dependencies.py
@@ -5,6 +5,7 @@ from typing import Iterable
 
 from fastapi import HTTPException, Query, Request, status
 
+from src.company_catalog import CompanyCatalogUnavailableError
 from src.read_service import CVMReadService
 from src.settings import AppSettings
 from src.startup import StartupReport, collect_startup_report
@@ -177,9 +178,16 @@ def limit_dependency(
     return int(limit)
 
 
-def coerce_company(cd_cvm: int, service: CVMReadService) -> None:
-    if service.get_company_info(cd_cvm) is None:
+def coerce_company(cd_cvm: int, service: CVMReadService):
+    try:
+        company = service.get_company_info(cd_cvm)
+    except CompanyCatalogUnavailableError as exc:
+        raise ServiceUnavailableError(
+            "Nao foi possivel consultar o catalogo CVM agora."
+        ) from exc
+    if company is None:
         raise NotFoundError(f"Empresa {cd_cvm} nao encontrada.")
+    return company
 
 
 def serialize_error(exc: ApiError) -> dict[str, dict[str, str]]:

--- a/apps/api/app/routes/companies.py
+++ b/apps/api/app/routes/companies.py
@@ -5,7 +5,7 @@ from fastapi.responses import Response
 
 from apps.api.app.dependencies import (
     InvalidRequestError,
-    NotFoundError,
+    ServiceUnavailableError,
     company_ids_dependency,
     coerce_company,
     ensure_api_ready,
@@ -33,6 +33,7 @@ from apps.api.app.presenters import (
     present_statement,
     present_statement_summary,
 )
+from src.company_catalog import CompanyCatalogUnavailableError
 from src.read_service import CVMReadService
 
 router = APIRouter(tags=["companies"])
@@ -149,7 +150,10 @@ def request_company_refresh(
     service: CVMReadService = Depends(get_read_service),
 ) -> RefreshDispatchPayload:
     ensure_api_ready(get_settings(request))
-    result = service.request_company_refresh(cd_cvm)
+    try:
+        result = service.request_company_refresh(cd_cvm)
+    except CompanyCatalogUnavailableError as exc:
+        raise ServiceUnavailableError(str(exc)) from exc
     if result == "already_queued":
         raise HTTPException(status_code=429, detail={"code": "refresh_already_queued"})
     return RefreshDispatchPayload(status=result, cd_cvm=cd_cvm)
@@ -192,9 +196,7 @@ def get_company(
     service: CVMReadService = Depends(get_read_service),
 ) -> CompanyInfoPayload:
     ensure_api_ready(get_settings(request))
-    info = service.get_company_info(cd_cvm)
-    if info is None:
-        raise NotFoundError(f"Empresa {cd_cvm} nao encontrada.")
+    info = coerce_company(cd_cvm, service)
     _apply_cache_headers(response, COMPANY_INFO_CACHE_CONTROL)
     return present_company_info(info)
 

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -16,6 +16,14 @@ from src.settings import AppSettings, build_settings
 API_TEST_DATABASE_URL_ENV = "API_TEST_DATABASE_URL"
 
 
+class _EmptyCompanyCatalog:
+    def lookup_company(self, cd_cvm: int):
+        return None
+
+    def search_companies(self, *, q: str, limit: int, exclude_codes=None):
+        return ()
+
+
 def _write_active_universe_cache(settings: AppSettings) -> None:
     settings.paths.cache_dir.mkdir(parents=True, exist_ok=True)
     payload = {
@@ -301,5 +309,6 @@ def api_settings(tmp_path: Path) -> AppSettings:
 @pytest.fixture
 def client(api_settings: AppSettings) -> TestClient:
     app = create_app(settings=api_settings)
+    app.state.read_service._company_catalog = _EmptyCompanyCatalog()
     with TestClient(app) as test_client:
         yield test_client

--- a/apps/api/tests/test_api_contract.py
+++ b/apps/api/tests/test_api_contract.py
@@ -11,7 +11,43 @@ import pytest
 from fastapi.testclient import TestClient
 
 from apps.api.app.main import create_app
+from src.company_catalog import CompanyCatalogEntry
 from src.settings import build_settings
+
+
+class StaticCompanyCatalog:
+    def __init__(self, *entries: CompanyCatalogEntry):
+        self.entries = tuple(entries)
+        self.by_cd_cvm = {entry.cd_cvm: entry for entry in entries}
+
+    def lookup_company(self, cd_cvm: int) -> CompanyCatalogEntry | None:
+        return self.by_cd_cvm.get(int(cd_cvm))
+
+    def search_companies(
+        self,
+        *,
+        q: str,
+        limit: int,
+        exclude_codes=None,
+    ) -> tuple[CompanyCatalogEntry, ...]:
+        normalized = str(q or "").strip().lower()
+        excluded = set(exclude_codes or set())
+        if not normalized:
+            return ()
+
+        matches = []
+        for entry in self.entries:
+            if entry.cd_cvm in excluded:
+                continue
+            haystacks = [
+                entry.company_name.lower(),
+                (entry.nome_comercial or "").lower(),
+                (entry.ticker_b3 or "").lower(),
+                str(entry.cd_cvm),
+            ]
+            if any(normalized in value for value in haystacks):
+                matches.append(entry)
+        return tuple(matches[: int(limit)])
 
 
 def test_health_returns_ok_payload(client: TestClient):
@@ -272,6 +308,34 @@ def test_company_suggestions_returns_empty_for_no_match(client: TestClient):
     assert response.json()["items"] == []
 
 
+def test_company_suggestions_fall_back_to_catalog_when_local_matches_are_missing(
+    client: TestClient,
+):
+    client.app.state.read_service._company_catalog = StaticCompanyCatalog(
+        CompanyCatalogEntry(
+            cd_cvm=19348,
+            company_name="ITAU UNIBANCO HOLDING S.A.",
+            nome_comercial="Itau Unibanco",
+            cnpj="60.872.504/0001-23",
+            setor_cvm="Financeiro",
+            ticker_b3="ITUB4",
+            is_active=True,
+        )
+    )
+
+    response = client.get("/companies/suggestions", params={"q": "itub4"})
+
+    assert response.status_code == 200
+    assert response.json()["items"] == [
+        {
+            "cd_cvm": 19348,
+            "company_name": "ITAU UNIBANCO HOLDING S.A.",
+            "ticker_b3": "ITUB4",
+            "sector_slug": "financeiro",
+        }
+    ]
+
+
 def test_company_suggestions_rejects_limit_above_max(client: TestClient):
     response = client.get("/companies/suggestions", params={"limit": 21})
 
@@ -383,6 +447,59 @@ def test_request_refresh_returns_202_dispatch_failed_without_github_token(client
     payload = response.json()
     assert payload["cd_cvm"] == 9512
     assert payload["status"] == "dispatch_failed"
+
+
+def test_request_refresh_bootstraps_unknown_local_company_from_catalog(
+    client: TestClient,
+):
+    from sqlalchemy import text as sa_text
+
+    client.app.state.read_service._company_catalog = StaticCompanyCatalog(
+        CompanyCatalogEntry(
+            cd_cvm=19348,
+            company_name="ITAU UNIBANCO HOLDING S.A.",
+            nome_comercial="Itau Unibanco",
+            cnpj="60.872.504/0001-23",
+            setor_cvm="Financeiro",
+            ticker_b3="ITUB4",
+            is_active=True,
+        )
+    )
+
+    response = client.post("/companies/19348/request-refresh")
+
+    assert response.status_code == 202
+    payload = response.json()
+    assert payload["cd_cvm"] == 19348
+    assert payload["status"] == "dispatch_failed"
+
+    engine = client.app.state.read_service.engine
+    with engine.connect() as conn:
+        company_row = conn.execute(
+            sa_text(
+                """
+                SELECT company_name, nome_comercial, setor_cvm, ticker_b3
+                FROM companies
+                WHERE cd_cvm = 19348
+                """
+            )
+        ).mappings().one()
+        refresh_row = conn.execute(
+            sa_text(
+                """
+                SELECT source_scope, last_status
+                FROM company_refresh_status
+                WHERE cd_cvm = 19348
+                """
+            )
+        ).mappings().one()
+
+    assert company_row["company_name"] == "ITAU UNIBANCO HOLDING S.A."
+    assert company_row["nome_comercial"] == "Itau Unibanco"
+    assert company_row["setor_cvm"] == "Financeiro"
+    assert company_row["ticker_b3"] == "ITUB4"
+    assert refresh_row["source_scope"] == "on_demand_bootstrap"
+    assert refresh_row["last_status"] == "dispatch_failed"
 
 
 def test_request_refresh_returns_404_for_unknown_company(client: TestClient):
@@ -520,6 +637,32 @@ def test_company_detail_returns_metadata(client: TestClient):
     assert payload["sector_slug"] == "energia"
 
 
+def test_company_detail_uses_catalog_fallback_for_unknown_local_company(
+    client: TestClient,
+):
+    client.app.state.read_service._company_catalog = StaticCompanyCatalog(
+        CompanyCatalogEntry(
+            cd_cvm=19348,
+            company_name="ITAU UNIBANCO HOLDING S.A.",
+            nome_comercial="Itau Unibanco",
+            cnpj="60.872.504/0001-23",
+            setor_cvm="Financeiro",
+            ticker_b3="ITUB4",
+            is_active=True,
+        )
+    )
+
+    response = client.get("/companies/19348")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["company_name"] == "ITAU UNIBANCO HOLDING S.A."
+    assert payload["nome_comercial"] == "Itau Unibanco"
+    assert payload["sector_name"] == "Financeiro"
+    assert payload["sector_slug"] == "financeiro"
+    assert payload["ticker_b3"] == "ITUB4"
+
+
 def test_company_detail_uses_sector_fallback_when_analytical_sector_is_missing(client: TestClient):
     response = client.get("/companies/11223")
 
@@ -546,6 +689,27 @@ def test_company_years_returns_sorted_values(client: TestClient):
 
 def test_company_years_returns_empty_list_when_company_has_no_reports(client: TestClient):
     response = client.get("/companies/77889/years")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_company_years_return_empty_list_for_catalog_company_without_local_reports(
+    client: TestClient,
+):
+    client.app.state.read_service._company_catalog = StaticCompanyCatalog(
+        CompanyCatalogEntry(
+            cd_cvm=19348,
+            company_name="ITAU UNIBANCO HOLDING S.A.",
+            nome_comercial="Itau Unibanco",
+            cnpj="60.872.504/0001-23",
+            setor_cvm="Financeiro",
+            ticker_b3="ITUB4",
+            is_active=True,
+        )
+    )
+
+    response = client.get("/companies/19348/years")
 
     assert response.status_code == 200
     assert response.json() == []

--- a/apps/web/components/companies/companies-directory-client.tsx
+++ b/apps/web/components/companies/companies-directory-client.tsx
@@ -186,6 +186,9 @@ export function CompaniesDirectoryPageContent({
           viewMode={viewMode}
           hasActiveFilters={Boolean(currentSearch || currentSector)}
           clearHref={clearHref}
+          fallbackSuggestions={data.fallbackSuggestions?.items ?? []}
+          searchTerm={currentSearch}
+          showCatalogFallback={!currentSector}
         />
 
         <DirectoryPagination

--- a/apps/web/components/companies/company-card.tsx
+++ b/apps/web/components/companies/company-card.tsx
@@ -32,16 +32,14 @@ export function CompanyCard({ item }: CompanyCardProps) {
 
   return (
     <Link
-      href={hasData ? `/empresas/${item.cd_cvm}` : "#"}
-      aria-disabled={!hasData}
+      href={`/empresas/${item.cd_cvm}`}
       className={cn(
         "group flex flex-col gap-4 overflow-hidden rounded-[1.25rem] border border-border/60 bg-card p-5 transition-all duration-200",
         hasData
           ? "hover:-translate-y-0.5 hover:border-primary/25 hover:shadow-[0_18px_36px_-24px_rgba(16,30,24,0.2)]"
-          : "pointer-events-none opacity-50",
+          : "hover:-translate-y-0.5 hover:border-primary/20 hover:bg-muted/30",
       )}
     >
-      {/* Header: avatar + ticker + arrow */}
       <div className="flex items-start justify-between gap-3">
         <div className="flex items-center gap-3">
           <div
@@ -54,9 +52,9 @@ export function CompanyCard({ item }: CompanyCardProps) {
           >
             {initials}
           </div>
-          {item.ticker_b3 && (
+          {item.ticker_b3 ? (
             <span
-              className="rounded-[0.35rem] border font-mono text-[0.7rem] font-medium px-1.5 py-0.5"
+              className="rounded-[0.35rem] border px-1.5 py-0.5 font-mono text-[0.7rem] font-medium"
               style={{
                 background: `color-mix(in oklch, ${color} 10%, transparent)`,
                 borderColor: `color-mix(in oklch, ${color} 22%, transparent)`,
@@ -65,7 +63,7 @@ export function CompanyCard({ item }: CompanyCardProps) {
             >
               {item.ticker_b3}
             </span>
-          )}
+          ) : null}
         </div>
         <svg
           width="14"
@@ -85,23 +83,26 @@ export function CompanyCard({ item }: CompanyCardProps) {
         </svg>
       </div>
 
-      {/* Name + sector */}
       <div className="min-w-0 flex-1">
-        <p className="font-heading text-[0.95rem] font-medium leading-tight text-foreground line-clamp-2">
+        <p className="line-clamp-2 font-heading text-[0.95rem] font-medium leading-tight text-foreground">
           {item.company_name}
         </p>
-        {item.sector_name && (
+        {item.sector_name ? (
           <p className="mt-0.5 text-[0.75rem] text-muted-foreground">{item.sector_name}</p>
-        )}
+        ) : null}
+        {!hasData ? (
+          <p className="mt-2 text-[0.72rem] font-medium uppercase tracking-[0.18em] text-primary/80">
+            Disponivel on-demand
+          </p>
+        ) : null}
       </div>
 
-      {/* Metrics row */}
       <div className="grid grid-cols-3 divide-x divide-border/60 border-t border-border/60 pt-3">
         {(
           [
-            { label: "Receita", value: "—" },
-            { label: "YoY", value: "—" },
-            { label: "ROE", value: "—" },
+            { label: "Receita", value: "--" },
+            { label: "YoY", value: "--" },
+            { label: "ROE", value: "--" },
           ] as const
         ).map(({ label, value }) => (
           <div key={label} className="px-2 first:pl-0 last:pr-0">
@@ -115,8 +116,7 @@ export function CompanyCard({ item }: CompanyCardProps) {
         ))}
       </div>
 
-      {/* Sparkline */}
-      {sparkPts && (
+      {sparkPts ? (
         <div className="overflow-hidden rounded-[0.5rem]">
           <svg
             width="100%"
@@ -141,7 +141,7 @@ export function CompanyCard({ item }: CompanyCardProps) {
             />
           </svg>
         </div>
-      )}
+      ) : null}
     </Link>
   );
 }

--- a/apps/web/components/companies/company-directory-list.tsx
+++ b/apps/web/components/companies/company-directory-list.tsx
@@ -5,7 +5,8 @@ import { CompanyCard } from "@/components/companies/company-card";
 import { CompanyRow } from "@/components/companies/company-row";
 import { SurfaceCard } from "@/components/shared/design-system-recipes";
 import { buttonVariants } from "@/components/ui/button";
-import type { CompanyDirectoryItem } from "@/lib/api";
+import type { CompanyDirectoryItem, CompanySuggestionItem } from "@/lib/api";
+import { getSectorNameFromSlug } from "@/lib/constants";
 import { cn } from "@/lib/utils";
 
 type CompanyDirectoryListProps = {
@@ -13,6 +14,9 @@ type CompanyDirectoryListProps = {
   viewMode: "rows" | "cards";
   hasActiveFilters: boolean;
   clearHref: string;
+  fallbackSuggestions?: CompanySuggestionItem[];
+  searchTerm?: string;
+  showCatalogFallback?: boolean;
 };
 
 export function CompanyDirectoryList({
@@ -20,16 +24,59 @@ export function CompanyDirectoryList({
   viewMode,
   hasActiveFilters,
   clearHref,
+  fallbackSuggestions = [],
+  searchTerm = "",
+  showCatalogFallback = false,
 }: CompanyDirectoryListProps) {
   if (items.length === 0) {
+    const hasCatalogFallback =
+      showCatalogFallback &&
+      searchTerm.trim().length >= 2 &&
+      fallbackSuggestions.length > 0;
+
     return (
       <SurfaceCard tone="muted" padding="hero" className="items-center text-center">
         <InboxIcon className="size-10 text-muted-foreground/50" />
-        <p className="font-heading text-xl text-foreground">Nenhuma empresa encontrada.</p>
-        <p className="max-w-sm text-sm leading-7 text-muted-foreground">
-          Ajuste o termo de busca ou remova o filtro setorial para ampliar o diretório
-          disponível.
+        <p className="font-heading text-xl text-foreground">
+          {hasCatalogFallback
+            ? "Nenhuma empresa encontrada na base local."
+            : "Nenhuma empresa encontrada."}
         </p>
+        <p className="max-w-sm text-sm leading-7 text-muted-foreground">
+          {hasCatalogFallback
+            ? "O diretorio local ainda nao tem dados processados para essa busca, mas o catalogo CVM abaixo permite abrir a pagina e solicitar o bootstrap on-demand."
+            : "Ajuste o termo de busca ou remova o filtro setorial para ampliar o diretorio disponivel."}
+        </p>
+
+        {hasCatalogFallback ? (
+          <div className="grid w-full max-w-2xl gap-3 text-left">
+            {fallbackSuggestions.map((item) => (
+              <Link
+                key={item.cd_cvm}
+                href={`/empresas/${item.cd_cvm}`}
+                className="rounded-[1.25rem] border border-border/65 bg-card px-4 py-3 transition-colors hover:border-primary/25 hover:bg-background"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div className="min-w-0 space-y-1">
+                    <p className="truncate font-medium text-foreground">{item.company_name}</p>
+                    <p className="text-sm text-muted-foreground">
+                      {getSectorNameFromSlug(item.sector_slug) ?? "Setor nao informado"}
+                    </p>
+                  </div>
+                  <div className="text-right">
+                    {item.ticker_b3 ? (
+                      <p className="font-mono text-xs uppercase tracking-[0.18em] text-muted-foreground">
+                        {item.ticker_b3}
+                      </p>
+                    ) : null}
+                    <p className="font-mono text-sm text-foreground">CVM {item.cd_cvm}</p>
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
+        ) : null}
+
         {hasActiveFilters ? (
           <Link
             href={clearHref}

--- a/apps/web/components/companies/company-row.tsx
+++ b/apps/web/components/companies/company-row.tsx
@@ -30,24 +30,19 @@ export function CompanyRow({ item }: CompanyRowProps) {
   const anos = item.anos_disponiveis ?? [];
   const sparkPts = buildSparklinePoints(anos);
   const initials = (item.ticker_b3 ?? item.company_name).slice(0, 2).toUpperCase();
-  const yearsRange =
-    anos.length > 0 ? `${Math.min(...anos)}–${Math.max(...anos)}` : "—";
+  const yearsRange = anos.length > 0 ? `${Math.min(...anos)}-${Math.max(...anos)}` : "--";
 
   return (
     <Link
-      href={hasData ? `/empresas/${item.cd_cvm}` : "#"}
-      aria-disabled={!hasData}
+      href={`/empresas/${item.cd_cvm}`}
       className={cn(
         "group grid items-center gap-x-4 px-5 py-3 transition-colors",
         "[grid-template-columns:42px_minmax(0,1fr)_32px]",
         "sm:[grid-template-columns:42px_minmax(0,2fr)_minmax(0,1fr)_32px]",
         "lg:[grid-template-columns:42px_minmax(0,2.2fr)_minmax(0,1.1fr)_minmax(0,1fr)_minmax(0,0.85fr)_32px]",
-        hasData
-          ? "cursor-pointer hover:bg-muted/40"
-          : "pointer-events-none opacity-50",
+        hasData ? "cursor-pointer hover:bg-muted/40" : "hover:bg-muted/25",
       )}
     >
-      {/* Sector avatar */}
       <div
         className="flex size-[42px] shrink-0 items-center justify-center rounded-[10px] font-heading text-sm font-semibold"
         style={{
@@ -59,15 +54,14 @@ export function CompanyRow({ item }: CompanyRowProps) {
         {initials}
       </div>
 
-      {/* Name + ticker + CVM */}
       <div className="min-w-0">
         <div className="flex flex-wrap items-center gap-1.5">
-          <span className="truncate font-medium text-[0.9rem] text-foreground">
+          <span className="truncate text-[0.9rem] font-medium text-foreground">
             {item.company_name}
           </span>
-          {item.ticker_b3 && (
+          {item.ticker_b3 ? (
             <span
-              className="shrink-0 rounded-[0.35rem] border font-mono text-[0.68rem] font-medium px-1.5 py-0.5"
+              className="shrink-0 rounded-[0.35rem] border px-1.5 py-0.5 font-mono text-[0.68rem] font-medium"
               style={{
                 background: `color-mix(in oklch, ${color} 10%, transparent)`,
                 borderColor: `color-mix(in oklch, ${color} 22%, transparent)`,
@@ -76,19 +70,20 @@ export function CompanyRow({ item }: CompanyRowProps) {
             >
               {item.ticker_b3}
             </span>
-          )}
+          ) : null}
+          {!hasData ? (
+            <span className="shrink-0 rounded-full border border-primary/20 bg-primary/8 px-2 py-0.5 text-[0.62rem] font-medium uppercase tracking-[0.14em] text-primary/80">
+              On-demand
+            </span>
+          ) : null}
         </div>
-        <p className="mt-0.5 text-[0.72rem] text-muted-foreground">
-          CVM {item.cd_cvm}
-        </p>
+        <p className="mt-0.5 text-[0.72rem] text-muted-foreground">CVM {item.cd_cvm}</p>
       </div>
 
-      {/* Sector — sm+ */}
       <p className="hidden truncate text-[0.82rem] text-muted-foreground sm:block">
-        {item.sector_name ?? "—"}
+        {item.sector_name ?? "--"}
       </p>
 
-      {/* Sparkline + range — lg+ */}
       <div className="hidden items-center gap-2 lg:flex">
         {sparkPts ? (
           <svg width={54} height={20} viewBox="0 0 54 20" aria-hidden className="shrink-0">
@@ -107,14 +102,12 @@ export function CompanyRow({ item }: CompanyRowProps) {
         </span>
       </div>
 
-      {/* Anos count — lg+ */}
       <div className="hidden text-right lg:block">
         <span className="font-mono text-[0.78rem] tabular-nums text-muted-foreground">
-          {anos.length > 0 ? `${anos.length} anos` : "—"}
+          {anos.length > 0 ? `${anos.length} anos` : "--"}
         </span>
       </div>
 
-      {/* Chevron */}
       <ChevronRightIcon className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
     </Link>
   );

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -44,6 +44,10 @@ export type CompanySuggestionItem = {
   sector_slug: string;
 };
 
+export type CompanySuggestionsResponse = {
+  items: CompanySuggestionItem[];
+};
+
 export type CompanySectorFilter = {
   sector_name: string;
   sector_slug: string;
@@ -217,6 +221,9 @@ const COMPANY_DIRECTORY_API_READ: ApiReadRequestInit = {
 const COMPANY_FILTERS_API_READ: ApiReadRequestInit = {
   next: { revalidate: 3600 },
 };
+const COMPANY_SUGGESTIONS_API_READ: ApiReadRequestInit = {
+  next: { revalidate: 60 },
+};
 const COMPANY_INFO_API_READ: ApiReadRequestInit = {
   next: { revalidate: 3600 },
 };
@@ -308,6 +315,21 @@ function isCompanyFiltersResponse(value: unknown): value is CompanyFiltersRespon
   return (
     isRecord(value) &&
     Array.isArray(value.sectors)
+  );
+}
+
+function isCompanySuggestionsResponse(value: unknown): value is CompanySuggestionsResponse {
+  return (
+    isRecord(value) &&
+    Array.isArray(value.items) &&
+    value.items.every(
+      (item) =>
+        isRecord(item) &&
+        typeof item.cd_cvm === "number" &&
+        typeof item.company_name === "string" &&
+        isNullableString(item.ticker_b3) &&
+        typeof item.sector_slug === "string",
+    )
   );
 }
 
@@ -741,6 +763,20 @@ export async function fetchCompanyFilters(): Promise<CompanyFiltersResponse> {
       invalidResponseMessage: "A API retornou filtros de empresas invalidos.",
     },
   )) as CompanyFiltersResponse;
+}
+
+export async function fetchCompanySuggestions(
+  q: string,
+  limit = 6,
+): Promise<CompanySuggestionsResponse> {
+  return (await apiFetch<CompanySuggestionsResponse>(
+    `/companies/suggestions${buildQuery({ q, limit })}`,
+    {
+      request: COMPANY_SUGGESTIONS_API_READ,
+      validate: isCompanySuggestionsResponse,
+      invalidResponseMessage: "A API retornou sugestoes de empresas invalidas.",
+    },
+  )) as CompanySuggestionsResponse;
 }
 
 export async function fetchSectorDirectory(): Promise<SectorDirectory> {

--- a/apps/web/lib/companies-page-data.ts
+++ b/apps/web/lib/companies-page-data.ts
@@ -1,21 +1,26 @@
 import {
   fetchCompanies,
   fetchCompanyFilters,
+  fetchCompanySuggestions,
   getUserFacingErrorMessage,
   type CompanyDirectoryPage,
   type CompanyFiltersResponse,
+  type CompanySuggestionsResponse,
 } from "./api.ts";
 
 type CompaniesPageLoaders = {
   fetchDirectory?: () => Promise<CompanyDirectoryPage>;
   fetchFilters?: () => Promise<CompanyFiltersResponse>;
+  fetchFallbackSuggestions?: () => Promise<CompanySuggestionsResponse>;
 };
 
 export type CompaniesPageData = {
   directory: CompanyDirectoryPage | null;
   filters: CompanyFiltersResponse | null;
+  fallbackSuggestions: CompanySuggestionsResponse | null;
   directoryError: string | null;
   filtersError: string | null;
+  fallbackSuggestionsError: string | null;
 };
 
 export async function loadCompaniesPageData(
@@ -37,16 +42,28 @@ export async function loadCompaniesPageData(
         pageSize: params.pageSize,
       }));
   const fetchFilters = loaders.fetchFilters ?? (() => fetchCompanyFilters());
+  const shouldFetchFallbackSuggestions =
+    params.search.trim().length >= 2 && !params.sector;
+  const fetchFallbackSuggestions =
+    loaders.fetchFallbackSuggestions ??
+    (() => fetchCompanySuggestions(params.search, 6));
 
-  const [directoryResult, filtersResult] = await Promise.allSettled([
+  const [directoryResult, filtersResult, fallbackSuggestionsResult] = await Promise.allSettled([
     fetchDirectory(),
     fetchFilters(),
+    shouldFetchFallbackSuggestions
+      ? fetchFallbackSuggestions()
+      : Promise.resolve({ items: [] }),
   ]);
 
   return {
     directory:
       directoryResult.status === "fulfilled" ? directoryResult.value : null,
     filters: filtersResult.status === "fulfilled" ? filtersResult.value : null,
+    fallbackSuggestions:
+      fallbackSuggestionsResult.status === "fulfilled"
+        ? fallbackSuggestionsResult.value
+        : null,
     directoryError:
       directoryResult.status === "rejected"
         ? getUserFacingErrorMessage(directoryResult.reason)
@@ -54,6 +71,10 @@ export async function loadCompaniesPageData(
     filtersError:
       filtersResult.status === "rejected"
         ? getUserFacingErrorMessage(filtersResult.reason)
+        : null,
+    fallbackSuggestionsError:
+      fallbackSuggestionsResult.status === "rejected"
+        ? getUserFacingErrorMessage(fallbackSuggestionsResult.reason)
         : null,
   };
 }

--- a/apps/web/tests/api-client.test.ts
+++ b/apps/web/tests/api-client.test.ts
@@ -5,6 +5,7 @@ import {
   ApiClientError,
   fetchCompanies,
   fetchCompanyFilters,
+  fetchCompanySuggestions,
   fetchSectorDetail,
   fetchRefreshStatus,
   getUserFacingErrorCopy,
@@ -101,6 +102,34 @@ test("fetchCompanyFilters opts into the backend-aligned revalidate window", asyn
 
     assert.equal(capturedInit?.cache, undefined);
     assert.deepEqual(capturedInit?.next, { revalidate: 3600 });
+  } finally {
+    restore();
+  }
+});
+
+test("fetchCompanySuggestions opts into the backend-aligned revalidate window", async () => {
+  let capturedInit: RequestInit | undefined;
+  const restore = withFetchMock((async (_input, init) => {
+    capturedInit = init;
+
+    return new Response(
+      JSON.stringify({
+        items: [],
+      }),
+      {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+        },
+      },
+    );
+  }) as FetchMock);
+
+  try {
+    await fetchCompanySuggestions("itub4", 6);
+
+    assert.equal(capturedInit?.cache, undefined);
+    assert.deepEqual(capturedInit?.next, { revalidate: 60 });
   } finally {
     restore();
   }

--- a/apps/web/tests/companies-page-data.test.ts
+++ b/apps/web/tests/companies-page-data.test.ts
@@ -75,6 +75,50 @@ test("loadCompaniesPageData keeps the directory when filters fail", async () => 
   assert.match(result.filtersError ?? "", /A API da V2 nao conseguiu concluir esta solicitacao agora/i);
 });
 
+test("loadCompaniesPageData keeps catalog fallback suggestions for empty local search results", async () => {
+  const result = await loadCompaniesPageData(
+    {
+      search: "itub4",
+      sector: null,
+      page: 1,
+      pageSize: 20,
+    },
+    {
+      fetchDirectory: async () => ({
+        items: [],
+        pagination: {
+          page: 1,
+          page_size: 20,
+          total_items: 0,
+          total_pages: 1,
+          has_next: false,
+          has_previous: false,
+        },
+        applied_filters: {
+          search: "itub4",
+          sector: null,
+        },
+      }),
+      fetchFilters: async () => ({ sectors: [] }),
+      fetchFallbackSuggestions: async () => ({
+        items: [
+          {
+            cd_cvm: 19348,
+            company_name: "ITAU UNIBANCO HOLDING S.A.",
+            ticker_b3: "ITUB4",
+            sector_slug: "financeiro",
+          },
+        ],
+      }),
+    },
+  );
+
+  assert.equal(result.directory?.items.length, 0);
+  assert.equal(result.fallbackSuggestions?.items.length, 1);
+  assert.equal(result.fallbackSuggestions?.items[0]?.cd_cvm, 19348);
+  assert.equal(result.fallbackSuggestionsError, null);
+});
+
 test("readCompaniesDirectoryQuery normalizes search params for the client loader", () => {
   const query = new URLSearchParams("busca=%20PETR4%20&setor=energia&pagina=0&view=cards");
 

--- a/docs/INTERFACE_MAP.md
+++ b/docs/INTERFACE_MAP.md
@@ -38,10 +38,12 @@ pessoa que trabalhe em qualquer uma das duas areas deve atualizar este arquivo
 |---|---|---|
 | `GET /health` | - | Trust strip / sinal de saude da API |
 | `GET /companies` | `page=1&page_size=8` | Sugestoes rapidas de empresas na home |
+| `GET /companies/suggestions` | `q=`, `limit=` | Autocomplete com fallback para catalogo CVM |
 
-**Rota interna Next.js**:
-- `GET /api/company-search?q=<termo>` -> chama `GET /companies` com `search=q` e
-  retorna ate 6 itens para o autocomplete do hero.
+**Notas de implementacao**:
+- o hero consulta `GET /companies/suggestions` diretamente
+- quando a busca local nao encontra resultados suficientes, o autocomplete pode
+  complementar itens do catalogo CVM para abrir o detalhe on-demand
 
 ---
 
@@ -73,6 +75,8 @@ pessoa que trabalhe em qualquer uma das duas areas deve atualizar este arquivo
 | `GET /companies/{cd_cvm}/statements` | `stmt=DRE\|BPA\|BPP\|DFC`, `years=2023,2024` | Aba Demonstracoes |
 | `GET /companies/{cd_cvm}/kpis` | `years=2023,2024` | Aba Visao Geral |
 | `GET /companies/{cd_cvm}/export/excel` | - | Download do workbook Excel completo da empresa, sempre com todos os anos disponiveis |
+| `POST /companies/{cd_cvm}/request-refresh` | - | Dispara bootstrap/refresh on-demand da empresa |
+| `GET /refresh-status` | `cd_cvm=` | Polling do status de refresh na pagina sem dados |
 
 **Query params publicos da rota**: `?anos=2023,2024&aba=visao-geral\|demonstracoes&stmt=DRE\|BPA\|BPP\|DFC`
 
@@ -83,6 +87,8 @@ Notas de contrato:
 - `4Q` depende do anual `YYYY` combinado com a base trimestral do mesmo ano
 - no bundle de KPIs trimestrais, `4Q` e deduplicado contra `YYYY`; o periodo
   explicito permanece visivel na aba Demonstracoes
+- `GET /companies/{cd_cvm}` e `POST /companies/{cd_cvm}/request-refresh` podem
+  usar fallback de catalogo CVM quando a empresa ainda nao existe na base local
 
 ---
 
@@ -227,16 +233,18 @@ de produto. Nao consome endpoints de API.
 |---|---|
 | `GET /health` | `/` |
 | `GET /companies` | `/`, `/empresas`, `/comparar` |
+| `GET /companies/suggestions` | `/` |
 | `GET /companies/filters` | `/empresas` |
 | `GET /companies/{cd_cvm}` | `/empresas/[cd_cvm]`, `/comparar` |
 | `GET /companies/{cd_cvm}/years` | `/empresas/[cd_cvm]`, `/comparar` |
 | `GET /companies/{cd_cvm}/statements` | `/empresas/[cd_cvm]` |
 | `GET /companies/{cd_cvm}/kpis` | `/empresas/[cd_cvm]`, `/comparar` |
 | `GET /companies/{cd_cvm}/export/excel` | `/empresas/[cd_cvm]` |
+| `POST /companies/{cd_cvm}/request-refresh` | `/empresas/[cd_cvm]` |
 | `GET /companies/export/excel-batch` | `/comparar` |
 | `GET /sectors` | `/setores` |
 | `GET /sectors/{slug}` | `/setores/[slug]` |
-| `GET /refresh-status` | Nao consumido pelo frontend ainda |
+| `GET /refresh-status` | `/empresas/[cd_cvm]` |
 | `GET /base-health` | `/` (parcialmente, se trust strip expandir) |
 
 ---

--- a/docs/V2_API_CONTRACT.md
+++ b/docs/V2_API_CONTRACT.md
@@ -75,7 +75,7 @@ Resposta exemplo:
 ```
 
 Regras do endpoint:
-- retorna apenas empresas que possuem dados em `financial_reports`
+- retorna empresas da tabela local `companies`, inclusive companhias ainda sem demonstracoes financeiras processadas
 - ordena por `company_name ASC`
 - `sector` usa slug canonico estavel, nao label livre
 - `anos_disponiveis` e montado de forma portavel na camada de leitura
@@ -152,10 +152,32 @@ Resposta exemplo:
 Regras do endpoint:
 - payload retorna apenas `cd_cvm`, `company_name`, `ticker_b3`, `sector_slug` — sem `anos_disponiveis`, `has_financial_data`, nem metricas de cobertura
 - `ticker_b3` e `null` quando a empresa nao possui ticker cadastrado
+- quando a busca local nao encontra resultados suficientes, o endpoint pode complementar as sugestoes com itens validos do catalogo remoto da CVM
 - resposta vazia (`items: []`) quando nenhuma empresa corresponde a `q`; nunca 404
 - headers de cache:
   - `Cache-Control: public, max-age=60, stale-while-revalidate=300`
   - `Vary: Origin`
+
+### `POST /companies/{cd_cvm}/request-refresh`
+
+Uso:
+- dispara ingestao on-demand para uma companhia especifica
+- quando o `cd_cvm` ainda nao existe na tabela local `companies`, o backend pode bootstrapar o metadata a partir do catalogo remoto da CVM antes de enfileirar o workflow
+
+Resposta exemplo:
+
+```json
+{
+  "status": "dispatched",
+  "cd_cvm": 19348
+}
+```
+
+Regras do endpoint:
+- `202` quando o dispatch foi tentado (`dispatched` ou `dispatch_failed`)
+- `429` quando ja existe uma execucao recente em fila para o mesmo `cd_cvm`
+- `404` apenas quando o `cd_cvm` nao existe no catalogo consultado
+- `503` quando o catalogo remoto precisa ser consultado mas esta indisponivel
 
 ### `GET /sectors`
 
@@ -260,6 +282,7 @@ Resposta exemplo:
 ```
 
 Regras do endpoint:
+- quando a empresa nao existe na tabela local `companies`, o backend pode usar o catalogo remoto da CVM como fallback de metadata
 - headers de cache:
   - `Cache-Control: public, max-age=3600`
   - `Vary: Origin`
@@ -278,7 +301,7 @@ Headers principais:
 - `Content-Disposition: attachment; filename="<ticker-ou-cvm>_<yyyymmdd>.xlsx"`
 
 Regras do endpoint:
-- `404` para empresa inexistente
+- `404` para `cd_cvm` inexistente no catalogo consultado
 - `422` para empresa existente sem anos exportaveis
 - o workbook e gerado no dominio Python (`src/read_service.py` +
   `src/excel_exporter.py`), nao na camada HTTP
@@ -315,6 +338,7 @@ Resposta:
 Regras do endpoint:
 - retorna apenas anos anuais exportaveis
 - usa `PERIOD_LABEL = REPORT_YEAR` como criterio de disponibilidade
+- empresa valida sem dados anuais locais retorna `[]` em vez de `404`
 - headers de cache:
   - `Cache-Control: public, max-age=86400, stale-while-revalidate=604800`
   - `Vary: Origin`
@@ -358,6 +382,7 @@ Resposta exemplo:
 Regras do endpoint:
 - aceita anos anuais no filtro `years`, mas a matriz pode expor colunas
   trimestrais quando elas existirem para os anos solicitados
+- empresa valida sem dados locais pode retornar tabela vazia; `404` fica reservado a `cd_cvm` inexistente
 - headers de cache:
   - `Cache-Control: public, max-age=600`
   - `Vary: Origin`
@@ -399,6 +424,7 @@ Resposta exemplo:
 Regras do endpoint:
 - `annual` usa somente `PERIOD_LABEL = REPORT_YEAR`
 - `quarterly` pode usar periodos trimestrais dos anos solicitados
+- empresa valida sem dados locais pode retornar tabelas vazias; `404` fica reservado a `cd_cvm` inexistente
 - headers de cache:
   - `Cache-Control: public, max-age=600`
   - `Vary: Origin`
@@ -449,6 +475,7 @@ Regras do endpoint:
 - cada bloco expoe apenas linhas de resumo condensado (codigos subtotais e filhos diretos selecionados)
 - `IS_SUBTOTAL` e `true` para codigos marcados como subtotais em cada demonstracao
 - se nenhuma demonstracao tiver dados, `blocks` retorna `[]` (nao e erro)
+- `404` fica reservado a `cd_cvm` inexistente; empresa valida sem dados locais retorna `blocks: []`
 - `years` no response reflete exatamente os anos solicitados, ordenados ascendente
 
 ### `GET /refresh-status?cd_cvm=`

--- a/src/company_catalog.py
+++ b/src/company_catalog.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import io
+import threading
+import time
+from dataclasses import dataclass
+
+import pandas as pd
+import requests
+
+from src.ticker_map import TICKER_MAP
+
+CVM_MASTER_URL = "https://dados.cvm.gov.br/dados/CIA_ABERTA/CAD/DADOS/cad_cia_aberta.csv"
+ACTIVE_STATUS_VALUES = {"ATIVO", "A"}
+DEFAULT_CATALOG_TTL_SECONDS = 900
+
+
+class CompanyCatalogUnavailableError(RuntimeError):
+    """Raised when the remote CVM company catalog cannot be consulted."""
+
+
+def _normalize_display_ticker(value: str | None) -> str | None:
+    if not value:
+        return None
+    normalized = str(value).strip().upper()
+    if normalized.endswith(".SA"):
+        normalized = normalized[:-3]
+    return normalized or None
+
+
+@dataclass(frozen=True)
+class CompanyCatalogEntry:
+    cd_cvm: int
+    company_name: str
+    nome_comercial: str | None
+    cnpj: str | None
+    setor_cvm: str | None
+    ticker_b3: str | None
+    is_active: bool
+
+
+@dataclass(frozen=True)
+class CompanyCatalogSnapshot:
+    entries: tuple[CompanyCatalogEntry, ...]
+    by_cd_cvm: dict[int, CompanyCatalogEntry]
+
+
+class CompanyCatalogService:
+    def __init__(
+        self,
+        *,
+        timeout: int,
+        ttl_seconds: int = DEFAULT_CATALOG_TTL_SECONDS,
+    ) -> None:
+        self.timeout = int(timeout)
+        self.ttl_seconds = int(ttl_seconds)
+        self._cache_lock = threading.Lock()
+        self._cached_snapshot: CompanyCatalogSnapshot | None = None
+        self._cached_at = 0.0
+
+    def lookup_company(self, cd_cvm: int) -> CompanyCatalogEntry | None:
+        snapshot = self._load_snapshot()
+        return snapshot.by_cd_cvm.get(int(cd_cvm))
+
+    def search_companies(
+        self,
+        *,
+        q: str,
+        limit: int,
+        exclude_codes: set[int] | None = None,
+    ) -> tuple[CompanyCatalogEntry, ...]:
+        normalized_query = str(q or "").strip().lower()
+        if not normalized_query or int(limit) <= 0:
+            return ()
+
+        excluded = exclude_codes or set()
+        snapshot = self._load_snapshot()
+        matches: list[tuple[tuple[int, int, str], CompanyCatalogEntry]] = []
+
+        for entry in snapshot.entries:
+            if entry.cd_cvm in excluded:
+                continue
+
+            company_name = entry.company_name.lower()
+            trade_name = (entry.nome_comercial or "").lower()
+            ticker = (entry.ticker_b3 or "").lower()
+            code = str(entry.cd_cvm)
+
+            names = [value for value in (company_name, trade_name) if value]
+            rank: int | None = None
+
+            if ticker == normalized_query or code == normalized_query:
+                rank = 0
+            elif any(value.startswith(normalized_query) for value in names):
+                rank = 1
+            elif ticker.startswith(normalized_query):
+                rank = 2
+            elif (
+                any(normalized_query in value for value in names)
+                or normalized_query in ticker
+                or normalized_query in code
+            ):
+                rank = 3
+
+            if rank is None:
+                continue
+
+            display_name = trade_name or company_name
+            matches.append(
+                (
+                    (rank, 0 if entry.is_active else 1, display_name),
+                    entry,
+                )
+            )
+
+        matches.sort(key=lambda item: item[0])
+        return tuple(entry for _, entry in matches[: int(limit)])
+
+    def _load_snapshot(self) -> CompanyCatalogSnapshot:
+        now = time.monotonic()
+        with self._cache_lock:
+            if (
+                self._cached_snapshot is not None
+                and (now - self._cached_at) < self.ttl_seconds
+            ):
+                return self._cached_snapshot
+
+        try:
+            response = requests.get(CVM_MASTER_URL, timeout=self.timeout)
+            response.raise_for_status()
+            raw_df = pd.read_csv(
+                io.BytesIO(response.content),
+                sep=";",
+                encoding="latin1",
+                usecols=[
+                    "CD_CVM",
+                    "DENOM_SOCIAL",
+                    "DENOM_COMERC",
+                    "CNPJ_CIA",
+                    "SETOR_ATIV",
+                    "SIT",
+                ],
+                dtype={"CD_CVM": str, "CNPJ_CIA": str},
+            )
+        except Exception as exc:
+            raise CompanyCatalogUnavailableError(
+                "Nao foi possivel consultar o catalogo CVM agora."
+            ) from exc
+
+        snapshot = self._build_snapshot(raw_df)
+        with self._cache_lock:
+            self._cached_snapshot = snapshot
+            self._cached_at = time.monotonic()
+            return snapshot
+
+    @staticmethod
+    def _build_snapshot(raw_df: pd.DataFrame) -> CompanyCatalogSnapshot:
+        df = raw_df.copy()
+        df["CD_CVM"] = pd.to_numeric(df["CD_CVM"], errors="coerce")
+        df = df.dropna(subset=["CD_CVM"]).copy()
+        df["CD_CVM"] = df["CD_CVM"].astype(int)
+        df["DENOM_SOCIAL"] = df["DENOM_SOCIAL"].fillna("").astype(str).str.strip()
+        df["DENOM_COMERC"] = df["DENOM_COMERC"].fillna("").astype(str).str.strip()
+        df["SETOR_ATIV"] = df["SETOR_ATIV"].fillna("").astype(str).str.strip()
+        df["CNPJ_CIA"] = df["CNPJ_CIA"].fillna("").astype(str).str.strip()
+        df["SIT"] = df["SIT"].fillna("").astype(str).str.strip().str.upper()
+        df = df.drop_duplicates(subset="CD_CVM").sort_values("DENOM_SOCIAL")
+
+        entries: list[CompanyCatalogEntry] = []
+        by_cd_cvm: dict[int, CompanyCatalogEntry] = {}
+
+        for _, row in df.iterrows():
+            cd_cvm = int(row["CD_CVM"])
+            company_name = str(row["DENOM_SOCIAL"]).strip() or f"CVM_{cd_cvm}"
+            nome_comercial = str(row["DENOM_COMERC"]).strip() or None
+            setor_cvm = str(row["SETOR_ATIV"]).strip() or None
+            cnpj = str(row["CNPJ_CIA"]).strip() or None
+            ticker_b3 = _normalize_display_ticker(TICKER_MAP.get(cd_cvm))
+            entry = CompanyCatalogEntry(
+                cd_cvm=cd_cvm,
+                company_name=company_name,
+                nome_comercial=nome_comercial,
+                cnpj=cnpj,
+                setor_cvm=setor_cvm,
+                ticker_b3=ticker_b3,
+                is_active=str(row["SIT"]).upper() in ACTIVE_STATUS_VALUES,
+            )
+            entries.append(entry)
+            by_cd_cvm[cd_cvm] = entry
+
+        return CompanyCatalogSnapshot(entries=tuple(entries), by_cd_cvm=by_cd_cvm)

--- a/src/read_service.py
+++ b/src/read_service.py
@@ -9,6 +9,11 @@ from typing import Any
 import pandas as pd
 from sqlalchemy import bindparam, inspect, text
 
+from src.company_catalog import (
+    CompanyCatalogEntry,
+    CompanyCatalogUnavailableError,
+    CompanyCatalogService,
+)
 from src.contracts import (
     CompanyDirectoryAppliedFilters,
     CompanyDirectoryPage,
@@ -75,6 +80,7 @@ class CVMReadService:
         self.settings = settings or get_settings()
         self.engine = build_engine(self.settings)
         self.query_layer = CVMQueryLayer(engine=self.engine)
+        self._company_catalog = None
         self._operational_service = None
 
     @property
@@ -83,6 +89,14 @@ class CVMReadService:
             from desktop.services import IntelligentSelectorService
             self._operational_service = IntelligentSelectorService(settings=self.settings)
         return self._operational_service
+
+    @property
+    def company_catalog(self) -> CompanyCatalogService:
+        if self._company_catalog is None:
+            self._company_catalog = CompanyCatalogService(
+                timeout=self.settings.company_list_timeout
+            )
+        return self._company_catalog
 
     def search_companies(self, search: str = "") -> list[CompanySearchResult]:
         df = self.query_layer.get_companies(search)
@@ -94,20 +108,15 @@ class CVMReadService:
 
     def get_company_info(self, cd_cvm: int) -> CompanyInfoDTO | None:
         payload = self.query_layer.get_company_info(cd_cvm)
-        if not payload:
+        if payload:
+            return self._build_company_info_dto(payload, default_cd_cvm=cd_cvm)
+
+        catalog_entry = self.company_catalog.lookup_company(cd_cvm)
+        if catalog_entry is None:
             return None
-        sector_name = canonical_sector_name(payload.get("setor_analitico"), payload.get("setor_cvm"))
-        return CompanyInfoDTO(
-            cd_cvm=int(payload.get("cd_cvm") or cd_cvm),
-            company_name=str(payload.get("company_name") or ""),
-            nome_comercial=payload.get("nome_comercial"),
-            cnpj=payload.get("cnpj"),
-            setor_cvm=payload.get("setor_cvm"),
-            setor_analitico=payload.get("setor_analitico"),
-            sector_name=sector_name,
-            sector_slug=sector_slugify(sector_name),
-            company_type=payload.get("company_type"),
-            ticker_b3=payload.get("ticker_b3"),
+        return self._build_company_info_dto(
+            self._company_catalog_payload(catalog_entry),
+            default_cd_cvm=cd_cvm,
         )
 
     def get_company_info_dict(self, cd_cvm: int) -> dict[str, Any]:
@@ -119,6 +128,103 @@ class CVMReadService:
 
     def get_available_statements(self, cd_cvm: int) -> list[str]:
         return self.query_layer.get_available_statements(cd_cvm)
+
+    @staticmethod
+    def _company_catalog_payload(entry: CompanyCatalogEntry) -> dict[str, Any]:
+        return {
+            "cd_cvm": int(entry.cd_cvm),
+            "company_name": entry.company_name,
+            "nome_comercial": entry.nome_comercial,
+            "cnpj": entry.cnpj,
+            "setor_cvm": entry.setor_cvm,
+            "setor_analitico": None,
+            "company_type": "comercial",
+            "ticker_b3": entry.ticker_b3,
+        }
+
+    @staticmethod
+    def _build_company_info_dto(
+        payload: dict[str, Any],
+        *,
+        default_cd_cvm: int,
+    ) -> CompanyInfoDTO:
+        sector_name = canonical_sector_name(
+            payload.get("setor_analitico"),
+            payload.get("setor_cvm"),
+        )
+        company_name = str(payload.get("company_name") or "").strip() or f"CVM_{default_cd_cvm}"
+        company_type = str(payload.get("company_type") or "comercial").strip() or "comercial"
+        return CompanyInfoDTO(
+            cd_cvm=int(payload.get("cd_cvm") or default_cd_cvm),
+            company_name=company_name,
+            nome_comercial=payload.get("nome_comercial"),
+            cnpj=payload.get("cnpj"),
+            setor_cvm=payload.get("setor_cvm"),
+            setor_analitico=payload.get("setor_analitico"),
+            sector_name=sector_name,
+            sector_slug=sector_slugify(sector_name),
+            company_type=company_type,
+            ticker_b3=payload.get("ticker_b3"),
+        )
+
+    def _ensure_company_catalog_metadata(self, cd_cvm: int) -> bool:
+        if self.query_layer.get_company_info(cd_cvm):
+            return False
+
+        catalog_entry = self.company_catalog.lookup_company(cd_cvm)
+        if catalog_entry is None:
+            return False
+
+        now_iso = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+        with self.engine.begin() as conn:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO companies (
+                        cd_cvm,
+                        company_name,
+                        nome_comercial,
+                        cnpj,
+                        setor_cvm,
+                        company_type,
+                        ticker_b3,
+                        is_active,
+                        updated_at
+                    ) VALUES (
+                        :cd_cvm,
+                        :company_name,
+                        :nome_comercial,
+                        :cnpj,
+                        :setor_cvm,
+                        :company_type,
+                        :ticker_b3,
+                        :is_active,
+                        :updated_at
+                    )
+                    ON CONFLICT(cd_cvm) DO UPDATE SET
+                        company_name = excluded.company_name,
+                        nome_comercial = COALESCE(excluded.nome_comercial, companies.nome_comercial),
+                        cnpj = COALESCE(excluded.cnpj, companies.cnpj),
+                        setor_cvm = COALESCE(excluded.setor_cvm, companies.setor_cvm),
+                        company_type = COALESCE(excluded.company_type, companies.company_type),
+                        ticker_b3 = COALESCE(excluded.ticker_b3, companies.ticker_b3),
+                        is_active = excluded.is_active,
+                        updated_at = excluded.updated_at
+                    """
+                ),
+                {
+                    "cd_cvm": int(catalog_entry.cd_cvm),
+                    "company_name": catalog_entry.company_name,
+                    "nome_comercial": catalog_entry.nome_comercial,
+                    "cnpj": catalog_entry.cnpj,
+                    "setor_cvm": catalog_entry.setor_cvm,
+                    "company_type": "comercial",
+                    "ticker_b3": catalog_entry.ticker_b3,
+                    "is_active": 1 if catalog_entry.is_active else 0,
+                    "updated_at": now_iso,
+                },
+            )
+        return True
 
     def list_companies(
         self,
@@ -180,7 +286,7 @@ class CVMReadService:
 
     def suggest_companies(self, q: str, limit: int) -> tuple[CompanySuggestionDTO, ...]:
         df = self.query_layer.get_company_suggestions(q=q, limit=limit)
-        return tuple(
+        local_items = tuple(
             CompanySuggestionDTO(
                 cd_cvm=int(row["cd_cvm"]),
                 company_name=str(row["company_name"]),
@@ -189,6 +295,31 @@ class CVMReadService:
             )
             for _, row in df.iterrows()
         )
+        if not str(q or "").strip() or len(local_items) >= int(limit):
+            return local_items[: int(limit)]
+
+        seen_codes = {item.cd_cvm for item in local_items}
+        try:
+            catalog_items = self.company_catalog.search_companies(
+                q=q,
+                limit=max(0, int(limit) - len(local_items)),
+                exclude_codes=seen_codes,
+            )
+        except CompanyCatalogUnavailableError:
+            return local_items[: int(limit)]
+
+        fallback_items = tuple(
+            CompanySuggestionDTO(
+                cd_cvm=int(entry.cd_cvm),
+                company_name=entry.company_name,
+                ticker_b3=entry.ticker_b3,
+                sector_slug=sector_slugify(
+                    canonical_sector_name(None, entry.setor_cvm)
+                ),
+            )
+            for entry in catalog_items
+        )
+        return (local_items + fallback_items)[: int(limit)]
 
     def resolve_sector_slug(self, sector_slug: str | None) -> str | None:
         return self._resolve_sector_slug(sector_slug)
@@ -514,12 +645,13 @@ class CVMReadService:
         Returns one of: "dispatched", "dispatch_failed", "already_queued".
         Raises NotFoundError if cd_cvm is unknown.
         """
+        bootstrapped = self._ensure_company_catalog_metadata(cd_cvm)
         start_year, end_year = self._resolve_refresh_range(start_year=2010, end_year=None)
         return self._dispatch_refresh_request(
             cd_cvm=cd_cvm,
             start_year=start_year,
             end_year=end_year,
-            source_scope="on_demand",
+            source_scope="on_demand_bootstrap" if bootstrapped else "on_demand",
             already_queued_window=timedelta(minutes=self.RANKED_REFRESH_QUEUE_WINDOW_MINUTES),
         )
 


### PR DESCRIPTION
## Summary
- add CVM catalog fallback and metadata bootstrap for unknown companies in the API runtime
- allow the web app to navigate no-data companies and surface catalog suggestions when local search is empty
- document the updated on-demand bootstrap contract and add backend/frontend coverage

## Validation
- pytest apps/api/tests -q
- npm run lint
- npm run typecheck
- npm run test:unit
- npm run build

Closes #156
