### PR TITLE
feat: add progress and ETA to on-demand refresh

### DIFF
--- a/apps/api/app/presenters.py
+++ b/apps/api/app/presenters.py
@@ -233,6 +233,12 @@ class RefreshStatusPayload(BaseModel):
     last_end_year: int | None = None
     last_rows_inserted: int | None = None
     updated_at: str | None = None
+    estimated_progress_pct: float | None = None
+    estimated_eta_seconds: int | None = None
+    estimated_total_seconds: int | None = None
+    elapsed_seconds: int | None = None
+    estimated_completion_at: str | None = None
+    estimate_confidence: str | None = None
 
 
 class HealthYearCoveragePayload(BaseModel):

--- a/apps/api/tests/test_api_contract.py
+++ b/apps/api/tests/test_api_contract.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import io
 import logging
 import zipfile
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -899,6 +900,112 @@ def test_refresh_status_returns_operational_rows(client: TestClient):
     payload = response.json()
     assert len(payload) == 1
     assert payload[0]["last_status"] == "success"
+    assert payload[0]["estimated_progress_pct"] is None
+    assert payload[0]["estimated_eta_seconds"] is None
+
+
+def test_refresh_status_returns_estimated_progress_for_active_refresh(client: TestClient):
+    from sqlalchemy import text as sa_text
+
+    now = datetime.now(timezone.utc).replace(microsecond=0)
+    now_iso = now.isoformat()
+    queued_at = (now - timedelta(minutes=4)).isoformat()
+
+    with client.app.state.read_service.engine.begin() as conn:
+        conn.execute(
+            sa_text(
+                """
+                INSERT INTO company_refresh_status (
+                    cd_cvm, company_name, source_scope, last_attempt_at, last_success_at,
+                    last_status, last_error, last_start_year, last_end_year,
+                    last_rows_inserted, updated_at
+                ) VALUES (
+                    :cd_cvm, :company_name, :source_scope, :last_attempt_at, :last_success_at,
+                    :last_status, :last_error, :last_start_year, :last_end_year,
+                    :last_rows_inserted, :updated_at
+                )
+                ON CONFLICT (cd_cvm) DO UPDATE SET
+                    company_name = excluded.company_name,
+                    source_scope = excluded.source_scope,
+                    last_attempt_at = excluded.last_attempt_at,
+                    last_success_at = excluded.last_success_at,
+                    last_status = excluded.last_status,
+                    last_error = excluded.last_error,
+                    last_start_year = excluded.last_start_year,
+                    last_end_year = excluded.last_end_year,
+                    last_rows_inserted = excluded.last_rows_inserted,
+                    updated_at = excluded.updated_at
+                """
+            ),
+            [
+                {
+                    "cd_cvm": 4170,
+                    "company_name": "VALE",
+                    "source_scope": "on_demand",
+                    "last_attempt_at": queued_at,
+                    "last_success_at": None,
+                    "last_status": "queued",
+                    "last_error": None,
+                    "last_start_year": 2010,
+                    "last_end_year": 2024,
+                    "last_rows_inserted": None,
+                    "updated_at": now_iso,
+                },
+                {
+                    "cd_cvm": 19348,
+                    "company_name": "LOCALIZA",
+                    "source_scope": "local",
+                    "last_attempt_at": (now - timedelta(hours=3)).isoformat(),
+                    "last_success_at": (now - timedelta(hours=2, minutes=44)).isoformat(),
+                    "last_status": "success",
+                    "last_error": None,
+                    "last_start_year": 2010,
+                    "last_end_year": 2024,
+                    "last_rows_inserted": 120,
+                    "updated_at": (now - timedelta(hours=2, minutes=44)).isoformat(),
+                },
+                {
+                    "cd_cvm": 20532,
+                    "company_name": "WEG",
+                    "source_scope": "local",
+                    "last_attempt_at": (now - timedelta(hours=2, minutes=30)).isoformat(),
+                    "last_success_at": (now - timedelta(hours=2, minutes=12)).isoformat(),
+                    "last_status": "success",
+                    "last_error": None,
+                    "last_start_year": 2010,
+                    "last_end_year": 2024,
+                    "last_rows_inserted": 116,
+                    "updated_at": (now - timedelta(hours=2, minutes=12)).isoformat(),
+                },
+                {
+                    "cd_cvm": 90678,
+                    "company_name": "ITAU",
+                    "source_scope": "local",
+                    "last_attempt_at": (now - timedelta(hours=2)).isoformat(),
+                    "last_success_at": (now - timedelta(hours=1, minutes=47)).isoformat(),
+                    "last_status": "success",
+                    "last_error": None,
+                    "last_start_year": 2010,
+                    "last_end_year": 2024,
+                    "last_rows_inserted": 112,
+                    "updated_at": (now - timedelta(hours=1, minutes=47)).isoformat(),
+                },
+            ],
+        )
+
+    response = client.get("/refresh-status", params={"cd_cvm": 4170})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload) == 1
+    assert payload[0]["last_status"] == "queued"
+    assert payload[0]["estimated_progress_pct"] > 10.0
+    assert payload[0]["estimated_progress_pct"] < 96.0
+    assert payload[0]["estimated_eta_seconds"] is not None
+    assert payload[0]["estimated_total_seconds"] is not None
+    assert payload[0]["elapsed_seconds"] >= 240
+    assert payload[0]["estimated_completion_at"] is not None
+    assert payload[0]["estimate_confidence"] == "medium"
 
 
 def test_base_health_returns_snapshot(client: TestClient):

--- a/apps/api/tests/test_presenters.py
+++ b/apps/api/tests/test_presenters.py
@@ -149,10 +149,18 @@ def test_presenters_serialize_dtos_without_raw_pandas_objects():
                 last_end_year=2024,
                 last_rows_inserted=30,
                 updated_at="2026-04-08T08:55:00",
+                estimated_progress_pct=64.5,
+                estimated_eta_seconds=420,
+                estimated_total_seconds=1200,
+                elapsed_seconds=780,
+                estimated_completion_at="2026-04-08T09:10:00",
+                estimate_confidence="medium",
             )
         ]
     )[0]
     assert refresh.last_status == "success"
+    assert refresh.estimated_progress_pct == 64.5
+    assert refresh.estimate_confidence == "medium"
 
     health = present_health_snapshot(
         HealthSnapshot(

--- a/apps/web/components/company/company-freshness-card.tsx
+++ b/apps/web/components/company/company-freshness-card.tsx
@@ -129,7 +129,7 @@ export async function CompanyFreshnessCard({
         </p>
       ) : null}
 
-      <CompanyRequestRefreshLazy cdCvm={cdCvm} />
+      <CompanyRequestRefreshLazy cdCvm={cdCvm} initialStatus={freshness} />
     </SurfaceCard>
   );
 }

--- a/apps/web/components/company/company-no-data.tsx
+++ b/apps/web/components/company/company-no-data.tsx
@@ -10,7 +10,7 @@ import {
 import { CompanyRequestRefreshLazy } from "@/components/company/company-request-refresh-lazy";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { buttonVariants } from "@/components/ui/button";
-import type { CompanyInfo } from "@/lib/api";
+import { fetchCompanyFreshness, type CompanyInfo } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
 type CompanyNoDataPageProps = {
@@ -33,9 +33,16 @@ function CompanyMetaCard({ label, value }: CompanyMetaCardProps) {
   );
 }
 
-export function CompanyNoDataPage({ company }: CompanyNoDataPageProps) {
+export async function CompanyNoDataPage({ company }: CompanyNoDataPageProps) {
   const sectorLabel =
     company.sector_name || company.setor_analitico || company.setor_cvm || "Setor nao informado";
+  let initialFreshness = null;
+
+  try {
+    initialFreshness = await fetchCompanyFreshness(company.cd_cvm);
+  } catch {
+    initialFreshness = null;
+  }
 
   return (
     <PageShell density="relaxed" className="max-w-5xl">
@@ -93,7 +100,10 @@ export function CompanyNoDataPage({ company }: CompanyNoDataPageProps) {
           </Alert>
 
           <div className="flex flex-wrap items-start gap-3">
-            <CompanyRequestRefreshLazy cdCvm={company.cd_cvm} />
+            <CompanyRequestRefreshLazy
+              cdCvm={company.cd_cvm}
+              initialStatus={initialFreshness}
+            />
             <Link
               href="/empresas"
               className={cn(

--- a/apps/web/components/company/company-request-refresh-lazy.tsx
+++ b/apps/web/components/company/company-request-refresh-lazy.tsx
@@ -2,6 +2,8 @@
 
 import dynamic from "next/dynamic";
 
+import type { RefreshStatusItem } from "@/lib/api";
+
 const CompanyRequestRefresh = dynamic(
   () =>
     import("@/components/company/company-request-refresh").then(
@@ -18,10 +20,14 @@ const CompanyRequestRefresh = dynamic(
 
 type CompanyRequestRefreshLazyProps = {
   cdCvm: number;
+  initialStatus?: RefreshStatusItem | null;
 };
 
 export function CompanyRequestRefreshLazy({
   cdCvm,
+  initialStatus = null,
 }: CompanyRequestRefreshLazyProps) {
-  return <CompanyRequestRefresh cdCvm={cdCvm} />;
+  return (
+    <CompanyRequestRefresh cdCvm={cdCvm} initialStatus={initialStatus} />
+  );
 }

--- a/apps/web/components/company/company-request-refresh.tsx
+++ b/apps/web/components/company/company-request-refresh.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef, useState } from "react";
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
 import {
   type RefreshStatusItem,
   fetchRefreshStatus,
@@ -15,6 +16,7 @@ import {
 
 type CompanyRequestRefreshProps = {
   cdCvm: number;
+  initialStatus?: RefreshStatusItem | null;
 };
 
 type RefreshPhase =
@@ -30,11 +32,39 @@ type RefreshState = {
   message?: string;
   detail?: string;
   startedAt?: number;
+  currentItem?: RefreshStatusItem | null;
 };
 
+type RefreshEstimate = {
+  progress: number;
+  etaLabel: string;
+  completionLabel?: string;
+  confidenceLabel?: string;
+  indicatorClassName: string;
+};
+
+const ACTIVE_REFRESH_STATUSES = new Set(["queued", "running"]);
 const POLL_INTERVAL_MS = 10_000;
 const POLL_TIMEOUT_MS = 15 * 60 * 1_000;
 const RELOAD_DELAY_MS = 1_200;
+
+const ESTIMATE_TIME_FORMATTER = new Intl.DateTimeFormat("pt-BR", {
+  hour: "2-digit",
+  minute: "2-digit",
+});
+
+function isActiveRefreshStatus(status: string | null | undefined): boolean {
+  return ACTIVE_REFRESH_STATUSES.has(String(status || "").trim().toLowerCase());
+}
+
+function parseTimestamp(value: string | null | undefined): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const timestamp = new Date(value).getTime();
+  return Number.isNaN(timestamp) ? undefined : timestamp;
+}
 
 function getPollingCopy(item: RefreshStatusItem | undefined): {
   message: string;
@@ -59,11 +89,126 @@ function getPollingCopy(item: RefreshStatusItem | undefined): {
   }
 }
 
+function formatDuration(seconds: number): string {
+  if (seconds < 60) {
+    return "menos de 1 min";
+  }
+
+  const totalMinutes = Math.round(seconds / 60);
+  if (totalMinutes < 60) {
+    return `${totalMinutes} min`;
+  }
+
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (minutes === 0) {
+    return `${hours} h`;
+  }
+
+  return `${hours} h ${minutes} min`;
+}
+
+function formatEstimatedTime(dateIso: string | null | undefined): string | null {
+  if (!dateIso) {
+    return null;
+  }
+
+  const date = new Date(dateIso);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return ESTIMATE_TIME_FORMATTER.format(date);
+}
+
+function getConfidenceLabel(confidence: string | null | undefined): string | null {
+  switch (String(confidence || "").trim().toLowerCase()) {
+    case "high":
+      return "Estimativa baseada em execucoes recentes consistentes.";
+    case "medium":
+      return "Estimativa baseada nas ultimas execucoes concluidas.";
+    case "low":
+      return "Estimativa inicial. A amostra historica ainda e pequena.";
+    default:
+      return null;
+  }
+}
+
+function buildPollingState(item: RefreshStatusItem): RefreshState {
+  const copy = getPollingCopy(item);
+  return {
+    phase: "polling",
+    startedAt: parseTimestamp(item.last_attempt_at) ?? Date.now(),
+    message: copy.message,
+    detail: copy.detail,
+    currentItem: item,
+  };
+}
+
+function buildRefreshEstimate(
+  phase: RefreshPhase,
+  item: RefreshStatusItem | null | undefined,
+): RefreshEstimate | null {
+  if (phase === "submitting") {
+    return {
+      progress: 6,
+      etaLabel: "Preparando a fila on-demand...",
+      indicatorClassName:
+        "bg-gradient-to-r from-amber-500 via-orange-400 to-rose-400",
+    };
+  }
+
+  if (phase === "success") {
+    return {
+      progress: 100,
+      etaLabel: "Processamento concluido",
+      indicatorClassName:
+        "bg-gradient-to-r from-emerald-500 via-teal-400 to-cyan-400",
+    };
+  }
+
+  if (!item || !isActiveRefreshStatus(item.last_status)) {
+    return null;
+  }
+
+  const progress = Math.min(
+    100,
+    Math.max(
+      8,
+      item.estimated_progress_pct ??
+        (String(item.last_status).toLowerCase() === "running" ? 28 : 14),
+    ),
+  );
+  const totalSeconds = item.estimated_total_seconds;
+  const elapsedSeconds = item.elapsed_seconds;
+  const isOverdue =
+    typeof totalSeconds === "number" &&
+    typeof elapsedSeconds === "number" &&
+    elapsedSeconds > totalSeconds;
+  const etaSeconds = item.estimated_eta_seconds;
+  const completionTime = formatEstimatedTime(item.estimated_completion_at);
+
+  return {
+    progress,
+    etaLabel: isOverdue
+      ? "Acima da estimativa, mas ainda em processamento."
+      : typeof etaSeconds === "number" && etaSeconds > 0
+        ? `~${formatDuration(etaSeconds)} restantes`
+        : "Finalizando a atualizacao...",
+    completionLabel: completionTime ? `Previsao: ${completionTime}` : undefined,
+    confidenceLabel: getConfidenceLabel(item.estimate_confidence) ?? undefined,
+    indicatorClassName:
+      "bg-gradient-to-r from-emerald-500 via-lime-400 to-cyan-400",
+  };
+}
+
 export function CompanyRequestRefresh({
   cdCvm,
+  initialStatus = null,
 }: CompanyRequestRefreshProps) {
   const [state, setState] = useState<RefreshState>({ phase: "idle" });
   const reloadTimerRef = useRef<number | null>(null);
+  const hydratedInitialStatusRef = useRef(false);
 
   useEffect(() => {
     return () => {
@@ -72,6 +217,17 @@ export function CompanyRequestRefresh({
       }
     };
   }, []);
+
+  useEffect(() => {
+    if (hydratedInitialStatusRef.current || !initialStatus) {
+      return;
+    }
+
+    hydratedInitialStatusRef.current = true;
+    if (isActiveRefreshStatus(initialStatus.last_status)) {
+      setState(buildPollingState(initialStatus));
+    }
+  }, [initialStatus]);
 
   useEffect(() => {
     if (state.phase !== "polling" || state.startedAt === undefined) {
@@ -87,12 +243,14 @@ export function CompanyRequestRefresh({
       }
 
       if (Date.now() - pollingStartedAt >= POLL_TIMEOUT_MS) {
-        setState({
+        setState((currentState) => ({
           phase: "timeout",
+          startedAt: currentState.startedAt,
+          currentItem: currentState.currentItem,
           message: "O processamento ainda nao terminou.",
           detail:
             "Voce pode tentar novamente para reiniciar o acompanhamento desta empresa.",
-        });
+        }));
         return;
       }
 
@@ -103,15 +261,17 @@ export function CompanyRequestRefresh({
           return;
         }
 
-        const currentItem = items[0];
+        const currentItem = items[0] ?? null;
         const currentStatus = currentItem?.last_status;
 
         if (currentStatus === "success") {
-          setState({
+          setState((currentState) => ({
             phase: "success",
+            startedAt: currentState.startedAt,
+            currentItem,
             message: "Dados disponiveis! Recarregando...",
             detail: "A leitura detalhada desta empresa sera atualizada agora.",
-          });
+          }));
           reloadTimerRef.current = window.setTimeout(() => {
             window.location.reload();
           }, RELOAD_DELAY_MS);
@@ -119,22 +279,25 @@ export function CompanyRequestRefresh({
         }
 
         if (currentStatus === "error" || currentStatus === "dispatch_failed") {
-          setState({
+          setState((currentState) => ({
             phase: "error",
+            startedAt: currentState.startedAt,
+            currentItem,
             message:
               currentItem?.last_error ??
               "Nao foi possivel concluir a atualizacao desta empresa.",
             detail:
               "A solicitacao foi encerrada com falha. Tente novamente em instantes.",
-          });
+          }));
           return;
         }
 
-        const copy = getPollingCopy(currentItem);
+        const copy = getPollingCopy(currentItem ?? undefined);
         setState((currentState) =>
           currentState.phase === "polling"
             ? {
                 ...currentState,
+                currentItem,
                 message: copy.message,
                 detail: copy.detail,
               }
@@ -145,12 +308,14 @@ export function CompanyRequestRefresh({
           return;
         }
 
-        setState({
+        setState((currentState) => ({
           phase: "error",
+          startedAt: currentState.startedAt,
+          currentItem: currentState.currentItem,
           message: getUserFacingErrorMessage(error),
           detail:
             "O acompanhamento do refresh foi interrompido. Tente novamente em instantes.",
-        });
+        }));
       }
     }
 
@@ -167,7 +332,11 @@ export function CompanyRequestRefresh({
   }, [cdCvm, state.phase, state.startedAt]);
 
   async function handleRequestRefresh() {
-    if (state.phase === "submitting" || state.phase === "polling" || state.phase === "success") {
+    if (
+      state.phase === "submitting" ||
+      state.phase === "polling" ||
+      state.phase === "success"
+    ) {
       return;
     }
 
@@ -190,6 +359,7 @@ export function CompanyRequestRefresh({
           payload.status === "dispatch_failed"
             ? "O backend vai expor o status final desta tentativa na fila de refresh."
             : "A pagina sera recarregada assim que os dados estiverem prontos.",
+        currentItem: null,
       });
     } catch (error) {
       if (isApiClientError(error) && error.status === 429) {
@@ -198,6 +368,7 @@ export function CompanyRequestRefresh({
           startedAt: Date.now(),
           message: "Solicitacao ja em andamento.",
           detail: "Acompanhando o processamento atual desta companhia.",
+          currentItem: null,
         });
         return;
       }
@@ -206,6 +377,7 @@ export function CompanyRequestRefresh({
         phase: "error",
         message: getUserFacingErrorMessage(error),
         detail: "Tente novamente em instantes.",
+        currentItem: null,
       });
     }
   }
@@ -237,6 +409,8 @@ export function CompanyRequestRefresh({
 
   const showStatus = state.phase !== "idle";
   const isDestructive = state.phase === "error" || state.phase === "timeout";
+  const estimate = buildRefreshEstimate(state.phase, state.currentItem);
+  const progressLabel = `${Math.round(estimate?.progress ?? 0)}%`;
 
   return (
     <div className="flex min-w-[18rem] flex-col gap-3 sm:max-w-xl">
@@ -272,6 +446,44 @@ export function CompanyRequestRefresh({
           <AlertDescription className="space-y-3">
             <p>{state.message}</p>
             {state.detail ? <p>{state.detail}</p> : null}
+
+            {estimate ? (
+              <div className="rounded-[1.25rem] border border-border/65 bg-background/82 px-4 py-4 shadow-[0_1px_0_rgba(255,255,255,0.22)]">
+                <div className="mb-3 flex items-start justify-between gap-3">
+                  <div>
+                    <p className="text-[0.7rem] font-medium uppercase tracking-[0.22em] text-muted-foreground">
+                      Estimativa de conclusao
+                    </p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      Progresso aproximado do refresh on-demand.
+                    </p>
+                  </div>
+                  <p className="text-lg font-semibold tabular-nums text-foreground">
+                    {progressLabel}
+                  </p>
+                </div>
+
+                <Progress
+                  value={estimate.progress}
+                  aria-label="Progresso estimado da atualizacao on-demand"
+                  indicatorClassName={estimate.indicatorClassName}
+                />
+
+                <div className="mt-3 flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
+                  <span>{estimate.etaLabel}</span>
+                  {estimate.completionLabel ? (
+                    <span>{estimate.completionLabel}</span>
+                  ) : null}
+                </div>
+
+                {estimate.confidenceLabel ? (
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    {estimate.confidenceLabel}
+                  </p>
+                ) : null}
+              </div>
+            ) : null}
+
             {state.phase === "timeout" ? (
               <Button
                 type="button"

--- a/apps/web/components/ui/progress.tsx
+++ b/apps/web/components/ui/progress.tsx
@@ -1,0 +1,99 @@
+"use client"
+
+import { Progress as ProgressPrimitive } from "@base-ui/react/progress"
+
+import { cn } from "@/lib/utils"
+
+type ProgressProps = ProgressPrimitive.Root.Props & {
+  trackClassName?: string
+  indicatorClassName?: string
+}
+
+function Progress({
+  className,
+  children,
+  value,
+  trackClassName,
+  indicatorClassName,
+  ...props
+}: ProgressProps) {
+  return (
+    <ProgressPrimitive.Root
+      value={value}
+      data-slot="progress"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    >
+      {children}
+      <ProgressTrack className={trackClassName}>
+        <ProgressIndicator className={indicatorClassName} />
+      </ProgressTrack>
+    </ProgressPrimitive.Root>
+  )
+}
+
+function ProgressTrack({
+  className,
+  ...props
+}: ProgressPrimitive.Track.Props) {
+  return (
+    <ProgressPrimitive.Track
+      data-slot="progress-track"
+      className={cn(
+        "relative h-2.5 w-full overflow-hidden rounded-full bg-foreground/8 shadow-[inset_0_1px_0_rgba(255,255,255,0.22)] dark:bg-background/70",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function ProgressIndicator({
+  className,
+  ...props
+}: ProgressPrimitive.Indicator.Props) {
+  return (
+    <ProgressPrimitive.Indicator
+      data-slot="progress-indicator"
+      className={cn(
+        "h-full rounded-full bg-primary transition-[translate,width] duration-500 ease-out",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function ProgressLabel({
+  className,
+  ...props
+}: ProgressPrimitive.Label.Props) {
+  return (
+    <ProgressPrimitive.Label
+      data-slot="progress-label"
+      className={cn("text-sm font-medium text-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function ProgressValue({
+  className,
+  ...props
+}: ProgressPrimitive.Value.Props) {
+  return (
+    <ProgressPrimitive.Value
+      data-slot="progress-value"
+      className={cn("text-sm font-medium tabular-nums text-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Progress,
+  ProgressIndicator,
+  ProgressLabel,
+  ProgressTrack,
+  ProgressValue,
+}

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -88,6 +88,12 @@ export type RefreshStatusItem = {
   last_end_year: number | null;
   last_rows_inserted: number | null;
   updated_at: string | null;
+  estimated_progress_pct: number | null;
+  estimated_eta_seconds: number | null;
+  estimated_total_seconds: number | null;
+  elapsed_seconds: number | null;
+  estimated_completion_at: string | null;
+  estimate_confidence: string | null;
 };
 
 export type TabularDataRow = Record<string, string | number | boolean | null>;
@@ -389,7 +395,13 @@ function isRefreshStatusItem(value: unknown): value is RefreshStatusItem {
     isNullableNumber(value.last_start_year) &&
     isNullableNumber(value.last_end_year) &&
     isNullableNumber(value.last_rows_inserted) &&
-    isNullableString(value.updated_at)
+    isNullableString(value.updated_at) &&
+    isNullableNumber(value.estimated_progress_pct) &&
+    isNullableNumber(value.estimated_eta_seconds) &&
+    isNullableNumber(value.estimated_total_seconds) &&
+    isNullableNumber(value.elapsed_seconds) &&
+    isNullableString(value.estimated_completion_at) &&
+    isNullableString(value.estimate_confidence)
   );
 }
 

--- a/apps/web/tests/api-client.test.ts
+++ b/apps/web/tests/api-client.test.ts
@@ -274,6 +274,49 @@ test("fetchRefreshStatus keeps explicit no-store semantics for polling flows", a
   }
 });
 
+test("fetchRefreshStatus accepts estimated progress fields from the API", async () => {
+  const restore = withFetchMock((async () =>
+    new Response(
+      JSON.stringify([
+        {
+          cd_cvm: 4170,
+          company_name: "VALE",
+          source_scope: "on_demand",
+          last_attempt_at: "2026-04-21T12:00:00+00:00",
+          last_success_at: null,
+          last_status: "queued",
+          last_error: null,
+          last_start_year: 2010,
+          last_end_year: 2024,
+          last_rows_inserted: null,
+          updated_at: "2026-04-21T12:00:00+00:00",
+          estimated_progress_pct: 31.4,
+          estimated_eta_seconds: 840,
+          estimated_total_seconds: 1260,
+          elapsed_seconds: 420,
+          estimated_completion_at: "2026-04-21T12:21:00+00:00",
+          estimate_confidence: "medium",
+        },
+      ]),
+      {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+        },
+      },
+    )) as FetchMock);
+
+  try {
+    const payload = await fetchRefreshStatus(4170);
+
+    assert.equal(payload[0]?.estimated_progress_pct, 31.4);
+    assert.equal(payload[0]?.estimated_eta_seconds, 840);
+    assert.equal(payload[0]?.estimate_confidence, "medium");
+  } finally {
+    restore();
+  }
+});
+
 test("getFilenameFromDisposition keeps quoted filenames when present", () => {
   const filename = getFilenameFromDisposition(
     'attachment; filename="PETR4_20260409.xlsx"',

--- a/docs/INTERFACE_MAP.md
+++ b/docs/INTERFACE_MAP.md
@@ -76,7 +76,7 @@ pessoa que trabalhe em qualquer uma das duas areas deve atualizar este arquivo
 | `GET /companies/{cd_cvm}/kpis` | `years=2023,2024` | Aba Visao Geral |
 | `GET /companies/{cd_cvm}/export/excel` | - | Download do workbook Excel completo da empresa, sempre com todos os anos disponiveis |
 | `POST /companies/{cd_cvm}/request-refresh` | - | Dispara bootstrap/refresh on-demand da empresa |
-| `GET /refresh-status` | `cd_cvm=` | Polling do status de refresh na pagina sem dados |
+| `GET /refresh-status` | `cd_cvm=` | Polling do status de refresh e da barra estimada de progresso/ETA |
 
 **Query params publicos da rota**: `?anos=2023,2024&aba=visao-geral\|demonstracoes&stmt=DRE\|BPA\|BPP\|DFC`
 
@@ -89,6 +89,8 @@ Notas de contrato:
   explicito permanece visivel na aba Demonstracoes
 - `GET /companies/{cd_cvm}` e `POST /companies/{cd_cvm}/request-refresh` podem
   usar fallback de catalogo CVM quando a empresa ainda nao existe na base local
+- `GET /refresh-status` alimenta a experiencia de acompanhamento on-demand
+  tanto na pagina sem dados quanto no card de freshness da empresa
 
 ---
 

--- a/docs/V2_API_CONTRACT.md
+++ b/docs/V2_API_CONTRACT.md
@@ -491,20 +491,39 @@ Resposta exemplo:
 ```json
 [
   {
-    "cd_cvm": 9512,
-    "company_name": "PETROBRAS",
-    "source_scope": "local",
-    "last_attempt_at": "2026-04-08T08:50:00",
-    "last_success_at": "2026-04-08T08:55:00",
-    "last_status": "success",
+    "cd_cvm": 4170,
+    "company_name": "VALE",
+    "source_scope": "on_demand",
+    "last_attempt_at": "2026-04-21T12:00:00+00:00",
+    "last_success_at": null,
+    "last_status": "queued",
     "last_error": null,
-    "last_start_year": 2023,
+    "last_start_year": 2010,
     "last_end_year": 2024,
-    "last_rows_inserted": 30,
-    "updated_at": "2026-04-08T08:55:00"
+    "last_rows_inserted": null,
+    "updated_at": "2026-04-21T12:04:00+00:00",
+    "estimated_progress_pct": 31.4,
+    "estimated_eta_seconds": 840,
+    "estimated_total_seconds": 1260,
+    "elapsed_seconds": 420,
+    "estimated_completion_at": "2026-04-21T12:21:00+00:00",
+    "estimate_confidence": "medium"
   }
 ]
 ```
+
+Regras do endpoint:
+- `cd_cvm` continua opcional; quando informado, o payload tende a retornar `[]`
+  ou um unico item
+- `estimated_progress_pct`, `estimated_eta_seconds`, `estimated_total_seconds`,
+  `elapsed_seconds`, `estimated_completion_at` e `estimate_confidence` sao
+  campos aditivos e podem vir `null`
+- os campos de estimativa sao preenchidos apenas para refresh ativo
+  (`last_status = queued|running`); para estados finais o contrato pode manter
+  esses campos nulos
+- a estimativa usa throughput historico recente da propria base e deve ser
+  tratada como aproximacao de UX, nao como SLA operacional
+- `estimate_confidence` usa `low|medium|high`
 
 ### `GET /base-health?start_year=&end_year=&force_refresh=`
 

--- a/src/contracts.py
+++ b/src/contracts.py
@@ -394,6 +394,12 @@ class RefreshStatusDTO:
     last_end_year: int | None
     last_rows_inserted: int | None
     updated_at: str | None
+    estimated_progress_pct: float | None = None
+    estimated_eta_seconds: int | None = None
+    estimated_total_seconds: int | None = None
+    elapsed_seconds: int | None = None
+    estimated_completion_at: str | None = None
+    estimate_confidence: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)

--- a/src/read_service.py
+++ b/src/read_service.py
@@ -4,6 +4,7 @@ import io
 import zipfile
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
+from statistics import median
 from typing import Any
 
 import pandas as pd
@@ -75,6 +76,11 @@ class CVMReadService:
     THROUGHPUT_MIN_SUCCESS_SAMPLES = 3
     RANKED_REFRESH_QUEUE_WINDOW_MINUTES = 10
     PRIORITIZED_BACKLOG_STALE_HOURS = 12
+    ACTIVE_REFRESH_STATUSES = {"queued", "running"}
+    REFRESH_ESTIMATE_DEFAULT_TOTAL_SECONDS = 18 * 60
+    REFRESH_ESTIMATE_PROGRESS_FLOOR = 12.0
+    REFRESH_ESTIMATE_PROGRESS_CEILING = 92.0
+    REFRESH_ESTIMATE_PROGRESS_CAP = 96.0
 
     def __init__(self, settings: AppSettings | None = None):
         self.settings = settings or get_settings()
@@ -622,22 +628,64 @@ class CVMReadService:
         )
         with self.engine.connect() as conn:
             rows = conn.execute(query, {"cd_cvm": int(cd_cvm) if cd_cvm is not None else None}).mappings().all()
+        duration_profile = (
+            self._estimate_refresh_duration_profile()
+            if any(
+                str(row.get("last_status") or "").strip().lower()
+                in self.ACTIVE_REFRESH_STATUSES
+                for row in rows
+            )
+            else None
+        )
         return [
-            RefreshStatusDTO(
-                cd_cvm=int(row["cd_cvm"]),
-                company_name=str(row["company_name"] or ""),
-                source_scope=row.get("source_scope"),
-                last_attempt_at=row.get("last_attempt_at"),
-                last_success_at=row.get("last_success_at"),
-                last_status=row.get("last_status"),
-                last_error=row.get("last_error"),
-                last_start_year=int(row["last_start_year"]) if row.get("last_start_year") is not None else None,
-                last_end_year=int(row["last_end_year"]) if row.get("last_end_year") is not None else None,
-                last_rows_inserted=int(row["last_rows_inserted"]) if row.get("last_rows_inserted") is not None else None,
-                updated_at=row.get("updated_at"),
+            self._build_refresh_status_dto(
+                row,
+                duration_profile=duration_profile,
             )
             for row in rows
         ]
+
+    def _build_refresh_status_dto(
+        self,
+        row: dict[str, Any],
+        *,
+        duration_profile: dict[str, Any] | None,
+    ) -> RefreshStatusDTO:
+        estimate = self._estimate_refresh_runtime(
+            row,
+            duration_profile=duration_profile,
+        )
+        return RefreshStatusDTO(
+            cd_cvm=int(row["cd_cvm"]),
+            company_name=str(row["company_name"] or ""),
+            source_scope=row.get("source_scope"),
+            last_attempt_at=row.get("last_attempt_at"),
+            last_success_at=row.get("last_success_at"),
+            last_status=row.get("last_status"),
+            last_error=row.get("last_error"),
+            last_start_year=(
+                int(row["last_start_year"])
+                if row.get("last_start_year") is not None
+                else None
+            ),
+            last_end_year=(
+                int(row["last_end_year"])
+                if row.get("last_end_year") is not None
+                else None
+            ),
+            last_rows_inserted=(
+                int(row["last_rows_inserted"])
+                if row.get("last_rows_inserted") is not None
+                else None
+            ),
+            updated_at=row.get("updated_at"),
+            estimated_progress_pct=estimate["estimated_progress_pct"],
+            estimated_eta_seconds=estimate["estimated_eta_seconds"],
+            estimated_total_seconds=estimate["estimated_total_seconds"],
+            elapsed_seconds=estimate["elapsed_seconds"],
+            estimated_completion_at=estimate["estimated_completion_at"],
+            estimate_confidence=estimate["estimate_confidence"],
+        )
 
     def request_company_refresh(self, cd_cvm: int) -> str:
         """Dispatch on-demand ingest for one company.
@@ -1266,6 +1314,157 @@ class CVMReadService:
         with self.engine.connect() as conn:
             rows = conn.execute(query, params).mappings().all()
         return {int(row["cd_cvm"]): dict(row) for row in rows}
+
+    def _default_refresh_year_span(self) -> int:
+        start_year, end_year = self._resolve_refresh_range(
+            start_year=2010,
+            end_year=None,
+        )
+        return max(1, int(end_year) - int(start_year) + 1)
+
+    def _refresh_year_span(self, row: dict[str, Any]) -> int:
+        start_year = row.get("last_start_year")
+        end_year = row.get("last_end_year")
+        if start_year is None or end_year is None:
+            return self._default_refresh_year_span()
+        try:
+            year_span = int(end_year) - int(start_year) + 1
+        except (TypeError, ValueError):
+            return self._default_refresh_year_span()
+        return max(1, year_span)
+
+    def _estimate_refresh_duration_profile(self) -> dict[str, Any]:
+        typical_year_span = float(self._default_refresh_year_span())
+        year_span_samples = 0
+
+        if inspect(self.engine).has_table("company_refresh_status"):
+            query = text(
+                """
+                SELECT last_start_year, last_end_year
+                FROM company_refresh_status
+                WHERE last_status = 'success'
+                  AND last_start_year IS NOT NULL
+                  AND last_end_year IS NOT NULL
+                ORDER BY last_success_at DESC
+                LIMIT 200
+                """
+            )
+            with self.engine.connect() as conn:
+                rows = conn.execute(query).mappings().all()
+
+            year_spans = []
+            for row in rows:
+                try:
+                    year_span = int(row["last_end_year"]) - int(row["last_start_year"]) + 1
+                except (TypeError, ValueError):
+                    continue
+                if year_span > 0:
+                    year_spans.append(year_span)
+
+            if year_spans:
+                typical_year_span = float(median(year_spans))
+                year_span_samples = len(year_spans)
+
+        throughput = self._estimate_refresh_throughput()
+        per_hour = throughput.get("per_hour")
+        typical_total_seconds = (
+            max(60.0, 3600.0 / float(per_hour))
+            if per_hour
+            else float(self.REFRESH_ESTIMATE_DEFAULT_TOTAL_SECONDS)
+        )
+
+        return {
+            "typical_year_span": max(1.0, typical_year_span),
+            "typical_total_seconds": float(typical_total_seconds),
+            "sample_size": max(
+                int(throughput.get("sample_size") or 0),
+                int(year_span_samples),
+            ),
+            "confidence": str(throughput.get("confidence") or "low"),
+        }
+
+    def _estimate_refresh_runtime(
+        self,
+        row: dict[str, Any],
+        *,
+        duration_profile: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        last_status = str(row.get("last_status") or "").strip().lower()
+        if last_status not in self.ACTIVE_REFRESH_STATUSES:
+            return {
+                "estimated_progress_pct": None,
+                "estimated_eta_seconds": None,
+                "estimated_total_seconds": None,
+                "elapsed_seconds": None,
+                "estimated_completion_at": None,
+                "estimate_confidence": None,
+            }
+
+        attempted_at = self._parse_timestamp(row.get("last_attempt_at"))
+        profile = duration_profile or self._estimate_refresh_duration_profile()
+        typical_year_span = max(
+            1.0,
+            float(profile.get("typical_year_span") or self._default_refresh_year_span()),
+        )
+        current_year_span = float(self._refresh_year_span(row))
+        typical_total_seconds = max(
+            60.0,
+            float(
+                profile.get("typical_total_seconds")
+                or self.REFRESH_ESTIMATE_DEFAULT_TOTAL_SECONDS
+            ),
+        )
+        estimated_total_seconds = max(
+            60,
+            int(round(typical_total_seconds * (current_year_span / typical_year_span))),
+        )
+
+        now = datetime.now(timezone.utc)
+        elapsed_seconds = (
+            max(0, int(round((now - attempted_at).total_seconds())))
+            if attempted_at is not None
+            else None
+        )
+        estimated_completion_at = (
+            (
+                attempted_at + timedelta(seconds=estimated_total_seconds)
+                if attempted_at is not None
+                else now + timedelta(seconds=estimated_total_seconds)
+            )
+            .replace(microsecond=0)
+            .isoformat()
+        )
+
+        if elapsed_seconds is None:
+            estimated_progress_pct = self.REFRESH_ESTIMATE_PROGRESS_FLOOR
+            estimated_eta_seconds = estimated_total_seconds
+        else:
+            ratio = float(elapsed_seconds) / float(estimated_total_seconds)
+            estimated_progress_pct = self.REFRESH_ESTIMATE_PROGRESS_FLOOR + (
+                min(1.0, ratio)
+                * (
+                    self.REFRESH_ESTIMATE_PROGRESS_CEILING
+                    - self.REFRESH_ESTIMATE_PROGRESS_FLOOR
+                )
+            )
+            if ratio > 1.0:
+                estimated_progress_pct = min(
+                    self.REFRESH_ESTIMATE_PROGRESS_CAP,
+                    estimated_progress_pct + min(6.0, (ratio - 1.0) * 10.0),
+                )
+            estimated_eta_seconds = max(0, estimated_total_seconds - elapsed_seconds)
+
+        if last_status == "running":
+            estimated_progress_pct = max(estimated_progress_pct, 28.0)
+
+        return {
+            "estimated_progress_pct": round(float(estimated_progress_pct), 1),
+            "estimated_eta_seconds": int(estimated_eta_seconds),
+            "estimated_total_seconds": int(estimated_total_seconds),
+            "elapsed_seconds": elapsed_seconds,
+            "estimated_completion_at": estimated_completion_at,
+            "estimate_confidence": str(profile.get("confidence") or "low"),
+        }
 
     def _estimate_refresh_throughput(self) -> dict[str, Any]:
         if not inspect(self.engine).has_table("company_refresh_status"):


### PR DESCRIPTION
## Summary
- add additive estimated progress and ETA fields to the refresh-status contract based on recent refresh history
- surface the on-demand refresh progress bar and timing hints on both the no-data company page and the freshness card
- document the new polling UX and cover the contract/frontend validators with tests

## Testing
- pytest apps/api/tests -q
- npm run lint
- npm run typecheck
- npm run build

Closes #158
