### PR TITLE
feat(web): improve on-demand refresh UX

### DIFF
--- a/apps/web/components/company/company-request-refresh.tsx
+++ b/apps/web/components/company/company-request-refresh.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { LoaderCircleIcon, RotateCcwIcon } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import {
@@ -13,205 +14,84 @@ import {
   getUserFacingErrorMessage,
   isApiClientError,
 } from "@/lib/api";
+import {
+  applyManualStatusFailure,
+  applyRefreshPollFailure,
+  applyRefreshStatusResult,
+  createDelayedRefreshState,
+  createDispatchFailureState,
+  createDispatchedRefreshState,
+  createIdleRefreshState,
+  createSubmittingRefreshState,
+  getNextPollingDelayMs,
+  getRefreshViewModel,
+  hasRefreshTimedOut,
+  hydrateRefreshState,
+  isAutoPollingPhase,
+  RELOAD_DELAY_MS,
+  type RefreshMachineState,
+} from "@/lib/company-refresh-state";
+import { cn } from "@/lib/utils";
 
 type CompanyRequestRefreshProps = {
   cdCvm: number;
   initialStatus?: RefreshStatusItem | null;
 };
 
-type RefreshPhase =
-  | "idle"
-  | "submitting"
-  | "polling"
-  | "success"
-  | "error"
-  | "timeout";
-
-type RefreshState = {
-  phase: RefreshPhase;
-  message?: string;
-  detail?: string;
-  startedAt?: number;
-  currentItem?: RefreshStatusItem | null;
-};
-
-type RefreshEstimate = {
-  progress: number;
-  etaLabel: string;
-  completionLabel?: string;
-  confidenceLabel?: string;
-  indicatorClassName: string;
-};
-
-const ACTIVE_REFRESH_STATUSES = new Set(["queued", "running"]);
-const POLL_INTERVAL_MS = 10_000;
-const POLL_TIMEOUT_MS = 15 * 60 * 1_000;
-const RELOAD_DELAY_MS = 1_200;
-
-const ESTIMATE_TIME_FORMATTER = new Intl.DateTimeFormat("pt-BR", {
-  hour: "2-digit",
-  minute: "2-digit",
-});
-
-function isActiveRefreshStatus(status: string | null | undefined): boolean {
-  return ACTIVE_REFRESH_STATUSES.has(String(status || "").trim().toLowerCase());
-}
-
-function parseTimestamp(value: string | null | undefined): number | undefined {
-  if (!value) {
-    return undefined;
-  }
-
-  const timestamp = new Date(value).getTime();
-  return Number.isNaN(timestamp) ? undefined : timestamp;
-}
-
-function getPollingCopy(item: RefreshStatusItem | undefined): {
-  message: string;
-  detail?: string;
-} {
-  switch (item?.last_status) {
-    case "queued":
-      return {
-        message: "Solicitacao enviada. Aguardando processamento...",
-        detail: "Acompanhando a fila atual da ingestao on-demand.",
-      };
-    case "running":
-      return {
-        message: "Atualizando demonstracoes financeiras...",
-        detail: "Os dados desta companhia estao sendo processados agora.",
-      };
-    default:
-      return {
-        message: "Acompanhando o processamento atual...",
-        detail: "A pagina sera recarregada assim que os dados ficarem disponiveis.",
-      };
-  }
-}
-
-function formatDuration(seconds: number): string {
-  if (seconds < 60) {
-    return "menos de 1 min";
-  }
-
-  const totalMinutes = Math.round(seconds / 60);
-  if (totalMinutes < 60) {
-    return `${totalMinutes} min`;
-  }
-
-  const hours = Math.floor(totalMinutes / 60);
-  const minutes = totalMinutes % 60;
-  if (minutes === 0) {
-    return `${hours} h`;
-  }
-
-  return `${hours} h ${minutes} min`;
-}
-
-function formatEstimatedTime(dateIso: string | null | undefined): string | null {
-  if (!dateIso) {
-    return null;
-  }
-
-  const date = new Date(dateIso);
-  if (Number.isNaN(date.getTime())) {
-    return null;
-  }
-
-  return ESTIMATE_TIME_FORMATTER.format(date);
-}
-
-function getConfidenceLabel(confidence: string | null | undefined): string | null {
-  switch (String(confidence || "").trim().toLowerCase()) {
-    case "high":
-      return "Estimativa baseada em execucoes recentes consistentes.";
-    case "medium":
-      return "Estimativa baseada nas ultimas execucoes concluidas.";
-    case "low":
-      return "Estimativa inicial. A amostra historica ainda e pequena.";
-    default:
-      return null;
-  }
-}
-
-function buildPollingState(item: RefreshStatusItem): RefreshState {
-  const copy = getPollingCopy(item);
-  return {
-    phase: "polling",
-    startedAt: parseTimestamp(item.last_attempt_at) ?? Date.now(),
-    message: copy.message,
-    detail: copy.detail,
-    currentItem: item,
-  };
-}
-
-function buildRefreshEstimate(
-  phase: RefreshPhase,
-  item: RefreshStatusItem | null | undefined,
-): RefreshEstimate | null {
-  if (phase === "submitting") {
-    return {
-      progress: 6,
-      etaLabel: "Preparando a fila on-demand...",
-      indicatorClassName:
-        "bg-gradient-to-r from-amber-500 via-orange-400 to-rose-400",
-    };
-  }
-
-  if (phase === "success") {
-    return {
-      progress: 100,
-      etaLabel: "Processamento concluido",
-      indicatorClassName:
-        "bg-gradient-to-r from-emerald-500 via-teal-400 to-cyan-400",
-    };
-  }
-
-  if (!item || !isActiveRefreshStatus(item.last_status)) {
-    return null;
-  }
-
-  const progress = Math.min(
-    100,
-    Math.max(
-      8,
-      item.estimated_progress_pct ??
-        (String(item.last_status).toLowerCase() === "running" ? 28 : 14),
-    ),
-  );
-  const totalSeconds = item.estimated_total_seconds;
-  const elapsedSeconds = item.elapsed_seconds;
-  const isOverdue =
-    typeof totalSeconds === "number" &&
-    typeof elapsedSeconds === "number" &&
-    elapsedSeconds > totalSeconds;
-  const etaSeconds = item.estimated_eta_seconds;
-  const completionTime = formatEstimatedTime(item.estimated_completion_at);
-
-  return {
-    progress,
-    etaLabel: isOverdue
-      ? "Acima da estimativa, mas ainda em processamento."
-      : typeof etaSeconds === "number" && etaSeconds > 0
-        ? `~${formatDuration(etaSeconds)} restantes`
-        : "Finalizando a atualizacao...",
-    completionLabel: completionTime ? `Previsao: ${completionTime}` : undefined,
-    confidenceLabel: getConfidenceLabel(item.estimate_confidence) ?? undefined,
-    indicatorClassName:
-      "bg-gradient-to-r from-emerald-500 via-lime-400 to-cyan-400",
-  };
-}
-
 export function CompanyRequestRefresh({
   cdCvm,
   initialStatus = null,
 }: CompanyRequestRefreshProps) {
-  const [state, setState] = useState<RefreshState>({ phase: "idle" });
-  const reloadTimerRef = useRef<number | null>(null);
+  const [state, setState] = useState<RefreshMachineState>(() =>
+    createIdleRefreshState(),
+  );
+  const [isManualStatusRefreshing, setIsManualStatusRefreshing] =
+    useState(false);
   const hydratedInitialStatusRef = useRef(false);
+  const isMountedRef = useRef(true);
+  const reloadTimerRef = useRef<number | null>(null);
+  const view = getRefreshViewModel(state);
+
+  const pollRefreshStatus = useCallback(
+    async (source: "auto" | "manual") => {
+      try {
+        const items = await fetchRefreshStatus(cdCvm);
+
+        if (!isMountedRef.current) {
+          return;
+        }
+
+        setState((currentState) =>
+          applyRefreshStatusResult(
+            currentState,
+            items[0] ?? null,
+            Date.now(),
+            { source },
+          ),
+        );
+      } catch {
+        if (!isMountedRef.current) {
+          return;
+        }
+
+        setState((currentState) =>
+          source === "manual"
+            ? applyManualStatusFailure(currentState)
+            : applyRefreshPollFailure(currentState),
+        );
+      } finally {
+        if (isMountedRef.current && source === "manual") {
+          setIsManualStatusRefreshing(false);
+        }
+      }
+    },
+    [cdCvm],
+  );
 
   useEffect(() => {
     return () => {
+      isMountedRef.current = false;
+
       if (reloadTimerRef.current !== null) {
         window.clearTimeout(reloadTimerRef.current);
       }
@@ -224,193 +104,105 @@ export function CompanyRequestRefresh({
     }
 
     hydratedInitialStatusRef.current = true;
-    if (isActiveRefreshStatus(initialStatus.last_status)) {
-      setState(buildPollingState(initialStatus));
-    }
+    setState(hydrateRefreshState(initialStatus));
   }, [initialStatus]);
 
   useEffect(() => {
-    if (state.phase !== "polling" || state.startedAt === undefined) {
+    if (state.phase !== "success") {
       return;
     }
 
-    const pollingStartedAt = state.startedAt;
-    let active = true;
-
-    async function pollRefreshStatus() {
-      if (!active) {
-        return;
-      }
-
-      if (Date.now() - pollingStartedAt >= POLL_TIMEOUT_MS) {
-        setState((currentState) => ({
-          phase: "timeout",
-          startedAt: currentState.startedAt,
-          currentItem: currentState.currentItem,
-          message: "O processamento ainda nao terminou.",
-          detail:
-            "Voce pode tentar novamente para reiniciar o acompanhamento desta empresa.",
-        }));
-        return;
-      }
-
-      try {
-        const items = await fetchRefreshStatus(cdCvm);
-
-        if (!active) {
-          return;
-        }
-
-        const currentItem = items[0] ?? null;
-        const currentStatus = currentItem?.last_status;
-
-        if (currentStatus === "success") {
-          setState((currentState) => ({
-            phase: "success",
-            startedAt: currentState.startedAt,
-            currentItem,
-            message: "Dados disponiveis! Recarregando...",
-            detail: "A leitura detalhada desta empresa sera atualizada agora.",
-          }));
-          reloadTimerRef.current = window.setTimeout(() => {
-            window.location.reload();
-          }, RELOAD_DELAY_MS);
-          return;
-        }
-
-        if (currentStatus === "error" || currentStatus === "dispatch_failed") {
-          setState((currentState) => ({
-            phase: "error",
-            startedAt: currentState.startedAt,
-            currentItem,
-            message:
-              currentItem?.last_error ??
-              "Nao foi possivel concluir a atualizacao desta empresa.",
-            detail:
-              "A solicitacao foi encerrada com falha. Tente novamente em instantes.",
-          }));
-          return;
-        }
-
-        const copy = getPollingCopy(currentItem ?? undefined);
-        setState((currentState) =>
-          currentState.phase === "polling"
-            ? {
-                ...currentState,
-                currentItem,
-                message: copy.message,
-                detail: copy.detail,
-              }
-            : currentState,
-        );
-      } catch (error) {
-        if (!active) {
-          return;
-        }
-
-        setState((currentState) => ({
-          phase: "error",
-          startedAt: currentState.startedAt,
-          currentItem: currentState.currentItem,
-          message: getUserFacingErrorMessage(error),
-          detail:
-            "O acompanhamento do refresh foi interrompido. Tente novamente em instantes.",
-        }));
-      }
-    }
-
-    void pollRefreshStatus();
-
-    const intervalId = window.setInterval(() => {
-      void pollRefreshStatus();
-    }, POLL_INTERVAL_MS);
+    reloadTimerRef.current = window.setTimeout(() => {
+      window.location.reload();
+    }, RELOAD_DELAY_MS);
 
     return () => {
-      active = false;
-      window.clearInterval(intervalId);
+      if (reloadTimerRef.current !== null) {
+        window.clearTimeout(reloadTimerRef.current);
+        reloadTimerRef.current = null;
+      }
     };
-  }, [cdCvm, state.phase, state.startedAt]);
+  }, [state.phase]);
 
-  async function handleRequestRefresh() {
-    if (
-      state.phase === "submitting" ||
-      state.phase === "polling" ||
-      state.phase === "success"
-    ) {
+  useEffect(() => {
+    if (!isAutoPollingPhase(state.phase)) {
       return;
     }
 
-    setState({
-      phase: "submitting",
-      message: "Solicitando atualizacao...",
-      detail: "Preparando o disparo on-demand desta companhia.",
-    });
+    if (hasRefreshTimedOut(state, Date.now())) {
+      setState((currentState) =>
+        hasRefreshTimedOut(currentState, Date.now())
+          ? createDelayedRefreshState(currentState)
+          : currentState,
+      );
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      void pollRefreshStatus("auto");
+    }, getNextPollingDelayMs(state));
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [pollRefreshStatus, state]);
+
+  async function handleRequestRefresh() {
+    if (view.requestButtonDisabled) {
+      return;
+    }
+
+    setState(createSubmittingRefreshState());
 
     try {
       const payload = await fetchRequestRefresh(cdCvm);
-      setState({
-        phase: "polling",
-        startedAt: Date.now(),
-        message:
-          payload.status === "dispatch_failed"
-            ? "Dispatch registrado com falha. Acompanhando o status..."
-            : "Solicitacao enviada. Acompanhando processamento...",
-        detail:
-          payload.status === "dispatch_failed"
-            ? "O backend vai expor o status final desta tentativa na fila de refresh."
-            : "A pagina sera recarregada assim que os dados estiverem prontos.",
-        currentItem: null,
-      });
-    } catch (error) {
-      if (isApiClientError(error) && error.status === 429) {
-        setState({
-          phase: "polling",
-          startedAt: Date.now(),
-          message: "Solicitacao ja em andamento.",
-          detail: "Acompanhando o processamento atual desta companhia.",
-          currentItem: null,
-        });
+
+      if (!isMountedRef.current) {
         return;
       }
 
-      setState({
-        phase: "error",
-        message: getUserFacingErrorMessage(error),
-        detail: "Tente novamente em instantes.",
-        currentItem: null,
-      });
+      if (payload.status === "dispatch_failed") {
+        setState(
+          createDispatchFailureState(
+            "Nao foi possivel iniciar a atualizacao desta empresa.",
+          ),
+        );
+        return;
+      }
+
+      setState(createDispatchedRefreshState(Date.now()));
+    } catch (error) {
+      if (!isMountedRef.current) {
+        return;
+      }
+
+      if (isApiClientError(error) && error.status === 429) {
+        setState(createDispatchedRefreshState(Date.now()));
+        return;
+      }
+
+      setState(createDispatchFailureState(getUserFacingErrorMessage(error)));
     }
   }
 
-  function handleReset() {
-    if (reloadTimerRef.current !== null) {
-      window.clearTimeout(reloadTimerRef.current);
-      reloadTimerRef.current = null;
+  function handleManualStatusRefresh() {
+    if (state.phase !== "delayed" || isManualStatusRefreshing) {
+      return;
     }
 
-    setState({ phase: "idle" });
+    setIsManualStatusRefreshing(true);
+    void pollRefreshStatus("manual");
   }
 
-  const isBusy =
+  const showButtonSpinner =
     state.phase === "submitting" ||
-    state.phase === "polling" ||
+    state.phase === "queued" ||
+    state.phase === "running" ||
+    state.phase === "reconnecting" ||
     state.phase === "success";
-
-  const buttonLabel =
-    state.phase === "submitting"
-      ? "Solicitando..."
-      : state.phase === "polling"
-        ? "Atualizando..."
-        : state.phase === "success"
-          ? "Recarregando..."
-          : state.phase === "error" || state.phase === "timeout"
-            ? "Solicitar novamente"
-            : "Solicitar dados financeiros";
-
-  const showStatus = state.phase !== "idle";
-  const isDestructive = state.phase === "error" || state.phase === "timeout";
-  const estimate = buildRefreshEstimate(state.phase, state.currentItem);
-  const progressLabel = `${Math.round(estimate?.progress ?? 0)}%`;
+  const progressLabel = view.estimate
+    ? `${Math.round(view.estimate.progress)}%`
+    : null;
 
   return (
     <div className="flex min-w-[18rem] flex-col gap-3 sm:max-w-xl">
@@ -420,81 +212,117 @@ export function CompanyRequestRefresh({
         size="lg"
         className="w-fit rounded-full px-5"
         onClick={handleRequestRefresh}
-        disabled={isBusy}
+        disabled={view.requestButtonDisabled}
       >
-        {isBusy ? <LoaderCircleIcon className="animate-spin" /> : null}
-        {buttonLabel}
+        {showButtonSpinner ? (
+          <LoaderCircleIcon className="animate-spin" />
+        ) : null}
+        {view.requestButtonLabel}
       </Button>
 
-      {showStatus ? (
+      {view.showCard ? (
         <Alert
           className={
-            isDestructive
+            view.isDestructive
               ? "rounded-[1.5rem] border border-destructive/25 bg-destructive/6 px-4 py-4"
               : "rounded-[1.5rem] border border-border/70 bg-muted/28 px-4 py-4"
           }
         >
-          <AlertTitle>
-            {state.phase === "success"
-              ? "Atualizacao concluida"
-              : state.phase === "timeout"
-                ? "Tempo limite atingido"
-                : state.phase === "error"
-                  ? "Refresh indisponivel"
-                  : "Atualizacao em andamento"}
+          <AlertTitle className="space-y-2">
+            <Badge
+              variant="outline"
+              className={cn(
+                "w-fit rounded-full border px-2.5 py-0.5 text-[0.7rem] uppercase tracking-[0.18em]",
+                view.stepClassName,
+              )}
+            >
+              {view.stepLabel}
+            </Badge>
+            <span className="block">{view.title}</span>
           </AlertTitle>
-          <AlertDescription className="space-y-3">
-            <p>{state.message}</p>
-            {state.detail ? <p>{state.detail}</p> : null}
 
-            {estimate ? (
+          <AlertDescription
+            className="space-y-3"
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            <p>{view.message}</p>
+            {view.detail ? <p>{view.detail}</p> : null}
+
+            {view.estimate ? (
               <div className="rounded-[1.25rem] border border-border/65 bg-background/82 px-4 py-4 shadow-[0_1px_0_rgba(255,255,255,0.22)]">
                 <div className="mb-3 flex items-start justify-between gap-3">
                   <div>
                     <p className="text-[0.7rem] font-medium uppercase tracking-[0.22em] text-muted-foreground">
-                      Estimativa de conclusao
+                      Progresso do refresh
                     </p>
                     <p className="mt-1 text-xs text-muted-foreground">
-                      Progresso aproximado do refresh on-demand.
+                      Acompanhamento aproximado da atualizacao on-demand.
                     </p>
                   </div>
-                  <p className="text-lg font-semibold tabular-nums text-foreground">
-                    {progressLabel}
-                  </p>
-                </div>
-
-                <Progress
-                  value={estimate.progress}
-                  aria-label="Progresso estimado da atualizacao on-demand"
-                  indicatorClassName={estimate.indicatorClassName}
-                />
-
-                <div className="mt-3 flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
-                  <span>{estimate.etaLabel}</span>
-                  {estimate.completionLabel ? (
-                    <span>{estimate.completionLabel}</span>
+                  {progressLabel ? (
+                    <p className="text-lg font-semibold tabular-nums text-foreground">
+                      {progressLabel}
+                    </p>
                   ) : null}
                 </div>
 
-                {estimate.confidenceLabel ? (
+                <Progress
+                  value={view.estimate.progress}
+                  aria-label="Progresso estimado da atualizacao on-demand"
+                  indicatorClassName={view.estimate.indicatorClassName}
+                />
+
+                <div className="mt-3 flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
+                  <span>{view.estimate.etaLabel}</span>
+                  {view.estimate.completionLabel ? (
+                    <span>{view.estimate.completionLabel}</span>
+                  ) : null}
+                </div>
+
+                {view.estimate.confidenceLabel ? (
                   <p className="mt-2 text-xs text-muted-foreground">
-                    {estimate.confidenceLabel}
+                    {view.estimate.confidenceLabel}
                   </p>
                 ) : null}
               </div>
             ) : null}
 
-            {state.phase === "timeout" ? (
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className="rounded-full px-3"
-                onClick={handleReset}
-              >
-                <RotateCcwIcon />
-                Tentar novamente
-              </Button>
+            {view.showManualStatusButton || view.showRequestAgainButton ? (
+              <div className="flex flex-wrap items-center gap-2">
+                {view.showManualStatusButton ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="rounded-full px-3"
+                    onClick={handleManualStatusRefresh}
+                    disabled={isManualStatusRefreshing}
+                  >
+                    {isManualStatusRefreshing ? (
+                      <LoaderCircleIcon className="animate-spin" />
+                    ) : (
+                      <RotateCcwIcon />
+                    )}
+                    {isManualStatusRefreshing
+                      ? "Atualizando status..."
+                      : "Atualizar status agora"}
+                  </Button>
+                ) : null}
+
+                {view.showRequestAgainButton ? (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="rounded-full px-3"
+                    onClick={handleRequestRefresh}
+                    disabled={isManualStatusRefreshing}
+                  >
+                    Solicitar novamente
+                  </Button>
+                ) : null}
+              </div>
             ) : null}
           </AlertDescription>
         </Alert>

--- a/apps/web/lib/company-refresh-state.ts
+++ b/apps/web/lib/company-refresh-state.ts
@@ -1,0 +1,674 @@
+import type { RefreshStatusItem } from "@/lib/api";
+
+export type RefreshPhase =
+  | "idle"
+  | "submitting"
+  | "queued"
+  | "running"
+  | "reconnecting"
+  | "delayed"
+  | "terminal_error"
+  | "success";
+
+export type RefreshMachineState = {
+  phase: RefreshPhase;
+  startedAt?: number;
+  currentItem: RefreshStatusItem | null;
+  lastKnownActiveItem: RefreshStatusItem | null;
+  failureCount: number;
+  canRequestAgain: boolean;
+  notice: string | null;
+  terminalMessage: string | null;
+};
+
+export type RefreshEstimate = {
+  progress: number;
+  etaLabel: string;
+  completionLabel?: string;
+  confidenceLabel?: string;
+  indicatorClassName: string;
+};
+
+export type RefreshViewModel = {
+  showCard: boolean;
+  title: string;
+  message: string;
+  detail?: string;
+  stepLabel: string;
+  stepClassName: string;
+  isDestructive: boolean;
+  estimate: RefreshEstimate | null;
+  requestButtonLabel: string;
+  requestButtonDisabled: boolean;
+  showManualStatusButton: boolean;
+  showRequestAgainButton: boolean;
+};
+
+export const POLL_INTERVAL_MS = 10_000;
+export const POLL_TIMEOUT_MS = 15 * 60 * 1_000;
+export const RELOAD_DELAY_MS = 1_200;
+
+const RECONNECT_DELAY_SEQUENCE_MS = [10_000, 20_000, 30_000, 60_000];
+const ACTIVE_REFRESH_STATUSES = new Set(["queued", "running"]);
+const TERMINAL_REFRESH_STATUSES = new Set(["error", "dispatch_failed"]);
+const ESTIMATE_TIME_FORMATTER = new Intl.DateTimeFormat("pt-BR", {
+  hour: "2-digit",
+  minute: "2-digit",
+});
+
+function normalizeStatus(status: string | null | undefined): string {
+  return String(status || "").trim().toLowerCase();
+}
+
+function getQueuedMessage(): { message: string; detail: string } {
+  return {
+    message: "Solicitacao enviada. Aguardando processamento...",
+    detail: "Acompanhando a fila atual da ingestao on-demand.",
+  };
+}
+
+function getRunningMessage(): { message: string; detail: string } {
+  return {
+    message: "Atualizando demonstracoes financeiras...",
+    detail: "Os dados desta companhia estao sendo processados agora.",
+  };
+}
+
+function getBadgeClassName(phase: RefreshPhase): string {
+  switch (phase) {
+    case "running":
+      return "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300";
+    case "reconnecting":
+      return "border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-300";
+    case "delayed":
+      return "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300";
+    case "terminal_error":
+      return "border-destructive/25 bg-destructive/10 text-destructive";
+    case "success":
+      return "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300";
+    default:
+      return "border-border/70 bg-muted/60 text-foreground/80";
+  }
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds < 60) {
+    return "menos de 1 min";
+  }
+
+  const totalMinutes = Math.round(seconds / 60);
+  if (totalMinutes < 60) {
+    return `${totalMinutes} min`;
+  }
+
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (minutes === 0) {
+    return `${hours} h`;
+  }
+
+  return `${hours} h ${minutes} min`;
+}
+
+function formatEstimatedTime(dateIso: string | null | undefined): string | null {
+  if (!dateIso) {
+    return null;
+  }
+
+  const date = new Date(dateIso);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return ESTIMATE_TIME_FORMATTER.format(date);
+}
+
+function getConfidenceLabel(confidence: string | null | undefined): string | null {
+  switch (normalizeStatus(confidence)) {
+    case "high":
+      return "Estimativa baseada em execucoes recentes consistentes.";
+    case "medium":
+      return "Estimativa baseada nas ultimas execucoes concluidas.";
+    case "low":
+      return "Estimativa inicial.";
+    default:
+      return null;
+  }
+}
+
+function getFallbackProgress(
+  phase: RefreshPhase,
+  item: RefreshStatusItem | null | undefined,
+): number {
+  const itemStatus = normalizeStatus(item?.last_status);
+
+  if (itemStatus === "running") {
+    return phase === "delayed" ? 64 : 42;
+  }
+
+  if (itemStatus === "queued") {
+    return phase === "delayed" ? 26 : 16;
+  }
+
+  switch (phase) {
+    case "submitting":
+      return 6;
+    case "running":
+      return 42;
+    case "reconnecting":
+      return 38;
+    case "delayed":
+      return 52;
+    case "success":
+      return 100;
+    default:
+      return 16;
+  }
+}
+
+function getEstimateIndicatorClassName(phase: RefreshPhase): string {
+  switch (phase) {
+    case "submitting":
+      return "bg-gradient-to-r from-amber-500 via-orange-400 to-rose-400";
+    case "queued":
+      return "bg-gradient-to-r from-slate-500 via-sky-400 to-cyan-400";
+    case "reconnecting":
+      return "bg-gradient-to-r from-sky-500 via-cyan-400 to-teal-400";
+    case "delayed":
+      return "bg-gradient-to-r from-amber-500 via-orange-400 to-rose-400";
+    case "success":
+      return "bg-gradient-to-r from-emerald-500 via-teal-400 to-cyan-400";
+    default:
+      return "bg-gradient-to-r from-emerald-500 via-lime-400 to-cyan-400";
+  }
+}
+
+function getEstimateReferenceItem(
+  state: RefreshMachineState,
+): RefreshStatusItem | null {
+  if (isActiveRefreshStatus(state.currentItem?.last_status)) {
+    return state.currentItem;
+  }
+
+  return state.lastKnownActiveItem;
+}
+
+function buildRefreshEstimate(state: RefreshMachineState): RefreshEstimate | null {
+  if (state.phase === "idle" || state.phase === "terminal_error") {
+    return null;
+  }
+
+  if (state.phase === "success") {
+    return {
+      progress: 100,
+      etaLabel: "Processamento concluido",
+      indicatorClassName: getEstimateIndicatorClassName(state.phase),
+    };
+  }
+
+  const item = getEstimateReferenceItem(state);
+  const fallbackProgress = getFallbackProgress(state.phase, item);
+
+  if (state.phase === "submitting") {
+    return {
+      progress: fallbackProgress,
+      etaLabel: "Preparando o acompanhamento do refresh...",
+      indicatorClassName: getEstimateIndicatorClassName(state.phase),
+    };
+  }
+
+  const progress = Math.min(
+    100,
+    Math.max(8, item?.estimated_progress_pct ?? fallbackProgress),
+  );
+  const totalSeconds = item?.estimated_total_seconds;
+  const elapsedSeconds = item?.elapsed_seconds;
+  const etaSeconds = item?.estimated_eta_seconds;
+  const isOverdue =
+    typeof totalSeconds === "number" &&
+    typeof elapsedSeconds === "number" &&
+    elapsedSeconds > totalSeconds;
+  const confidence = normalizeStatus(item?.estimate_confidence);
+  const completionTime = formatEstimatedTime(item?.estimated_completion_at);
+  const hasEstimate =
+    typeof etaSeconds === "number" ||
+    typeof totalSeconds === "number" ||
+    typeof elapsedSeconds === "number";
+
+  return {
+    progress,
+    etaLabel: isOverdue
+      ? "Acima da estimativa, mas ainda em processamento."
+      : typeof etaSeconds === "number" && etaSeconds > 0
+        ? `~${formatDuration(etaSeconds)} restantes`
+        : hasEstimate
+          ? "Finalizando a atualizacao..."
+          : "Estimativa ainda indisponivel",
+    completionLabel:
+      (confidence === "medium" || confidence === "high") && completionTime
+        ? `Previsao: ${completionTime}`
+        : undefined,
+    confidenceLabel: getConfidenceLabel(item?.estimate_confidence) ?? undefined,
+    indicatorClassName: getEstimateIndicatorClassName(state.phase),
+  };
+}
+
+function buildActiveState(
+  phase: "queued" | "running",
+  item: RefreshStatusItem,
+  nowMs: number,
+  currentState?: RefreshMachineState,
+): RefreshMachineState {
+  return {
+    phase,
+    startedAt:
+      parseTimestamp(item.last_attempt_at) ??
+      currentState?.startedAt ??
+      nowMs,
+    currentItem: item,
+    lastKnownActiveItem: item,
+    failureCount: 0,
+    canRequestAgain: false,
+    notice: null,
+    terminalMessage: null,
+  };
+}
+
+export function isActiveRefreshStatus(
+  status: string | null | undefined,
+): boolean {
+  return ACTIVE_REFRESH_STATUSES.has(normalizeStatus(status));
+}
+
+export function parseTimestamp(
+  value: string | null | undefined,
+): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const timestamp = new Date(value).getTime();
+  return Number.isNaN(timestamp) ? undefined : timestamp;
+}
+
+export function createIdleRefreshState(): RefreshMachineState {
+  return {
+    phase: "idle",
+    currentItem: null,
+    lastKnownActiveItem: null,
+    failureCount: 0,
+    canRequestAgain: false,
+    notice: null,
+    terminalMessage: null,
+  };
+}
+
+export function createSubmittingRefreshState(): RefreshMachineState {
+  return {
+    phase: "submitting",
+    currentItem: null,
+    lastKnownActiveItem: null,
+    failureCount: 0,
+    canRequestAgain: false,
+    notice: null,
+    terminalMessage: null,
+  };
+}
+
+export function createDispatchedRefreshState(
+  nowMs = Date.now(),
+): RefreshMachineState {
+  return {
+    phase: "queued",
+    startedAt: nowMs,
+    currentItem: null,
+    lastKnownActiveItem: null,
+    failureCount: 0,
+    canRequestAgain: false,
+    notice: null,
+    terminalMessage: null,
+  };
+}
+
+export function createDispatchFailureState(
+  message?: string,
+): RefreshMachineState {
+  return {
+    phase: "terminal_error",
+    currentItem: null,
+    lastKnownActiveItem: null,
+    failureCount: 0,
+    canRequestAgain: false,
+    notice: null,
+    terminalMessage:
+      message ?? "Nao foi possivel iniciar a atualizacao desta empresa.",
+  };
+}
+
+export function hydrateRefreshState(
+  initialStatus: RefreshStatusItem | null | undefined,
+  nowMs = Date.now(),
+): RefreshMachineState {
+  if (isActiveRefreshStatus(initialStatus?.last_status) && initialStatus) {
+    return buildActiveState(
+      normalizeStatus(initialStatus.last_status) as "queued" | "running",
+      initialStatus,
+      nowMs,
+    );
+  }
+
+  return createIdleRefreshState();
+}
+
+export function isAutoPollingPhase(phase: RefreshPhase): boolean {
+  return (
+    phase === "queued" || phase === "running" || phase === "reconnecting"
+  );
+}
+
+export function hasRefreshTimedOut(
+  state: RefreshMachineState,
+  nowMs: number,
+  timeoutMs = POLL_TIMEOUT_MS,
+): boolean {
+  return (
+    isAutoPollingPhase(state.phase) &&
+    state.startedAt !== undefined &&
+    nowMs - state.startedAt >= timeoutMs
+  );
+}
+
+export function createDelayedRefreshState(
+  state: RefreshMachineState,
+): RefreshMachineState {
+  return {
+    ...state,
+    phase: "delayed",
+    currentItem: state.currentItem ?? state.lastKnownActiveItem,
+    failureCount: 0,
+    canRequestAgain: false,
+    notice: null,
+  };
+}
+
+export function getReconnectDelayMs(failureCount: number): number {
+  if (failureCount <= 1) {
+    return RECONNECT_DELAY_SEQUENCE_MS[0];
+  }
+
+  if (failureCount === 2) {
+    return RECONNECT_DELAY_SEQUENCE_MS[1];
+  }
+
+  if (failureCount === 3) {
+    return RECONNECT_DELAY_SEQUENCE_MS[2];
+  }
+
+  return RECONNECT_DELAY_SEQUENCE_MS[3];
+}
+
+export function getNextPollingDelayMs(
+  state: RefreshMachineState,
+): number {
+  if (state.phase === "reconnecting") {
+    return getReconnectDelayMs(state.failureCount);
+  }
+
+  return POLL_INTERVAL_MS;
+}
+
+export function applyRefreshPollFailure(
+  state: RefreshMachineState,
+): RefreshMachineState {
+  if (!isAutoPollingPhase(state.phase)) {
+    return state;
+  }
+
+  return {
+    ...state,
+    phase: "reconnecting",
+    currentItem: state.currentItem ?? state.lastKnownActiveItem,
+    failureCount: state.failureCount + 1,
+    canRequestAgain: false,
+    notice: "Conexao instavel. Tentando reconectar...",
+  };
+}
+
+export function applyManualStatusFailure(
+  state: RefreshMachineState,
+): RefreshMachineState {
+  if (state.phase !== "delayed") {
+    return state;
+  }
+
+  return {
+    ...state,
+    notice: "Nao foi possivel atualizar o status agora. Tente novamente.",
+  };
+}
+
+export function applyRefreshStatusResult(
+  state: RefreshMachineState,
+  item: RefreshStatusItem | null,
+  nowMs: number,
+  options: { source?: "auto" | "manual" } = {},
+): RefreshMachineState {
+  const source = options.source ?? "auto";
+
+  if (source === "auto" && !isAutoPollingPhase(state.phase)) {
+    return state;
+  }
+
+  if (source === "manual" && state.phase !== "delayed") {
+    return state;
+  }
+
+  const status = normalizeStatus(item?.last_status);
+
+  if (!item) {
+    if (source === "manual") {
+      return {
+        ...createDelayedRefreshState(state),
+        canRequestAgain: true,
+        notice: "Nenhum refresh ativo foi encontrado agora.",
+      };
+    }
+
+    if (state.lastKnownActiveItem) {
+      return applyRefreshPollFailure(state);
+    }
+
+    return {
+      ...state,
+      phase: "queued",
+      startedAt: state.startedAt ?? nowMs,
+      currentItem: null,
+      failureCount: 0,
+      canRequestAgain: false,
+      notice: null,
+      terminalMessage: null,
+    };
+  }
+
+  if (status === "success") {
+    return {
+      ...state,
+      phase: "success",
+      currentItem: item,
+      failureCount: 0,
+      canRequestAgain: false,
+      notice: null,
+      terminalMessage: null,
+    };
+  }
+
+  if (TERMINAL_REFRESH_STATUSES.has(status)) {
+    return {
+      ...state,
+      phase: "terminal_error",
+      currentItem: item,
+      failureCount: 0,
+      canRequestAgain: false,
+      notice: null,
+      terminalMessage:
+        item.last_error ??
+        "Nao foi possivel concluir a atualizacao desta empresa.",
+    };
+  }
+
+  if (status === "queued" || status === "running") {
+    return buildActiveState(status, item, nowMs, state);
+  }
+
+  if (source === "manual") {
+    return {
+      ...createDelayedRefreshState(state),
+      canRequestAgain: true,
+      notice: "Nenhum refresh ativo foi encontrado agora.",
+    };
+  }
+
+  return applyRefreshPollFailure(state);
+}
+
+export function getRefreshViewModel(
+  state: RefreshMachineState,
+): RefreshViewModel {
+  const estimate = buildRefreshEstimate(state);
+
+  switch (state.phase) {
+    case "submitting":
+      return {
+        showCard: true,
+        title: "Atualizacao em andamento",
+        message: "Enviando solicitacao...",
+        detail: "Preparando o disparo on-demand desta companhia.",
+        stepLabel: "Na fila",
+        stepClassName: getBadgeClassName(state.phase),
+        isDestructive: false,
+        estimate,
+        requestButtonLabel: "Enviando...",
+        requestButtonDisabled: true,
+        showManualStatusButton: false,
+        showRequestAgainButton: false,
+      };
+    case "queued": {
+      const copy = getQueuedMessage();
+      return {
+        showCard: true,
+        title: "Atualizacao em andamento",
+        message: copy.message,
+        detail: copy.detail,
+        stepLabel: "Na fila",
+        stepClassName: getBadgeClassName(state.phase),
+        isDestructive: false,
+        estimate,
+        requestButtonLabel: "Acompanhando atualizacao",
+        requestButtonDisabled: true,
+        showManualStatusButton: false,
+        showRequestAgainButton: false,
+      };
+    }
+    case "running": {
+      const copy = getRunningMessage();
+      return {
+        showCard: true,
+        title: "Atualizacao em andamento",
+        message: copy.message,
+        detail: copy.detail,
+        stepLabel: "Processando",
+        stepClassName: getBadgeClassName(state.phase),
+        isDestructive: false,
+        estimate,
+        requestButtonLabel: "Acompanhando atualizacao",
+        requestButtonDisabled: true,
+        showManualStatusButton: false,
+        showRequestAgainButton: false,
+      };
+    }
+    case "reconnecting":
+      return {
+        showCard: true,
+        title: "Atualizacao em andamento",
+        message: "Conexao instavel. Tentando reconectar...",
+        detail:
+          "Mantendo a ultima leitura conhecida enquanto retomamos o acompanhamento.",
+        stepLabel: "Reconectando",
+        stepClassName: getBadgeClassName(state.phase),
+        isDestructive: false,
+        estimate,
+        requestButtonLabel: "Reconectando...",
+        requestButtonDisabled: true,
+        showManualStatusButton: false,
+        showRequestAgainButton: false,
+      };
+    case "delayed":
+      return {
+        showCard: true,
+        title: "Atualizacao em andamento",
+        message: "Esta atualizacao esta demorando mais que o normal.",
+        detail: state.notice
+          ? `${state.notice} ${
+              state.canRequestAgain
+                ? "Se os dados ainda nao apareceram, voce pode solicitar novamente."
+                : ""
+            }`.trim()
+          : "O acompanhamento automatico foi pausado para evitar consultas repetidas. Atualize o status manualmente.",
+        stepLabel: "Demorado",
+        stepClassName: getBadgeClassName(state.phase),
+        isDestructive: false,
+        estimate,
+        requestButtonLabel: "Atualizacao demorada",
+        requestButtonDisabled: true,
+        showManualStatusButton: true,
+        showRequestAgainButton: state.canRequestAgain,
+      };
+    case "terminal_error":
+      return {
+        showCard: true,
+        title: "Refresh indisponivel",
+        message:
+          state.terminalMessage ??
+          "Nao foi possivel concluir a atualizacao desta empresa.",
+        detail: "Voce pode solicitar novamente em instantes.",
+        stepLabel: "Falha",
+        stepClassName: getBadgeClassName(state.phase),
+        isDestructive: true,
+        estimate,
+        requestButtonLabel: "Solicitar novamente",
+        requestButtonDisabled: false,
+        showManualStatusButton: false,
+        showRequestAgainButton: false,
+      };
+    case "success":
+      return {
+        showCard: true,
+        title: "Atualizacao concluida",
+        message: "Dados disponiveis! Recarregando...",
+        detail: "A leitura detalhada desta empresa sera atualizada agora.",
+        stepLabel: "Concluido",
+        stepClassName: getBadgeClassName(state.phase),
+        isDestructive: false,
+        estimate,
+        requestButtonLabel: "Recarregando...",
+        requestButtonDisabled: true,
+        showManualStatusButton: false,
+        showRequestAgainButton: false,
+      };
+    default:
+      return {
+        showCard: false,
+        title: "",
+        message: "",
+        detail: undefined,
+        stepLabel: "Na fila",
+        stepClassName: getBadgeClassName("queued"),
+        isDestructive: false,
+        estimate,
+        requestButtonLabel: "Solicitar dados financeiros",
+        requestButtonDisabled: false,
+        showManualStatusButton: false,
+        showRequestAgainButton: false,
+      };
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "eslint",
     "typecheck": "tsc --noEmit",
-    "test:unit": "node --experimental-strip-types --experimental-specifier-resolution=node --test tests/api-client.test.ts tests/companies-page-data.test.ts tests/company-period-range.test.ts tests/compare-utils.test.ts tests/compare-page-data.test.ts tests/sectors-page-data.test.ts",
+    "test:unit": "node --experimental-strip-types --experimental-specifier-resolution=node --test tests/api-client.test.ts tests/companies-page-data.test.ts tests/company-period-range.test.ts tests/company-refresh-state.test.ts tests/compare-utils.test.ts tests/compare-page-data.test.ts tests/sectors-page-data.test.ts",
     "test:e2e": "playwright test"
   },
   "dependencies": {

--- a/apps/web/tests/company-refresh-state.test.ts
+++ b/apps/web/tests/company-refresh-state.test.ts
@@ -1,0 +1,232 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { RefreshStatusItem } from "../lib/api.ts";
+import {
+  applyRefreshPollFailure,
+  applyRefreshStatusResult,
+  createDelayedRefreshState,
+  createDispatchedRefreshState,
+  getNextPollingDelayMs,
+  getReconnectDelayMs,
+  getRefreshViewModel,
+  hasRefreshTimedOut,
+  hydrateRefreshState,
+  POLL_INTERVAL_MS,
+  POLL_TIMEOUT_MS,
+} from "../lib/company-refresh-state.ts";
+
+function buildRefreshStatusItem(
+  overrides: Partial<RefreshStatusItem> = {},
+): RefreshStatusItem {
+  return {
+    cd_cvm: 4170,
+    company_name: "VALE",
+    source_scope: "on_demand",
+    last_attempt_at: "2026-04-21T12:00:00+00:00",
+    last_success_at: null,
+    last_status: "queued",
+    last_error: null,
+    last_start_year: 2010,
+    last_end_year: 2024,
+    last_rows_inserted: null,
+    updated_at: "2026-04-21T12:00:00+00:00",
+    estimated_progress_pct: null,
+    estimated_eta_seconds: null,
+    estimated_total_seconds: null,
+    elapsed_seconds: null,
+    estimated_completion_at: null,
+    estimate_confidence: null,
+    ...overrides,
+  };
+}
+
+test("hydrateRefreshState starts in idle without an active refresh", () => {
+  const state = hydrateRefreshState(null, Date.now());
+
+  assert.equal(state.phase, "idle");
+
+  const view = getRefreshViewModel(state);
+  assert.equal(view.showCard, false);
+  assert.equal(view.requestButtonDisabled, false);
+});
+
+test("hydrateRefreshState restores a queued refresh from server data", () => {
+  const state = hydrateRefreshState(
+    buildRefreshStatusItem({ last_status: "queued" }),
+    Date.now(),
+  );
+
+  assert.equal(state.phase, "queued");
+  assert.equal(state.lastKnownActiveItem?.last_status, "queued");
+});
+
+test("hydrateRefreshState restores a running refresh from server data", () => {
+  const state = hydrateRefreshState(
+    buildRefreshStatusItem({
+      last_status: "running",
+      estimated_progress_pct: 48.5,
+    }),
+    Date.now(),
+  );
+
+  assert.equal(state.phase, "running");
+  assert.equal(state.lastKnownActiveItem?.estimated_progress_pct, 48.5);
+});
+
+test("terminal backend statuses map to the destructive terminal error state", () => {
+  const state = applyRefreshStatusResult(
+    createDispatchedRefreshState(Date.now()),
+    buildRefreshStatusItem({
+      last_status: "error",
+      last_error: "Falha operacional ao atualizar a companhia.",
+    }),
+    Date.now(),
+  );
+
+  assert.equal(state.phase, "terminal_error");
+
+  const view = getRefreshViewModel(state);
+  assert.equal(view.isDestructive, true);
+  assert.equal(
+    view.message,
+    "Falha operacional ao atualizar a companhia.",
+  );
+});
+
+test("low-confidence estimates hide the exact completion clock", () => {
+  const state = hydrateRefreshState(
+    buildRefreshStatusItem({
+      last_status: "running",
+      estimated_progress_pct: 41.2,
+      estimated_eta_seconds: 840,
+      estimated_total_seconds: 1260,
+      elapsed_seconds: 420,
+      estimated_completion_at: "2026-04-21T12:21:00+00:00",
+      estimate_confidence: "low",
+    }),
+    Date.now(),
+  );
+
+  const view = getRefreshViewModel(state);
+
+  assert.equal(view.estimate?.confidenceLabel, "Estimativa inicial.");
+  assert.equal(view.estimate?.completionLabel, undefined);
+  assert.equal(view.estimate?.etaLabel, "~14 min restantes");
+});
+
+test("missing estimate fields fall back without breaking the progress UI", () => {
+  const state = hydrateRefreshState(
+    buildRefreshStatusItem({
+      last_status: "running",
+      estimated_progress_pct: null,
+      estimated_eta_seconds: null,
+      estimated_total_seconds: null,
+      elapsed_seconds: null,
+      estimated_completion_at: null,
+      estimate_confidence: null,
+    }),
+    Date.now(),
+  );
+
+  const view = getRefreshViewModel(state);
+
+  assert.equal(view.estimate?.etaLabel, "Estimativa ainda indisponivel");
+  assert.equal(view.estimate?.progress, 42);
+});
+
+test("transient poll failures preserve the last known progress and enter reconnecting", () => {
+  const activeState = hydrateRefreshState(
+    buildRefreshStatusItem({
+      last_status: "running",
+      estimated_progress_pct: 67,
+    }),
+    Date.now(),
+  );
+  const nextState = applyRefreshPollFailure(activeState);
+
+  assert.equal(nextState.phase, "reconnecting");
+  assert.equal(nextState.failureCount, 1);
+
+  const view = getRefreshViewModel(nextState);
+  assert.equal(view.message, "Conexao instavel. Tentando reconectar...");
+  assert.equal(view.estimate?.progress, 67);
+});
+
+test("reconnect delays back off and cap at sixty seconds", () => {
+  assert.equal(getReconnectDelayMs(1), 10_000);
+  assert.equal(getReconnectDelayMs(2), 20_000);
+  assert.equal(getReconnectDelayMs(3), 30_000);
+  assert.equal(getReconnectDelayMs(4), 60_000);
+  assert.equal(getReconnectDelayMs(7), 60_000);
+});
+
+test("successful recovery from reconnecting restores the active phase and normal cadence", () => {
+  const reconnectingState = applyRefreshPollFailure(
+    hydrateRefreshState(
+      buildRefreshStatusItem({
+        last_status: "running",
+        estimated_progress_pct: 58,
+      }),
+      Date.now(),
+    ),
+  );
+  const recoveredState = applyRefreshStatusResult(
+    reconnectingState,
+    buildRefreshStatusItem({
+      last_status: "running",
+      estimated_progress_pct: 63,
+    }),
+    Date.now(),
+  );
+
+  assert.equal(recoveredState.phase, "running");
+  assert.equal(recoveredState.failureCount, 0);
+  assert.equal(getNextPollingDelayMs(recoveredState), POLL_INTERVAL_MS);
+});
+
+test("delayed state appears after the timeout threshold without turning destructive", () => {
+  const nowMs = Date.now();
+  const timedOutState = hydrateRefreshState(
+    buildRefreshStatusItem({
+      last_status: "queued",
+      last_attempt_at: new Date(nowMs - POLL_TIMEOUT_MS - 1_000).toISOString(),
+      estimated_progress_pct: 22,
+    }),
+    nowMs,
+  );
+
+  assert.equal(hasRefreshTimedOut(timedOutState, nowMs), true);
+
+  const delayedState = createDelayedRefreshState(timedOutState);
+  const view = getRefreshViewModel(delayedState);
+
+  assert.equal(delayedState.phase, "delayed");
+  assert.equal(view.isDestructive, false);
+  assert.equal(view.showManualStatusButton, true);
+  assert.equal(view.message, "Esta atualizacao esta demorando mais que o normal.");
+});
+
+test("manual refresh from delayed enables request again when no active status is found", () => {
+  const delayedState = createDelayedRefreshState(
+    hydrateRefreshState(
+      buildRefreshStatusItem({
+        last_status: "running",
+        estimated_progress_pct: 54,
+      }),
+      Date.now(),
+    ),
+  );
+  const checkedState = applyRefreshStatusResult(
+    delayedState,
+    null,
+    Date.now(),
+    { source: "manual" },
+  );
+
+  assert.equal(checkedState.phase, "delayed");
+  assert.equal(checkedState.canRequestAgain, true);
+
+  const view = getRefreshViewModel(checkedState);
+  assert.equal(view.showRequestAgainButton, true);
+});


### PR DESCRIPTION
## Summary
- move the on-demand refresh state machine into a pure helper with explicit queued, running, reconnecting, delayed, terminal_error, and success states
- keep the last known active snapshot during transient polling failures and retry automatically with backoff instead of showing a destructive alert
- add delayed-state manual actions, clearer step badges, and safer progress/ETA copy that degrades cleanly when estimates are weak or absent

## Testing
- npm run test:unit
- npm run typecheck
- npm run lint
- npm run build

Closes #162
