### PR TITLE
[Task #170] Show fresh company data immediately after on-demand refresh

### DIFF
--- a/apps/web/app/empresas/[cd_cvm]/page.tsx
+++ b/apps/web/app/empresas/[cd_cvm]/page.tsx
@@ -42,6 +42,10 @@ type EmpresaDetailPageProps = {
 
 export const dynamic = "force-dynamic";
 
+const DETAIL_PAGE_MUTABLE_API_READ = {
+  cache: "no-store",
+} as const;
+
 function DetailPageError({
   message,
 }: {
@@ -116,8 +120,8 @@ export default async function EmpresaDetailPage({
 
   try {
     [company, availableYears] = await Promise.all([
-      fetchCompanyInfo(cdCvm),
-      fetchCompanyYears(cdCvm),
+      fetchCompanyInfo(cdCvm, { request: DETAIL_PAGE_MUTABLE_API_READ }),
+      fetchCompanyYears(cdCvm, { request: DETAIL_PAGE_MUTABLE_API_READ }),
     ]);
   } catch (error) {
     if (isApiClientError(error) && error.code === "not_found") {
@@ -147,13 +151,22 @@ export default async function EmpresaDetailPage({
 
   if (currentTab === "visao-geral") {
     try {
-      bundle = await fetchCompanyKpis(cdCvm, selectedYears);
+      bundle = await fetchCompanyKpis(cdCvm, selectedYears, {
+        request: DETAIL_PAGE_MUTABLE_API_READ,
+      });
     } catch (error) {
       contentError = getUserFacingErrorMessage(error);
     }
   } else {
     try {
-      statement = await fetchCompanyStatement(cdCvm, selectedYears, currentStatement);
+      statement = await fetchCompanyStatement(
+        cdCvm,
+        selectedYears,
+        currentStatement,
+        {
+          request: DETAIL_PAGE_MUTABLE_API_READ,
+        },
+      );
     } catch (error) {
       contentError = getUserFacingErrorMessage(error);
     }

--- a/apps/web/components/company/company-request-refresh.tsx
+++ b/apps/web/components/company/company-request-refresh.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { LoaderCircleIcon, RotateCcwIcon } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -43,6 +44,7 @@ export function CompanyRequestRefresh({
   cdCvm,
   initialStatus = null,
 }: CompanyRequestRefreshProps) {
+  const router = useRouter();
   const [state, setState] = useState<RefreshMachineState>(() =>
     createIdleRefreshState(),
   );
@@ -114,7 +116,7 @@ export function CompanyRequestRefresh({
     }
 
     reloadTimerRef.current = window.setTimeout(() => {
-      window.location.reload();
+      router.refresh();
     }, RELOAD_DELAY_MS);
 
     return () => {
@@ -123,7 +125,7 @@ export function CompanyRequestRefresh({
         reloadTimerRef.current = null;
       }
     };
-  }, [state.phase]);
+  }, [router, state.phase]);
 
   useEffect(() => {
     if (!isAutoPollingPhase(state.phase)) {

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -901,18 +901,22 @@ export async function fetchSectorDetail(
 
 export async function fetchCompanyInfo(
   cdCvm: number,
+  options?: { request?: ApiReadRequestInit },
 ): Promise<CompanyInfo | null> {
   return apiFetch<CompanyInfo>(`/companies/${cdCvm}`, {
     allowNotFound: true,
-    request: COMPANY_INFO_API_READ,
+    request: options?.request ?? COMPANY_INFO_API_READ,
     validate: isCompanyInfo,
     invalidResponseMessage: "A API retornou um detalhe de empresa invalido.",
   });
 }
 
-export async function fetchCompanyYears(cdCvm: number): Promise<number[]> {
+export async function fetchCompanyYears(
+  cdCvm: number,
+  options?: { request?: ApiReadRequestInit },
+): Promise<number[]> {
   return (await apiFetch<number[]>(`/companies/${cdCvm}/years`, {
-    request: COMPANY_YEARS_API_READ,
+    request: options?.request ?? COMPANY_YEARS_API_READ,
     validate: isNumberArray,
     invalidResponseMessage: "A API retornou anos invalidos para a empresa.",
   })) as number[];
@@ -921,13 +925,14 @@ export async function fetchCompanyYears(cdCvm: number): Promise<number[]> {
 export async function fetchCompanyKpis(
   cdCvm: number,
   years: number[],
+  options?: { request?: ApiReadRequestInit },
 ): Promise<KPIBundle> {
   return (await apiFetch<KPIBundle>(
     `/companies/${cdCvm}/kpis${buildQuery({
       years: years.join(","),
     })}`,
     {
-      request: COMPANY_DATA_API_READ,
+      request: options?.request ?? COMPANY_DATA_API_READ,
       validate: isKPIBundle,
       invalidResponseMessage: "A API retornou KPIs invalidos para a empresa.",
     },
@@ -938,6 +943,7 @@ export async function fetchCompanyStatement(
   cdCvm: number,
   years: number[],
   statementType: string,
+  options?: { request?: ApiReadRequestInit },
 ): Promise<StatementMatrix> {
   return (await apiFetch<StatementMatrix>(
     `/companies/${cdCvm}/statements${buildQuery({
@@ -945,7 +951,7 @@ export async function fetchCompanyStatement(
       years: years.join(","),
     })}`,
     {
-      request: COMPANY_DATA_API_READ,
+      request: options?.request ?? COMPANY_DATA_API_READ,
       validate: isStatementMatrix,
       invalidResponseMessage: "A API retornou uma demonstracao invalida para a empresa.",
     },

--- a/apps/web/tests/api-client.test.ts
+++ b/apps/web/tests/api-client.test.ts
@@ -6,7 +6,10 @@ import {
   fetchCompanies,
   fetchCompanyFilters,
   fetchCompanyFreshness,
+  fetchCompanyKpis,
+  fetchCompanyStatement,
   fetchCompanySuggestions,
+  fetchCompanyYears,
   fetchRequestRefresh,
   fetchSectorDetail,
   fetchRefreshStatus,
@@ -271,6 +274,110 @@ test("fetchRefreshStatus keeps explicit no-store semantics for polling flows", a
     await fetchRefreshStatus(1234);
 
     assert.equal(capturedInit?.cache, "no-store");
+  } finally {
+    restore();
+  }
+});
+
+test("fetchCompanyYears allows an explicit no-store override for company detail refreshes", async () => {
+  let capturedInit: RequestInit | undefined;
+  const restore = withFetchMock((async (_input, init) => {
+    capturedInit = init;
+
+    return new Response(JSON.stringify([2024]), {
+      status: 200,
+      headers: {
+        "content-type": "application/json",
+      },
+    });
+  }) as FetchMock);
+
+  try {
+    const payload = await fetchCompanyYears(4170, {
+      request: { cache: "no-store" },
+    });
+
+    assert.deepEqual(payload, [2024]);
+    assert.equal(capturedInit?.cache, "no-store");
+    assert.equal(capturedInit?.next, undefined);
+  } finally {
+    restore();
+  }
+});
+
+test("fetchCompanyKpis allows an explicit no-store override for company detail refreshes", async () => {
+  let capturedInit: RequestInit | undefined;
+  const restore = withFetchMock((async (_input, init) => {
+    capturedInit = init;
+
+    return new Response(
+      JSON.stringify({
+        cd_cvm: 4170,
+        years: [2024],
+        annual: {
+          columns: [],
+          rows: [],
+        },
+        quarterly: {
+          columns: [],
+          rows: [],
+        },
+      }),
+      {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+        },
+      },
+    );
+  }) as FetchMock);
+
+  try {
+    const payload = await fetchCompanyKpis(4170, [2024], {
+      request: { cache: "no-store" },
+    });
+
+    assert.equal(payload.cd_cvm, 4170);
+    assert.equal(capturedInit?.cache, "no-store");
+    assert.equal(capturedInit?.next, undefined);
+  } finally {
+    restore();
+  }
+});
+
+test("fetchCompanyStatement allows an explicit no-store override for company detail refreshes", async () => {
+  let capturedInit: RequestInit | undefined;
+  const restore = withFetchMock((async (_input, init) => {
+    capturedInit = init;
+
+    return new Response(
+      JSON.stringify({
+        cd_cvm: 4170,
+        statement_type: "DRE",
+        years: [2024],
+        table: {
+          columns: [],
+          rows: [],
+        },
+        exclude_conflicts: false,
+      }),
+      {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+        },
+      },
+    );
+  }) as FetchMock);
+
+  try {
+    const payload = await fetchCompanyStatement(4170, [2024], "DRE", {
+      request: { cache: "no-store" },
+    });
+
+    assert.equal(payload.statement_type, "DRE");
+    assert.equal(capturedInit?.cache, "no-store");
+    assert.equal(capturedInit?.next, undefined);
   } finally {
     restore();
   }


### PR DESCRIPTION
## Resumo
- força leituras `no-store` apenas na página de detalhe da empresa para evitar cache stale após refresh on-demand concluído
- troca o reload bruto por `router.refresh()` quando o polling detecta sucesso
- adiciona cobertura unitária para os overrides de cache nas leituras mutáveis da companhia

## Causa raiz
A tela de `/empresas/[cd_cvm]` recarregava após o job terminar, mas os fetches de `years` e dos blocos de dados ainda usavam janelas de `revalidate` longas no cache do Next. Isso mantinha a aba da companhia presa ao snapshot anterior mesmo depois do worker concluir a persistência.

## Validacao
- `npm run test:unit`
- `npm run typecheck`
- `npm run lint`

Closes #170