### PR TITLE
[Task] MASTER: harden on-demand search and refresh UX

### DIFF
--- a/apps/api/app/presenters.py
+++ b/apps/api/app/presenters.py
@@ -199,6 +199,9 @@ class RefreshDispatchPayload(BaseModel):
     job_id: str | None = None
     accepted_at: str
     message: str
+    status_reason_code: str | None = None
+    status_reason_message: str | None = None
+    is_retry_allowed: bool = False
 
 
 class RankedRefreshQueueItemPayload(BaseModel):
@@ -252,6 +255,15 @@ class RefreshStatusPayload(BaseModel):
     elapsed_seconds: int | None = None
     estimated_completion_at: str | None = None
     estimate_confidence: str | None = None
+    tracking_state: str | None = None
+    progress_mode: str | None = None
+    is_retry_allowed: bool = False
+    status_reason_code: str | None = None
+    status_reason_message: str | None = None
+    has_readable_current_data: bool = False
+    readable_years_count: int = 0
+    latest_attempt_outcome: str | None = None
+    source_label: str | None = None
 
 
 class HealthYearCoveragePayload(BaseModel):

--- a/apps/api/app/routes/companies.py
+++ b/apps/api/app/routes/companies.py
@@ -105,11 +105,15 @@ def get_company_suggestions(
     response: Response,
     q: str = Query(default="", description="Texto de busca livre (nome, ticker ou codigo CVM)."),
     limit: int = Query(default=6, ge=1, le=20, description="Numero maximo de sugestoes retornadas."),
+    ready_only: bool = Query(
+        default=False,
+        description="Quando true, retorna apenas companhias com historico anual local pronto.",
+    ),
     service: CVMReadService = Depends(get_read_service),
 ) -> CompanySuggestionsPayload:
     ensure_api_ready(get_settings(request))
     _apply_cache_headers(response, COMPANY_SUGGESTIONS_CACHE_CONTROL)
-    items = service.suggest_companies(q=q, limit=limit)
+    items = service.suggest_companies(q=q, limit=limit, ready_only=ready_only)
     return present_company_suggestions(items)
 
 

--- a/apps/api/tests/test_api_contract.py
+++ b/apps/api/tests/test_api_contract.py
@@ -209,7 +209,7 @@ def test_companies_pagination_respects_page_and_page_size(client: TestClient):
         "has_previous": True,
     }
     assert len(payload["items"]) == 1
-    assert payload["items"][0]["company_name"] == "SABESP"
+    assert payload["items"][0]["company_name"] == "VALE"
 
 
 def test_companies_sector_filter_uses_canonical_slug(client: TestClient):
@@ -300,6 +300,33 @@ def test_company_suggestions_respects_limit(client: TestClient):
 
     assert response.status_code == 200
     assert len(response.json()["items"]) <= 2
+
+
+def test_company_suggestions_can_limit_to_ready_companies(client: TestClient):
+    response = client.get("/companies/suggestions", params={"ready_only": "true"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["items"] == [
+        {
+            "cd_cvm": 9512,
+            "company_name": "PETROBRAS",
+            "ticker_b3": "PETR4",
+            "sector_slug": "energia",
+        },
+        {
+            "cd_cvm": 11223,
+            "company_name": "SABESP",
+            "ticker_b3": "SBSP3",
+            "sector_slug": "saneamento",
+        },
+        {
+            "cd_cvm": 4170,
+            "company_name": "VALE",
+            "ticker_b3": "VALE3",
+            "sector_slug": "materiais-basicos",
+        },
+    ]
 
 
 def test_company_suggestions_returns_empty_for_no_match(client: TestClient):
@@ -453,6 +480,9 @@ def test_request_refresh_returns_202_and_enqueues_internal_job(client: TestClien
     assert isinstance(payload["job_id"], str) and payload["job_id"]
     assert isinstance(payload["accepted_at"], str)
     assert "enfileirada" in payload["message"].lower()
+    assert payload["status_reason_code"] == "refresh_queued"
+    assert "aguardando processamento interno" in payload["status_reason_message"].lower()
+    assert payload["is_retry_allowed"] is False
 
     engine = client.app.state.read_service.engine
     with engine.connect() as conn:
@@ -594,6 +624,9 @@ def test_request_refresh_returns_already_current_without_creating_job(
     assert payload["status"] == "already_current"
     assert payload["job_id"] is None
     assert "ja atualizada" in payload["message"].lower()
+    assert payload["status_reason_code"] == "already_current"
+    assert "ja estava atualizada" in payload["status_reason_message"].lower()
+    assert payload["is_retry_allowed"] is False
 
     with engine.connect() as conn:
         queued_jobs = conn.execute(
@@ -1023,6 +1056,15 @@ def test_refresh_status_returns_operational_rows(client: TestClient):
     assert payload[0]["queue_position"] is None
     assert payload[0]["estimated_progress_pct"] is None
     assert payload[0]["estimated_eta_seconds"] is None
+    assert payload[0]["tracking_state"] == "success"
+    assert payload[0]["progress_mode"] == "none"
+    assert payload[0]["is_retry_allowed"] is False
+    assert payload[0]["status_reason_code"] == "refresh_completed"
+    assert payload[0]["status_reason_message"] == "Dados prontos para leitura nesta pagina."
+    assert payload[0]["has_readable_current_data"] is True
+    assert payload[0]["readable_years_count"] == 2
+    assert payload[0]["latest_attempt_outcome"] == "success"
+    assert payload[0]["source_label"] == "Base local materializada"
 
 
 def test_refresh_status_exposes_terminal_no_data_state(client: TestClient):
@@ -1060,6 +1102,18 @@ def test_refresh_status_exposes_terminal_no_data_state(client: TestClient):
     assert payload[0]["progress_message"] == "Nenhuma demonstracao encontrada para 2010-2025."
     assert payload[0]["finished_at"] == "2026-04-21T12:01:00+00:00"
     assert payload[0]["estimated_progress_pct"] is None
+    assert payload[0]["tracking_state"] == "no_data"
+    assert payload[0]["progress_mode"] == "none"
+    assert payload[0]["is_retry_allowed"] is True
+    assert payload[0]["status_reason_code"] == "no_new_financial_history"
+    assert (
+        payload[0]["status_reason_message"]
+        == "A ultima tentativa nao encontrou novos demonstrativos, mas a leitura atual continua disponivel."
+    )
+    assert payload[0]["has_readable_current_data"] is True
+    assert payload[0]["readable_years_count"] == 1
+    assert payload[0]["latest_attempt_outcome"] == "no_data"
+    assert payload[0]["source_label"] == "Solicitacao on-demand"
 
 
 def test_refresh_status_returns_real_progress_fields_for_active_refresh(client: TestClient):
@@ -1199,6 +1253,59 @@ def test_refresh_status_returns_real_progress_fields_for_active_refresh(client: 
                 },
             ],
         )
+        conn.execute(
+            sa_text(
+                """
+                INSERT INTO refresh_jobs (
+                    id,
+                    cd_cvm,
+                    company_name,
+                    source_scope,
+                    start_year,
+                    end_year,
+                    state,
+                    stage,
+                    requested_at,
+                    started_at,
+                    heartbeat_at,
+                    progress_current,
+                    progress_total,
+                    progress_message
+                ) VALUES (
+                    :id,
+                    :cd_cvm,
+                    :company_name,
+                    :source_scope,
+                    :start_year,
+                    :end_year,
+                    :state,
+                    :stage,
+                    :requested_at,
+                    :started_at,
+                    :heartbeat_at,
+                    :progress_current,
+                    :progress_total,
+                    :progress_message
+                )
+                """
+            ),
+            {
+                "id": "job-active-vale",
+                "cd_cvm": 4170,
+                "company_name": "VALE",
+                "source_scope": "on_demand",
+                "start_year": 2010,
+                "end_year": 2024,
+                "state": "running",
+                "stage": "download_extract",
+                "requested_at": started_at,
+                "started_at": started_at,
+                "heartbeat_at": now_iso,
+                "progress_current": 9,
+                "progress_total": 20,
+                "progress_message": "Download concluido para DFP/2018.",
+            },
+        )
 
     response = client.get("/refresh-status", params={"cd_cvm": 4170})
 
@@ -1218,6 +1325,18 @@ def test_refresh_status_returns_real_progress_fields_for_active_refresh(client: 
     assert payload[0]["elapsed_seconds"] >= 240
     assert payload[0]["estimated_completion_at"] is not None
     assert payload[0]["estimate_confidence"] == "high"
+    assert payload[0]["tracking_state"] == "running"
+    assert payload[0]["progress_mode"] == "real_progress"
+    assert payload[0]["is_retry_allowed"] is False
+    assert payload[0]["status_reason_code"] == "refresh_running"
+    assert (
+        payload[0]["status_reason_message"]
+        == "Os demonstrativos desta companhia estao sendo atualizados agora."
+    )
+    assert payload[0]["has_readable_current_data"] is True
+    assert payload[0]["readable_years_count"] == 1
+    assert payload[0]["latest_attempt_outcome"] == "queued"
+    assert payload[0]["source_label"] == "Solicitacao on-demand"
 
 
 def test_base_health_returns_snapshot(client: TestClient):

--- a/apps/web/app/api/company-search/route.ts
+++ b/apps/web/app/api/company-search/route.ts
@@ -1,0 +1,148 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { buildApiUrl } from "@/lib/api";
+
+type ProxyErrorPayload = {
+  error?: {
+    code?: string;
+    message?: string;
+  };
+  detail?:
+    | {
+        code?: string;
+        message?: string;
+      }
+    | string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function buildProxyErrorResponse(
+  status: number,
+  payload: ProxyErrorPayload | null,
+  fallbackMessage: string,
+) {
+  const detailCode =
+    isRecord(payload?.detail) && typeof payload.detail.code === "string"
+      ? payload.detail.code
+      : undefined;
+  const detailMessage =
+    isRecord(payload?.detail) && typeof payload.detail.message === "string"
+      ? payload.detail.message
+      : typeof payload?.detail === "string"
+        ? payload.detail
+        : undefined;
+  const code = payload?.error?.code ?? detailCode ?? "unknown_error";
+  const message = payload?.error?.message ?? detailMessage ?? fallbackMessage;
+
+  return NextResponse.json(
+    {
+      error: {
+        code,
+        message,
+      },
+    },
+    {
+      status,
+      headers: {
+        "cache-control": "no-store",
+      },
+    },
+  );
+}
+
+export async function GET(request: NextRequest) {
+  const query = new URLSearchParams();
+  const rawQ = request.nextUrl.searchParams.get("q");
+  const rawLimit = request.nextUrl.searchParams.get("limit");
+  const rawReadyOnly = request.nextUrl.searchParams.get("ready_only");
+
+  if (rawQ) {
+    query.set("q", rawQ);
+  }
+
+  if (rawLimit) {
+    query.set("limit", rawLimit);
+  }
+
+  if (rawReadyOnly === "1" || rawReadyOnly?.toLowerCase() === "true") {
+    query.set("ready_only", "true");
+  }
+
+  const upstreamUrl = buildApiUrl(
+    `/companies/suggestions${query.toString() ? `?${query.toString()}` : ""}`,
+  );
+
+  let upstream: Response;
+
+  try {
+    upstream = await fetch(upstreamUrl, {
+      cache: "no-store",
+      headers: {
+        Accept: "application/json",
+      },
+    });
+  } catch {
+    return NextResponse.json(
+      {
+        error: {
+          code: "network_error",
+          message: "Nao foi possivel conectar a API da V2.",
+        },
+      },
+      {
+        status: 503,
+        headers: {
+          "cache-control": "no-store",
+        },
+      },
+    );
+  }
+
+  if (!upstream.ok) {
+    let payload: ProxyErrorPayload | null = null;
+
+    try {
+      payload = (await upstream.json()) as ProxyErrorPayload;
+    } catch {
+      payload = null;
+    }
+
+    const fallbackMessage =
+      upstream.status >= 500
+        ? "A API da V2 nao conseguiu retornar sugestoes agora."
+        : "Nao foi possivel buscar sugestoes de empresas agora.";
+
+    return buildProxyErrorResponse(upstream.status, payload, fallbackMessage);
+  }
+
+  let payload: unknown;
+
+  try {
+    payload = await upstream.json();
+  } catch {
+    return NextResponse.json(
+      {
+        error: {
+          code: "invalid_response",
+          message: "A API da V2 retornou um corpo invalido para as sugestoes.",
+        },
+      },
+      {
+        status: 502,
+        headers: {
+          "cache-control": "no-store",
+        },
+      },
+    );
+  }
+
+  return NextResponse.json(payload, {
+    status: upstream.status,
+    headers: {
+      "cache-control": "no-store",
+    },
+  });
+}

--- a/apps/web/app/comparar/page.tsx
+++ b/apps/web/app/comparar/page.tsx
@@ -12,12 +12,13 @@ import {
 } from "@/components/shared/design-system-recipes";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { buttonVariants } from "@/components/ui/button";
-import { fetchCompanies, getApiBaseUrl } from "@/lib/api";
+import { fetchCompanySuggestions, type CompanySuggestionItem } from "@/lib/api";
 import {
   loadComparePageData,
   type CompareCompanyOption,
   type ComparePageData,
 } from "@/lib/compare-page-data";
+import { getSectorNameFromSlug } from "@/lib/constants";
 import { getFirstParam } from "@/lib/search-params";
 import { cn } from "@/lib/utils";
 
@@ -33,17 +34,12 @@ type ComparePageProps = {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 };
 
-function toQuickOption(item: {
-  cd_cvm: number;
-  company_name: string;
-  ticker_b3: string | null;
-  sector_name: string;
-}): CompareCompanyOption {
+function toQuickOption(item: CompanySuggestionItem): CompareCompanyOption {
   return {
     cd_cvm: item.cd_cvm,
     company_name: item.company_name,
     ticker_b3: item.ticker_b3,
-    sector_name: item.sector_name,
+    sector_name: getSectorNameFromSlug(item.sector_slug) ?? "Setor nao informado",
   };
 }
 
@@ -85,7 +81,7 @@ export default async function ComparePage({ searchParams }: ComparePageProps) {
 
   const [compareData, quickPayload] = await Promise.all([
     loadComparePageData(ids, years),
-    fetchCompanies({ page: 1, pageSize: 8 }).catch(() => null),
+    fetchCompanySuggestions("", 8, { readyOnly: true }).catch(() => null),
   ]);
 
   const quickCompanies = (quickPayload?.items ?? []).map(toQuickOption);
@@ -132,7 +128,6 @@ export default async function ComparePage({ searchParams }: ComparePageProps) {
       />
 
       <CompareSelector
-        apiBaseUrl={getApiBaseUrl()}
         pathname="/comparar"
         selectedCompanies={compareData.selectedCompanies}
         quickCompanies={saneQuickCompanies}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -5,7 +5,8 @@ import { DiscoverySectionLazy } from "@/components/home/discovery-section-lazy";
 import { HomeTrustStrip } from "@/components/home/home-trust-strip";
 import { buttonVariants } from "@/components/ui/button";
 import { PageShell } from "@/components/shared/design-system-recipes";
-import { fetchCompanies, getApiBaseUrl } from "@/lib/api";
+import { fetchCompanies } from "@/lib/api";
+import { prioritizeDiscoveryCompanies } from "@/lib/company-discovery";
 import { cn } from "@/lib/utils";
 
 export const revalidate = 300;
@@ -16,11 +17,14 @@ export default async function HomePage() {
   );
 
   const totalCompanies = topCompaniesResult?.pagination.total_items ?? null;
-  const topCompanies = topCompaniesResult?.items ?? [];
+  const topCompanies = prioritizeDiscoveryCompanies(
+    topCompaniesResult?.items ?? [],
+    8,
+  );
 
   return (
     <PageShell density="relaxed" className="flex flex-col items-center gap-14 pb-20">
-      <CompanySearchHero apiBaseUrl={getApiBaseUrl()} />
+      <CompanySearchHero />
 
       <HomeTrustStrip totalCompanies={totalCompanies} />
 

--- a/apps/web/components/companies/company-card.tsx
+++ b/apps/web/components/companies/company-card.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 
 import type { CompanyDirectoryItem } from "@/lib/api";
+import { getCompanyAvailability } from "@/lib/company-discovery";
 import { getSectorColor } from "@/lib/constants";
 import { cn } from "@/lib/utils";
 
@@ -25,17 +26,19 @@ type CompanyCardProps = {
 
 export function CompanyCard({ item }: CompanyCardProps) {
   const color = getSectorColor(item.sector_name);
-  const hasData = item.has_financial_data !== false;
   const anos = item.anos_disponiveis ?? [];
   const sparkPts = buildSparklinePoints(anos);
   const initials = (item.ticker_b3 ?? item.company_name).slice(0, 2).toUpperCase();
+  const availability = getCompanyAvailability(item);
+  const yearsRange =
+    anos.length > 0 ? `${Math.min(...anos)}-${Math.max(...anos)}` : availability.yearsLabel;
 
   return (
     <Link
       href={`/empresas/${item.cd_cvm}`}
       className={cn(
         "group flex flex-col gap-4 overflow-hidden rounded-[1.25rem] border border-border/60 bg-card p-5 transition-all duration-200",
-        hasData
+        availability.kind === "ready"
           ? "hover:-translate-y-0.5 hover:border-primary/25 hover:shadow-[0_18px_36px_-24px_rgba(16,30,24,0.2)]"
           : "hover:-translate-y-0.5 hover:border-primary/20 hover:bg-muted/30",
       )}
@@ -65,6 +68,16 @@ export function CompanyCard({ item }: CompanyCardProps) {
             </span>
           ) : null}
         </div>
+        <span
+          className={cn(
+            "rounded-full border px-2.5 py-1 text-[0.64rem] font-medium uppercase tracking-[0.14em]",
+            availability.kind === "ready"
+              ? "border-emerald-500/20 bg-emerald-500/8 text-emerald-700 dark:text-emerald-300"
+              : "border-primary/20 bg-primary/8 text-primary/80",
+          )}
+        >
+          {availability.badge}
+        </span>
         <svg
           width="14"
           height="14"
@@ -90,26 +103,30 @@ export function CompanyCard({ item }: CompanyCardProps) {
         {item.sector_name ? (
           <p className="mt-0.5 text-[0.75rem] text-muted-foreground">{item.sector_name}</p>
         ) : null}
-        {!hasData ? (
-          <p className="mt-2 text-[0.72rem] font-medium uppercase tracking-[0.18em] text-primary/80">
-            Disponivel on-demand
-          </p>
-        ) : null}
+        <p className="mt-2 text-[0.78rem] leading-6 text-muted-foreground">
+          {availability.detail}
+        </p>
       </div>
 
       <div className="grid grid-cols-3 divide-x divide-border/60 border-t border-border/60 pt-3">
         {(
           [
-            { label: "Receita", value: "--" },
-            { label: "YoY", value: "--" },
-            { label: "ROE", value: "--" },
+            { label: "Estado", value: availability.summary },
+            { label: "Historico", value: yearsRange },
+            {
+              label: "Entrada",
+              value:
+                availability.kind === "ready"
+                  ? "KPIs + DRE"
+                  : "Pedir on-demand",
+            },
           ] as const
         ).map(({ label, value }) => (
           <div key={label} className="px-2 first:pl-0 last:pr-0">
             <p className="text-[0.62rem] uppercase tracking-[0.12em] text-muted-foreground">
               {label}
             </p>
-            <p className="mt-0.5 font-mono text-[0.82rem] font-medium tabular-nums text-muted-foreground/70">
+            <p className="mt-0.5 text-[0.78rem] font-medium text-foreground/78">
               {value}
             </p>
           </div>

--- a/apps/web/components/companies/company-row.tsx
+++ b/apps/web/components/companies/company-row.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { ChevronRightIcon } from "lucide-react";
 
 import type { CompanyDirectoryItem } from "@/lib/api";
+import { getCompanyAvailability } from "@/lib/company-discovery";
 import { getSectorColor } from "@/lib/constants";
 import { cn } from "@/lib/utils";
 
@@ -26,11 +27,14 @@ type CompanyRowProps = {
 
 export function CompanyRow({ item }: CompanyRowProps) {
   const color = getSectorColor(item.sector_name);
-  const hasData = item.has_financial_data !== false;
   const anos = item.anos_disponiveis ?? [];
   const sparkPts = buildSparklinePoints(anos);
   const initials = (item.ticker_b3 ?? item.company_name).slice(0, 2).toUpperCase();
-  const yearsRange = anos.length > 0 ? `${Math.min(...anos)}-${Math.max(...anos)}` : "--";
+  const availability = getCompanyAvailability(item);
+  const yearsRange =
+    anos.length > 0
+      ? `${Math.min(...anos)}-${Math.max(...anos)}`
+      : availability.yearsLabel;
 
   return (
     <Link
@@ -40,7 +44,7 @@ export function CompanyRow({ item }: CompanyRowProps) {
         "[grid-template-columns:42px_minmax(0,1fr)_32px]",
         "sm:[grid-template-columns:42px_minmax(0,2fr)_minmax(0,1fr)_32px]",
         "lg:[grid-template-columns:42px_minmax(0,2.2fr)_minmax(0,1.1fr)_minmax(0,1fr)_minmax(0,0.85fr)_32px]",
-        hasData ? "cursor-pointer hover:bg-muted/40" : "hover:bg-muted/25",
+        "cursor-pointer hover:bg-muted/40",
       )}
     >
       <div
@@ -71,13 +75,23 @@ export function CompanyRow({ item }: CompanyRowProps) {
               {item.ticker_b3}
             </span>
           ) : null}
-          {!hasData ? (
-            <span className="shrink-0 rounded-full border border-primary/20 bg-primary/8 px-2 py-0.5 text-[0.62rem] font-medium uppercase tracking-[0.14em] text-primary/80">
-              On-demand
-            </span>
-          ) : null}
+          <span
+            className={cn(
+              "shrink-0 rounded-full border px-2 py-0.5 text-[0.62rem] font-medium uppercase tracking-[0.14em]",
+              availability.kind === "ready"
+                ? "border-emerald-500/20 bg-emerald-500/8 text-emerald-700 dark:text-emerald-300"
+                : "border-primary/20 bg-primary/8 text-primary/80",
+            )}
+          >
+            {availability.badge}
+          </span>
         </div>
-        <p className="mt-0.5 text-[0.72rem] text-muted-foreground">CVM {item.cd_cvm}</p>
+        <p className="mt-0.5 text-[0.72rem] text-muted-foreground">
+          CVM {item.cd_cvm}
+        </p>
+        <p className="mt-1 hidden text-[0.72rem] text-muted-foreground sm:block">
+          {availability.detail}
+        </p>
       </div>
 
       <p className="hidden truncate text-[0.82rem] text-muted-foreground sm:block">
@@ -103,8 +117,8 @@ export function CompanyRow({ item }: CompanyRowProps) {
       </div>
 
       <div className="hidden text-right lg:block">
-        <span className="font-mono text-[0.78rem] tabular-nums text-muted-foreground">
-          {anos.length > 0 ? `${anos.length} anos` : "--"}
+        <span className="text-[0.78rem] text-muted-foreground">
+          {availability.summary}
         </span>
       </div>
 

--- a/apps/web/components/company/company-freshness-card.tsx
+++ b/apps/web/components/company/company-freshness-card.tsx
@@ -3,7 +3,9 @@ import { SurfaceCard } from "@/components/shared/design-system-recipes";
 import {
   fetchCompanyFreshness,
   getUserFacingErrorMessage,
+  type RefreshStatusItem,
 } from "@/lib/api";
+import { cn } from "@/lib/utils";
 
 type CompanyFreshnessCardProps = {
   cdCvm: number;
@@ -67,6 +69,92 @@ function formatAbsolute(dateIso: string): string | null {
   return ABSOLUTE_TIME_FORMATTER.format(target);
 }
 
+function getStatusBadge(freshness: RefreshStatusItem | null) {
+  const trackingState = String(freshness?.tracking_state ?? "").toLowerCase();
+
+  if (trackingState === "queued" || trackingState === "running") {
+    return {
+      label: "Atualizando agora",
+      className:
+        "border-sky-500/25 bg-sky-500/10 text-sky-700 dark:text-sky-300",
+    };
+  }
+
+  if (trackingState === "stalled") {
+    return {
+      label: "Sem sinais recentes",
+      className:
+        "border-amber-500/25 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+    };
+  }
+
+  if (freshness?.has_readable_current_data) {
+    return {
+      label: "Leitura pronta",
+      className:
+        "border-emerald-500/25 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+    };
+  }
+
+  return {
+    label: "Historico pendente",
+    className:
+      "border-primary/20 bg-primary/8 text-primary/80",
+  };
+}
+
+function getSummaryCopy(freshness: RefreshStatusItem | null): {
+  title: string;
+  description: string;
+} {
+  const trackingState = String(freshness?.tracking_state ?? "").toLowerCase();
+  const latestOutcome = String(
+    freshness?.latest_attempt_outcome ?? freshness?.last_status ?? "",
+  ).toLowerCase();
+
+  if (trackingState === "queued" || trackingState === "running") {
+    return {
+      title: "Atualizacao em andamento",
+      description:
+        freshness?.status_reason_message ??
+        "A leitura atual continua disponivel enquanto o refresh acompanha a fila interna e o processamento.",
+    };
+  }
+
+  if (trackingState === "stalled") {
+    return {
+      title: "Atualizacao sem previsao firme",
+      description:
+        freshness?.status_reason_message ??
+        "A ultima solicitacao perdeu sinais recentes de progresso. O acompanhamento abaixo permite conferir se vale tentar de novo.",
+    };
+  }
+
+  if (freshness?.has_readable_current_data && latestOutcome === "no_data") {
+    return {
+      title: "Leitura atual continua valida",
+      description:
+        freshness?.status_reason_message ??
+        "A ultima tentativa nao encontrou novos demonstrativos, mas a pagina continua com uma leitura local utilizavel.",
+    };
+  }
+
+  if (freshness?.has_readable_current_data) {
+    return {
+      title: "Dados prontos para leitura",
+      description:
+        "Use este controle quando quiser confirmar se houve novos demonstrativos ou atualizar a serie local desta empresa.",
+    };
+  }
+
+  return {
+    title: "Primeira leitura ainda pendente",
+    description:
+      freshness?.status_reason_message ??
+      "Esta empresa ainda nao tem historico anual liberado na base local. A solicitacao abaixo dispara a primeira carga on-demand.",
+  };
+}
+
 export async function CompanyFreshnessCard({
   cdCvm,
 }: CompanyFreshnessCardProps) {
@@ -79,34 +167,54 @@ export async function CompanyFreshnessCard({
     fetchError = getUserFacingErrorMessage(error);
   }
 
+  const summary = getSummaryCopy(freshness);
+  const statusBadge = getStatusBadge(freshness);
   const lastSuccessAt = freshness?.last_success_at ?? null;
-  const sourceLabel = freshness?.source_scope ?? "CVM (DFP / ITR)";
+  const sourceLabel = freshness?.source_label ?? "Leitura CVM processada";
   const relativeLabel = lastSuccessAt ? formatRelative(lastSuccessAt) : null;
   const absoluteLabel = lastSuccessAt ? formatAbsolute(lastSuccessAt) : null;
+  const readableYearsLabel =
+    freshness?.has_readable_current_data
+      ? `${freshness.readable_years_count} ano${freshness.readable_years_count === 1 ? "" : "s"} anuais locais`
+      : "Nenhum ano anual local";
 
   return (
     <SurfaceCard tone="inset" padding="md" className="space-y-4">
-      <div className="space-y-2">
-        <p className="text-xs uppercase tracking-[0.22em] text-muted-foreground">
-          Atualizacao dos dados
-        </p>
-        <h3 className="font-heading text-xl tracking-[-0.02em] text-foreground">
-          Dispare uma nova leitura da CVM
-        </h3>
-        <p className="text-sm leading-6 text-muted-foreground">
-          Use este CTA quando precisar dos demonstrativos mais recentes
-          divulgados pela CVM.
-        </p>
+      <div className="space-y-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <span
+            className={cn(
+              "rounded-full border px-2.5 py-1 text-[0.64rem] font-medium uppercase tracking-[0.16em]",
+              statusBadge.className,
+            )}
+          >
+            {statusBadge.label}
+          </span>
+          <span className="rounded-full border border-border/65 px-2.5 py-1 text-[0.64rem] font-medium uppercase tracking-[0.16em] text-muted-foreground">
+            {sourceLabel}
+          </span>
+        </div>
+        <div className="space-y-2">
+          <p className="text-xs uppercase tracking-[0.22em] text-muted-foreground">
+            Estado da leitura
+          </p>
+          <h3 className="font-heading text-xl tracking-[-0.02em] text-foreground">
+            {summary.title}
+          </h3>
+          <p className="text-sm leading-6 text-muted-foreground">
+            {summary.description}
+          </p>
+        </div>
       </div>
 
       <dl className="grid gap-2.5 text-sm">
         <div className="flex items-baseline justify-between gap-3">
-          <dt className="text-muted-foreground">Ultima leitura</dt>
+          <dt className="text-muted-foreground">Leitura atual</dt>
           <dd
             className="text-right font-medium text-foreground"
             title={absoluteLabel ?? undefined}
           >
-            {relativeLabel ?? "Sem leitura previa"}
+            {relativeLabel ?? "Ainda sem materializacao local"}
           </dd>
         </div>
         {absoluteLabel ? (
@@ -118,8 +226,14 @@ export async function CompanyFreshnessCard({
           </div>
         ) : null}
         <div className="flex items-baseline justify-between gap-3">
-          <dt className="text-muted-foreground">Fonte</dt>
-          <dd className="text-right text-foreground">{sourceLabel}</dd>
+          <dt className="text-muted-foreground">Historico local</dt>
+          <dd className="text-right text-foreground">{readableYearsLabel}</dd>
+        </div>
+        <div className="flex items-baseline justify-between gap-3">
+          <dt className="text-muted-foreground">Ultimo resultado</dt>
+          <dd className="max-w-[18rem] text-right text-foreground/85">
+            {freshness?.status_reason_message ?? "Sem tentativa recente registrada"}
+          </dd>
         </div>
       </dl>
 

--- a/apps/web/components/company/company-no-data.tsx
+++ b/apps/web/components/company/company-no-data.tsx
@@ -22,6 +22,11 @@ type CompanyMetaCardProps = {
   value: string;
 };
 
+type ExpectationCardProps = {
+  title: string;
+  description: string;
+};
+
 function CompanyMetaCard({ label, value }: CompanyMetaCardProps) {
   return (
     <SurfaceCard tone="inset" padding="md" className="flex flex-col gap-1.5">
@@ -29,6 +34,15 @@ function CompanyMetaCard({ label, value }: CompanyMetaCardProps) {
         {label}
       </p>
       <p className="text-sm font-medium text-foreground">{value}</p>
+    </SurfaceCard>
+  );
+}
+
+function ExpectationCard({ title, description }: ExpectationCardProps) {
+  return (
+    <SurfaceCard tone="inset" padding="md" className="space-y-2">
+      <p className="text-sm font-semibold text-foreground">{title}</p>
+      <p className="text-sm leading-6 text-muted-foreground">{description}</p>
     </SurfaceCard>
   );
 }
@@ -43,6 +57,9 @@ export async function CompanyNoDataPage({ company }: CompanyNoDataPageProps) {
   } catch {
     initialFreshness = null;
   }
+
+  const lastOutcomeMessage =
+    initialFreshness?.status_reason_message ?? null;
 
   return (
     <PageShell density="relaxed" className="max-w-5xl">
@@ -69,16 +86,16 @@ export async function CompanyNoDataPage({ company }: CompanyNoDataPageProps) {
 
         <SurfaceCard tone="hero" padding="hero" className="space-y-8">
           <div className="flex flex-wrap items-center gap-3">
-            <InfoChip tone="brand">Detalhe da companhia</InfoChip>
+            <InfoChip tone="brand">Primeira leitura da companhia</InfoChip>
             <InfoChip>CVM {company.cd_cvm}</InfoChip>
             {company.ticker_b3 ? <InfoChip tone="muted">{company.ticker_b3}</InfoChip> : null}
           </div>
 
           <SectionHeading
-            eyebrow="Dados historicos indisponiveis"
+            eyebrow="Historico anual ainda nao liberado"
             title={company.company_name}
             titleAs="h1"
-            description="O cadastro desta companhia esta disponivel, mas ainda nao existem demonstracoes financeiras processadas para liberar a leitura detalhada."
+            description="O cadastro desta companhia esta disponivel, mas a leitura detalhada ainda depende de uma carga anual processada. Quando houver historico materializavel, esta pagina passa a liberar KPIs, demonstracoes e Excel."
             descriptionClassName="max-w-3xl"
           />
 
@@ -92,12 +109,33 @@ export async function CompanyNoDataPage({ company }: CompanyNoDataPageProps) {
           </div>
 
           <Alert className="rounded-[1.75rem] border border-border/70 bg-muted/28 px-5 py-5">
-            <AlertTitle>Dados historicos nao disponiveis</AlertTitle>
+            <AlertTitle>O que destrava esta pagina</AlertTitle>
             <AlertDescription>
-              Esta empresa ainda nao possui anos anuais processados para exibir
-              KPIs, demonstracoes financeiras ou exportacao em Excel nesta tela.
+              A solicitacao on-demand busca uma serie anual utilizavel na CVM e, quando encontra material suficiente, libera esta mesma aba para leitura. Se a CVM nao tiver historico anual processavel, o resultado aparece aqui de forma clara em vez de falhar em silencio.
             </AlertDescription>
           </Alert>
+
+          {lastOutcomeMessage ? (
+            <Alert className="rounded-[1.75rem] border border-border/70 bg-background/85 px-5 py-5">
+              <AlertTitle>Ultimo resultado conhecido</AlertTitle>
+              <AlertDescription>{lastOutcomeMessage}</AlertDescription>
+            </Alert>
+          ) : null}
+
+          <div className="grid gap-4 lg:grid-cols-3">
+            <ExpectationCard
+              title="1. O que acontece agora"
+              description="A companhia entra na fila interna, o worker tenta montar a serie anual e o status abaixo acompanha esse processo sem tirar voce da pagina."
+            />
+            <ExpectationCard
+              title="2. O que muda quando funciona"
+              description="Assim que a leitura ficar materializada, esta mesma rota passa a abrir os KPIs, as demonstracoes financeiras e o download em Excel."
+            />
+            <ExpectationCard
+              title="3. Quando nao houver historico"
+              description="Se nao existir serie anual suficiente para a janela padrao, a pagina informa isso claramente e voce pode tentar novamente mais tarde."
+            />
+          </div>
 
           <div className="flex flex-wrap items-start gap-3">
             <CompanyRequestRefreshLazy

--- a/apps/web/components/compare/compare-selector.tsx
+++ b/apps/web/components/compare/compare-selector.tsx
@@ -18,8 +18,9 @@ import { Button, buttonVariants } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { serializeCompanyIds } from "@/lib/compare-utils";
 import {
-  buildApiUrlFromBase,
   type CompanySuggestionItem,
+  fetchCompanySuggestionsRoute,
+  getUserFacingErrorMessage,
 } from "@/lib/api";
 import { getSectorNameFromSlug } from "@/lib/constants";
 import { formatYearsLabel } from "@/lib/formatters";
@@ -29,7 +30,6 @@ import { track } from "@/lib/track";
 import { cn } from "@/lib/utils";
 
 type CompareSelectorProps = {
-  apiBaseUrl: string;
   pathname: string;
   selectedCompanies: CompareCompanyOption[];
   quickCompanies: CompareCompanyOption[];
@@ -40,7 +40,6 @@ type CompareSelectorProps = {
 
 type SuggestionResponse = {
   items?: CompanySuggestionItem[];
-  error?: string;
 };
 
 const DEFAULT_MAX_COMPANIES = 5;
@@ -55,7 +54,6 @@ function toCompareOption(item: CompanySuggestionItem): CompareCompanyOption {
 }
 
 export function CompareSelector({
-  apiBaseUrl,
   pathname,
   selectedCompanies,
   quickCompanies,
@@ -94,22 +92,13 @@ export function CompareSelector({
       setSuggestionError(null);
 
       try {
-        const url = new URL(
-          buildApiUrlFromBase(apiBaseUrl, "/companies/suggestions"),
-        );
-        url.searchParams.set("q", normalized);
-        url.searchParams.set("limit", "6");
-
-        const response = await fetch(url.toString());
-        const payload = (await response.json()) as SuggestionResponse;
+        const payload = (await fetchCompanySuggestionsRoute(
+          normalized,
+          6,
+          { readyOnly: true },
+        )) as SuggestionResponse;
 
         if (!active) {
-          return;
-        }
-
-        if (!response.ok) {
-          setSuggestions([]);
-          setSuggestionError(payload.error ?? "Nao foi possivel buscar sugestoes.");
           return;
         }
 
@@ -118,12 +107,12 @@ export function CompareSelector({
           .filter((item) => !selectedIdSet.has(item.cd_cvm));
 
         setSuggestions(nextSuggestions);
-      } catch {
+      } catch (error) {
         if (!active) {
           return;
         }
         setSuggestions([]);
-        setSuggestionError("Nao foi possivel buscar sugestoes.");
+        setSuggestionError(getUserFacingErrorMessage(error));
       } finally {
         if (active) {
           setLoadingSuggestions(false);
@@ -135,7 +124,7 @@ export function CompareSelector({
       active = false;
       window.clearTimeout(timer);
     };
-  }, [apiBaseUrl, deferredQuery, maxCompanies, selectedCompanies.length, selectedIdSet]);
+  }, [deferredQuery, maxCompanies, selectedCompanies.length, selectedIdSet]);
 
   function pushSelection(nextIds: number[], nextYears: number[] | null) {
     const queryString = mergeSearchParams(searchParams.toString(), {
@@ -292,6 +281,15 @@ export function CompareSelector({
           </div>
         ) : null}
 
+        {!loadingSuggestions &&
+        deferredQuery.trim().length >= 2 &&
+        suggestions.length === 0 &&
+        !suggestionError ? (
+          <p className="text-sm text-muted-foreground">
+            Nenhuma companhia pronta para comparar apareceu com esse termo. A comparacao mostra apenas empresas com historico anual local.
+          </p>
+        ) : null}
+
         {quickOptions.length > 0 && selectedIds.length < maxCompanies ? (
           <div className="space-y-2">
             <p className="text-xs uppercase tracking-[0.22em] text-muted-foreground">Sugestoes rapidas</p>
@@ -311,6 +309,19 @@ export function CompareSelector({
                 </button>
               ))}
             </div>
+          </div>
+        ) : null}
+
+        {quickOptions.length === 0 &&
+        selectedCompanies.length === 0 &&
+        deferredQuery.trim().length < 2 ? (
+          <div className="rounded-[1.15rem] border border-dashed border-border/70 bg-muted/35 px-4 py-3">
+            <p className="text-sm font-medium text-foreground">
+              Nenhuma sugestao rapida pronta agora
+            </p>
+            <p className="mt-1 text-sm leading-6 text-muted-foreground">
+              Esta comparacao so lista companhias com historico anual local suficiente. Quando o slice atual nao tiver empresas prontas, use a busca para conferir uma companhia especifica ou abra o diretorio.
+            </p>
           </div>
         ) : null}
       </div>

--- a/apps/web/components/home/company-search-hero.tsx
+++ b/apps/web/components/home/company-search-hero.tsx
@@ -6,8 +6,9 @@ import { useRouter } from "next/navigation";
 
 import { buttonVariants } from "@/components/ui/button";
 import {
-  buildApiUrlFromBase,
   type CompanySuggestionItem,
+  fetchCompanySuggestionsRoute,
+  getUserFacingErrorMessage,
 } from "@/lib/api";
 import { getSectorColor, getSectorNameFromSlug } from "@/lib/constants";
 import { track } from "@/lib/track";
@@ -19,24 +20,17 @@ const QUICK_CHIPS = [
   "ITAUB4",
   "BBDC4",
   "Financeiro",
-  "Petróleo e Gás",
+  "Petroleo e Gas",
 ];
 
-type CompanySearchHeroProps = {
-  apiBaseUrl: string;
-};
-
-type SuggestionResponse = {
-  items?: CompanySuggestionItem[];
-};
-
-export function CompanySearchHero({ apiBaseUrl }: CompanySearchHeroProps) {
+export function CompanySearchHero() {
   const router = useRouter();
   const inputRef = useRef<HTMLInputElement>(null);
   const [query, setQuery] = useState("");
   const [focused, setFocused] = useState(false);
   const [suggestions, setSuggestions] = useState<CompanySuggestionItem[]>([]);
   const [loadingSuggestions, setLoadingSuggestions] = useState(false);
+  const [suggestionError, setSuggestionError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
   const deferredQuery = useDeferredValue(query);
 
@@ -45,35 +39,26 @@ export function CompanySearchHero({ apiBaseUrl }: CompanySearchHeroProps) {
     if (normalized.length < 2) {
       setSuggestions([]);
       setLoadingSuggestions(false);
+      setSuggestionError(null);
       return;
     }
 
     let active = true;
     const timer = window.setTimeout(async () => {
       setLoadingSuggestions(true);
+      setSuggestionError(null);
+
       try {
-        const url = new URL(
-          buildApiUrlFromBase(apiBaseUrl, "/companies/suggestions"),
-        );
-        url.searchParams.set("q", normalized);
-        url.searchParams.set("limit", "6");
-
-        const response = await fetch(url.toString());
-        const payload = (await response.json()) as SuggestionResponse;
-
-        if (!active) {
-          return;
+        const payload = await fetchCompanySuggestionsRoute(normalized, 6);
+        if (active) {
+          setSuggestions(payload.items ?? []);
         }
-
-        if (!response.ok) {
-          setSuggestions([]);
-          return;
-        }
-
-        setSuggestions(payload.items ?? []);
-      } catch {
+      } catch (error) {
         if (active) {
           setSuggestions([]);
+          setSuggestionError(
+            `${getUserFacingErrorMessage(error)} Pressione Enter para abrir o diretorio completo.`,
+          );
         }
       } finally {
         if (active) {
@@ -86,9 +71,10 @@ export function CompanySearchHero({ apiBaseUrl }: CompanySearchHeroProps) {
       active = false;
       window.clearTimeout(timer);
     };
-  }, [apiBaseUrl, deferredQuery]);
+  }, [deferredQuery]);
 
-  const showDropdown = focused && (loadingSuggestions || suggestions.length > 0);
+  const showDropdown =
+    focused && (loadingSuggestions || suggestions.length > 0 || suggestionError !== null);
 
   function navigateToCompany(item: CompanySuggestionItem) {
     track("home_suggestion_selected", {
@@ -110,15 +96,15 @@ export function CompanySearchHero({ apiBaseUrl }: CompanySearchHeroProps) {
     <div className="w-full max-w-[680px] mx-auto space-y-6 text-center">
       <div className="space-y-4">
         <h1 className="font-heading text-[clamp(2.5rem,5.5vw,4.25rem)] leading-[1.02] tracking-[-0.045em] text-foreground">
-          Análise financeira
+          Analise financeira
           <br />
           <span className="text-muted-foreground italic font-normal">
-            de quem está na bolsa.
+            de quem esta na bolsa.
           </span>
         </h1>
         <p className="max-w-[560px] mx-auto text-[1.0625rem] leading-[1.55] text-muted-foreground">
-          Pesquise qualquer companhia aberta brasileira. Leia DRE, balanço e KPIs
-          com 10+ anos de histórico, direto da CVM.
+          Pesquise qualquer companhia aberta brasileira. Leia DRE, balanco e KPIs
+          com 10+ anos de historico, direto da CVM.
         </p>
       </div>
 
@@ -141,7 +127,7 @@ export function CompanySearchHero({ apiBaseUrl }: CompanySearchHeroProps) {
             onFocus={() => setFocused(true)}
             onBlur={() => setTimeout(() => setFocused(false), 150)}
             onKeyDown={(event) => event.key === "Enter" && submit()}
-            placeholder="Petrobras, VALE3, setor financeiro…"
+            placeholder="Petrobras, VALE3, setor financeiro..."
             className="flex-1 border-none bg-transparent py-[0.85rem] text-[1.125rem] text-foreground outline-none placeholder:text-muted-foreground"
             aria-label="Buscar empresa"
           />
@@ -173,9 +159,18 @@ export function CompanySearchHero({ apiBaseUrl }: CompanySearchHeroProps) {
           <div className="absolute inset-x-0 top-full z-20 overflow-hidden rounded-[0_0_1.25rem_1.25rem] border border-t-0 border-ring/50 bg-card shadow-[0_20px_60px_-30px_rgba(16,30,24,0.25)]">
             <div className="border-t border-border bg-muted/30 px-5 py-1.5 text-[0.7rem] font-medium uppercase tracking-[0.2em] text-muted-foreground">
               {loadingSuggestions
-                ? "Buscando…"
-                : `${suggestions.length} resultado${suggestions.length !== 1 ? "s" : ""}`}
+                ? "Buscando..."
+                : suggestionError
+                  ? "Busca com fallback"
+                  : `${suggestions.length} resultado${suggestions.length !== 1 ? "s" : ""}`}
             </div>
+
+            {suggestionError ? (
+              <div className="border-t border-border/50 px-5 py-3 text-sm text-muted-foreground">
+                {suggestionError}
+              </div>
+            ) : null}
+
             {suggestions.map((item) => {
               const sectorName = getSectorNameFromSlug(item.sector_slug);
               const color = getSectorColor(sectorName);
@@ -214,7 +209,7 @@ export function CompanySearchHero({ apiBaseUrl }: CompanySearchHeroProps) {
                       ) : null}
                     </div>
                     <p className="text-[0.8rem] text-muted-foreground mt-0.5">
-                      {sectorName ?? "Setor não informado"}
+                      {sectorName ?? "Setor nao informado"}
                     </p>
                   </div>
                   <div className="text-right shrink-0">

--- a/apps/web/components/home/discovery-section.tsx
+++ b/apps/web/components/home/discovery-section.tsx
@@ -2,9 +2,10 @@
 
 import Link from "next/link";
 import { useState } from "react";
-import { TrendingUpIcon, TrendingDownIcon, ArrowRightIcon } from "lucide-react";
+import { ArrowRightIcon, TrendingDownIcon, TrendingUpIcon } from "lucide-react";
 
 import type { CompanyDirectoryItem } from "@/lib/api";
+import { getCompanyAvailability } from "@/lib/company-discovery";
 import { SECTOR_COLOR, getSectorColor } from "@/lib/constants";
 import { cn } from "@/lib/utils";
 
@@ -39,6 +40,9 @@ function CompanyCard({ co }: { co: CompanyDirectoryItem }) {
   const color = getSectorColor(co.sector_name);
   const anos = co.anos_disponiveis ?? [];
   const sparkPts = buildSparkPoints(anos);
+  const availability = getCompanyAvailability(co);
+  const historyLabel =
+    anos.length > 0 ? `${Math.min(...anos)}-${Math.max(...anos)}` : availability.yearsLabel;
 
   return (
     <Link
@@ -47,24 +51,39 @@ function CompanyCard({ co }: { co: CompanyDirectoryItem }) {
     >
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0 flex-1">
-          <div
-            className="mb-2 inline-block font-mono text-[0.7rem] font-medium px-1.5 py-0.5 rounded-[0.35rem]"
-            style={{
-              background: `color-mix(in oklch, ${color} 12%, transparent)`,
-              border: `1px solid color-mix(in oklch, ${color} 25%, transparent)`,
-              color,
-            }}
-          >
-            {co.ticker_b3 ?? `CVM ${co.cd_cvm}`}
+          <div className="mb-2 flex flex-wrap items-center gap-2">
+            <div
+              className="inline-block rounded-[0.35rem] px-1.5 py-0.5 font-mono text-[0.7rem] font-medium"
+              style={{
+                background: `color-mix(in oklch, ${color} 12%, transparent)`,
+                border: `1px solid color-mix(in oklch, ${color} 25%, transparent)`,
+                color,
+              }}
+            >
+              {co.ticker_b3 ?? `CVM ${co.cd_cvm}`}
+            </div>
+            <span
+              className={cn(
+                "rounded-full border px-2 py-0.5 text-[0.62rem] font-medium uppercase tracking-[0.14em]",
+                availability.kind === "ready"
+                  ? "border-emerald-500/20 bg-emerald-500/8 text-emerald-700 dark:text-emerald-300"
+                  : "border-primary/20 bg-primary/8 text-primary/80",
+              )}
+            >
+              {availability.badge}
+            </span>
           </div>
-          <p className="font-semibold text-[0.95rem] text-foreground line-clamp-1">
+          <p className="line-clamp-1 text-[0.95rem] font-semibold text-foreground">
             {co.company_name}
           </p>
-          {co.sector_name && (
+          {co.sector_name ? (
             <p className="mt-0.5 text-[0.75rem] text-muted-foreground">{co.sector_name}</p>
-          )}
+          ) : null}
+          <p className="mt-2 text-[0.78rem] leading-6 text-muted-foreground">
+            {availability.detail}
+          </p>
         </div>
-        {sparkPts && (
+        {sparkPts ? (
           <svg
             width={70}
             height={32}
@@ -87,21 +106,19 @@ function CompanyCard({ co }: { co: CompanyDirectoryItem }) {
               strokeLinejoin="round"
             />
           </svg>
-        )}
+        ) : null}
       </div>
       <div className="flex items-end justify-between border-t border-dashed border-border/60 pt-3">
         <div>
           <p className="text-[0.65rem] uppercase tracking-[0.15em] text-muted-foreground">
-            Dados disponíveis
+            Historico local
           </p>
           <p className="mt-0.5 font-mono text-sm font-medium text-foreground tabular-nums">
-            {anos.length > 0
-              ? `${Math.min(...anos)}–${Math.max(...anos)}`
-              : "—"}
+            {historyLabel}
           </p>
         </div>
-        <div className="flex items-center gap-1 text-[0.8rem] font-medium text-muted-foreground group-hover:text-primary transition-colors">
-          <span>{anos.length} anos</span>
+        <div className="flex items-center gap-1 text-[0.8rem] font-medium text-muted-foreground transition-colors group-hover:text-primary">
+          <span>{availability.summary}</span>
           <ArrowRightIcon className="size-3.5" />
         </div>
       </div>
@@ -113,6 +130,7 @@ function DestaquCard({ co, rank }: { co: CompanyDirectoryItem; rank: number }) {
   const color = getSectorColor(co.sector_name);
   const anos = co.anos_disponiveis ?? [];
   const sparkPts = buildSparkPoints(anos, 54, 22);
+  const availability = getCompanyAvailability(co);
   const isTop = rank < 3;
 
   return (
@@ -125,7 +143,7 @@ function DestaquCard({ co, rank }: { co: CompanyDirectoryItem; rank: number }) {
         {rank}
       </span>
       <span
-        className="shrink-0 font-mono text-[0.7rem] font-medium px-1.5 py-0.5 rounded-[0.35rem]"
+        className="shrink-0 rounded-[0.35rem] px-1.5 py-0.5 font-mono text-[0.7rem] font-medium"
         style={{
           background: `color-mix(in oklch, ${color} 12%, transparent)`,
           border: `1px solid color-mix(in oklch, ${color} 25%, transparent)`,
@@ -137,7 +155,7 @@ function DestaquCard({ co, rank }: { co: CompanyDirectoryItem; rank: number }) {
       <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[0.9rem] text-foreground">
         {co.company_name}
       </span>
-      {sparkPts && (
+      {sparkPts ? (
         <svg width={54} height={22} viewBox="0 0 54 22" aria-hidden className="shrink-0">
           <polyline
             points={sparkPts}
@@ -148,12 +166,12 @@ function DestaquCard({ co, rank }: { co: CompanyDirectoryItem; rank: number }) {
             strokeLinejoin="round"
           />
         </svg>
-      )}
+      ) : null}
       <span
-        className="shrink-0 font-mono text-[0.82rem] font-medium tabular-nums"
+        className="shrink-0 text-[0.78rem] font-medium"
         style={{ color: isTop ? "var(--chart-1)" : "var(--destructive)" }}
       >
-        {anos.length} anos
+        {availability.badge}
       </span>
     </button>
   );
@@ -167,17 +185,19 @@ export function DiscoverySection({ topCompanies }: DiscoverySectionProps) {
 
   return (
     <section className="w-full max-w-5xl mx-auto space-y-6 text-left">
-      {/* Header */}
       <div className="flex items-end justify-between flex-wrap gap-4">
         <div>
-          <p className="text-[0.72rem] font-medium uppercase tracking-[0.26em] text-muted-foreground mb-1">
+          <p className="mb-1 text-[0.72rem] font-medium uppercase tracking-[0.26em] text-muted-foreground">
             Descobrir
           </p>
           <h2 className="font-heading text-[2rem] font-medium leading-tight tracking-[-0.04em] text-foreground">
-            Por onde começar
+            Por onde comecar
           </h2>
+          <p className="mt-2 max-w-2xl text-sm leading-7 text-muted-foreground">
+            A home prioriza companhias com leitura pronta e deixa claro quando a
+            pagina ainda depende de uma carga on-demand.
+          </p>
         </div>
-        {/* Segmented control */}
         <div className="inline-flex items-center gap-0.5 rounded-full border border-border bg-muted p-1">
           {TABS.map((tab) => (
             <button
@@ -197,22 +217,20 @@ export function DiscoverySection({ topCompanies }: DiscoverySectionProps) {
         </div>
       </div>
 
-      {/* Populares */}
-      {activeTab === "populares" && (
+      {activeTab === "populares" ? (
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
           {topCompanies.slice(0, 8).map((co) => (
             <CompanyCard key={co.cd_cvm} co={co} />
           ))}
         </div>
-      )}
+      ) : null}
 
-      {/* Em destaque — 2-col mover lists */}
-      {activeTab === "destaque" && (
+      {activeTab === "destaque" ? (
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
           <div className="rounded-[1.25rem] border border-border/60 bg-card p-5">
             <div className="mb-3 flex items-center gap-2">
               <TrendingUpIcon className="size-4 text-[color:var(--chart-1)]" />
-              <span className="text-[0.95rem] font-semibold">Maior cobertura de dados</span>
+              <span className="text-[0.95rem] font-semibold">Leitura pronta agora</span>
             </div>
             <div className="flex flex-col gap-0.5">
               {topHalf.map((co, i) => (
@@ -223,7 +241,7 @@ export function DiscoverySection({ topCompanies }: DiscoverySectionProps) {
           <div className="rounded-[1.25rem] border border-border/60 bg-muted/30 p-5">
             <div className="mb-3 flex items-center gap-2">
               <TrendingDownIcon className="size-4 text-destructive" />
-              <span className="text-[0.95rem] font-semibold">Outros destaques</span>
+              <span className="text-[0.95rem] font-semibold">Outras entradas</span>
             </div>
             <div className="flex flex-col gap-0.5">
               {bottomHalf.map((co, i) => (
@@ -232,10 +250,9 @@ export function DiscoverySection({ topCompanies }: DiscoverySectionProps) {
             </div>
           </div>
         </div>
-      )}
+      ) : null}
 
-      {/* Setores */}
-      {activeTab === "setores" && (
+      {activeTab === "setores" ? (
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
           {Object.entries(SECTOR_COLOR).map(([sector, color]) => (
             <Link
@@ -255,12 +272,12 @@ export function DiscoverySection({ topCompanies }: DiscoverySectionProps) {
                 <p className="text-[0.88rem] font-semibold text-foreground leading-tight">
                   {sector}
                 </p>
-                <p className="text-[0.72rem] text-muted-foreground mt-0.5">Ver empresas</p>
+                <p className="mt-0.5 text-[0.72rem] text-muted-foreground">Ver empresas</p>
               </div>
             </Link>
           ))}
         </div>
-      )}
+      ) : null}
     </section>
   );
 }

--- a/apps/web/components/shared/site-header.tsx
+++ b/apps/web/components/shared/site-header.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { MenuIcon, XIcon } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { usePathname } from "next/navigation";
 
 import ThemeToggle from "@/components/toggle-theme";
@@ -20,11 +20,15 @@ const PRIMARY_NAV = [
 
 export function SiteHeader() {
   const pathname = usePathname();
-  const [mobileOpen, setMobileOpen] = useState(false);
-
-  useEffect(() => {
-    setMobileOpen(false);
-  }, [pathname]);
+  const [mobileMenuState, setMobileMenuState] = useState<{
+    open: boolean;
+    pathname: string;
+  }>({
+    open: false,
+    pathname,
+  });
+  const mobileOpen =
+    mobileMenuState.open && mobileMenuState.pathname === pathname;
 
   return (
     <header className="sticky top-0 z-30 border-b border-border/60 bg-background/88 backdrop-blur-xl">
@@ -78,7 +82,13 @@ export function SiteHeader() {
           <button
             type="button"
             className="inline-flex size-10 items-center justify-center rounded-full border border-border/65 bg-background/78 text-foreground shadow-sm shadow-black/5 md:hidden"
-            onClick={() => setMobileOpen((current) => !current)}
+            onClick={() =>
+              setMobileMenuState((current) =>
+                current.open && current.pathname === pathname
+                  ? { open: false, pathname }
+                  : { open: true, pathname },
+              )
+            }
             aria-expanded={mobileOpen}
             aria-controls="mobile-site-nav"
             aria-label={mobileOpen ? "Fechar menu" : "Abrir menu"}

--- a/apps/web/components/shared/site-header.tsx
+++ b/apps/web/components/shared/site-header.tsx
@@ -1,4 +1,9 @@
+"use client";
+
 import Link from "next/link";
+import { MenuIcon, XIcon } from "lucide-react";
+import { useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
 
 import ThemeToggle from "@/components/toggle-theme";
 import { buttonVariants } from "@/components/ui/button";
@@ -14,6 +19,13 @@ const PRIMARY_NAV = [
 ] as const;
 
 export function SiteHeader() {
+  const pathname = usePathname();
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  useEffect(() => {
+    setMobileOpen(false);
+  }, [pathname]);
+
   return (
     <header className="sticky top-0 z-30 border-b border-border/60 bg-background/88 backdrop-blur-xl">
       <div className="mx-auto flex h-16 w-full max-w-7xl items-center justify-between gap-6 px-4 sm:px-6 lg:px-10">
@@ -38,6 +50,7 @@ export function SiteHeader() {
                 className={cn(
                   buttonVariants({ variant: "ghost", size: "sm" }),
                   "rounded-full px-4 text-[0.84rem] text-foreground/78 hover:text-foreground",
+                  pathname === item.href && "bg-muted text-foreground",
                 )}
               >
                 {item.label}
@@ -57,13 +70,58 @@ export function SiteHeader() {
           )}
         </nav>
 
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-2 sm:gap-3">
           <ThemeToggle className="rounded-full border border-border/65 bg-background/78 px-2 py-1 shadow-sm shadow-black/5" />
           <span className="hidden text-xs uppercase tracking-[0.26em] text-muted-foreground lg:inline">
             Slice publico V2
           </span>
+          <button
+            type="button"
+            className="inline-flex size-10 items-center justify-center rounded-full border border-border/65 bg-background/78 text-foreground shadow-sm shadow-black/5 md:hidden"
+            onClick={() => setMobileOpen((current) => !current)}
+            aria-expanded={mobileOpen}
+            aria-controls="mobile-site-nav"
+            aria-label={mobileOpen ? "Fechar menu" : "Abrir menu"}
+          >
+            {mobileOpen ? <XIcon className="size-4" /> : <MenuIcon className="size-4" />}
+          </button>
         </div>
       </div>
+
+      {mobileOpen ? (
+        <div
+          id="mobile-site-nav"
+          className="border-t border-border/60 bg-background/96 px-4 py-4 shadow-[0_20px_40px_-28px_rgba(16,30,24,0.28)] md:hidden"
+        >
+          <nav className="flex flex-col gap-2">
+            {PRIMARY_NAV.map((item) =>
+              item.href ? (
+                <Link
+                  key={item.label}
+                  href={item.href}
+                  className={cn(
+                    buttonVariants({ variant: "ghost", size: "sm" }),
+                    "justify-start rounded-2xl px-4 py-3 text-[0.95rem] text-foreground/80",
+                    pathname === item.href && "bg-muted text-foreground",
+                  )}
+                >
+                  {item.label}
+                </Link>
+              ) : (
+                <div
+                  key={item.label}
+                  className="flex items-center justify-between rounded-2xl border border-border/60 px-4 py-3 text-[0.95rem] text-muted-foreground"
+                >
+                  <span>{item.label}</span>
+                  <span className="text-[0.68rem] font-medium uppercase tracking-[0.2em]">
+                    Em breve
+                  </span>
+                </div>
+              ),
+            )}
+          </nav>
+        </div>
+      ) : null}
     </header>
   );
 }

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -77,6 +77,9 @@ export type RefreshDispatchResponse = {
   job_id: string | null;
   accepted_at: string;
   message: string;
+  status_reason_code: string | null;
+  status_reason_message: string | null;
+  is_retry_allowed: boolean;
 };
 
 export type RefreshStatusItem = {
@@ -106,6 +109,15 @@ export type RefreshStatusItem = {
   elapsed_seconds: number | null;
   estimated_completion_at: string | null;
   estimate_confidence: string | null;
+  tracking_state: string | null;
+  progress_mode: string | null;
+  is_retry_allowed: boolean;
+  status_reason_code: string | null;
+  status_reason_message: string | null;
+  has_readable_current_data: boolean;
+  readable_years_count: number;
+  latest_attempt_outcome: string | null;
+  source_label: string | null;
 };
 
 type RawRefreshStatusItem = Omit<
@@ -116,6 +128,15 @@ type RawRefreshStatusItem = Omit<
   | "elapsed_seconds"
   | "estimated_completion_at"
   | "estimate_confidence"
+  | "tracking_state"
+  | "progress_mode"
+  | "is_retry_allowed"
+  | "status_reason_code"
+  | "status_reason_message"
+  | "has_readable_current_data"
+  | "readable_years_count"
+  | "latest_attempt_outcome"
+  | "source_label"
 > & {
   job_id?: string | null;
   stage?: string | null;
@@ -132,6 +153,15 @@ type RawRefreshStatusItem = Omit<
   elapsed_seconds?: number | null;
   estimated_completion_at?: string | null;
   estimate_confidence?: string | null;
+  tracking_state?: string | null;
+  progress_mode?: string | null;
+  is_retry_allowed?: boolean;
+  status_reason_code?: string | null;
+  status_reason_message?: string | null;
+  has_readable_current_data?: boolean;
+  readable_years_count?: number;
+  latest_attempt_outcome?: string | null;
+  source_label?: string | null;
 };
 
 export type TabularDataRow = Record<string, string | number | boolean | null>;
@@ -400,7 +430,10 @@ function isRefreshDispatchResponse(value: unknown): value is RefreshDispatchResp
     (value.status === "queued" || value.status === "already_current") &&
     isNullableString(value.job_id) &&
     typeof value.accepted_at === "string" &&
-    typeof value.message === "string"
+    typeof value.message === "string" &&
+    isNullableString(value.status_reason_code) &&
+    isNullableString(value.status_reason_message) &&
+    typeof value.is_retry_allowed === "boolean"
   );
 }
 
@@ -427,6 +460,10 @@ function isStatementMatrix(value: unknown): value is StatementMatrix {
 
 function isNullableNumber(value: unknown): value is number | null {
   return value === null || typeof value === "number";
+}
+
+function isOptionalBoolean(value: unknown): value is boolean | undefined {
+  return value === undefined || typeof value === "boolean";
 }
 
 function isOptionalNullableNumber(
@@ -463,7 +500,17 @@ function isRefreshStatusItem(value: unknown): value is RawRefreshStatusItem {
     isOptionalNullableNumber(value.estimated_total_seconds) &&
     isOptionalNullableNumber(value.elapsed_seconds) &&
     isOptionalNullableString(value.estimated_completion_at) &&
-    isOptionalNullableString(value.estimate_confidence)
+    isOptionalNullableString(value.estimate_confidence) &&
+    isOptionalNullableString(value.tracking_state) &&
+    isOptionalNullableString(value.progress_mode) &&
+    isOptionalBoolean(value.is_retry_allowed) &&
+    isOptionalNullableString(value.status_reason_code) &&
+    isOptionalNullableString(value.status_reason_message) &&
+    isOptionalBoolean(value.has_readable_current_data) &&
+    (value.readable_years_count === undefined ||
+      typeof value.readable_years_count === "number") &&
+    isOptionalNullableString(value.latest_attempt_outcome) &&
+    isOptionalNullableString(value.source_label)
   );
 }
 
@@ -491,6 +538,15 @@ function normalizeRefreshStatusItem(
     elapsed_seconds: item.elapsed_seconds ?? null,
     estimated_completion_at: item.estimated_completion_at ?? null,
     estimate_confidence: item.estimate_confidence ?? null,
+    tracking_state: item.tracking_state ?? null,
+    progress_mode: item.progress_mode ?? null,
+    is_retry_allowed: item.is_retry_allowed ?? false,
+    status_reason_code: item.status_reason_code ?? null,
+    status_reason_message: item.status_reason_message ?? null,
+    has_readable_current_data: item.has_readable_current_data ?? false,
+    readable_years_count: item.readable_years_count ?? 0,
+    latest_attempt_outcome: item.latest_attempt_outcome ?? null,
+    source_label: item.source_label ?? null,
   };
 }
 
@@ -865,13 +921,38 @@ export async function fetchCompanyFilters(): Promise<CompanyFiltersResponse> {
 export async function fetchCompanySuggestions(
   q: string,
   limit = 6,
+  options?: { readyOnly?: boolean },
 ): Promise<CompanySuggestionsResponse> {
   return (await apiFetch<CompanySuggestionsResponse>(
-    `/companies/suggestions${buildQuery({ q, limit })}`,
+    `/companies/suggestions${buildQuery({
+      q,
+      limit,
+      ready_only: options?.readyOnly ? "1" : null,
+    })}`,
     {
       request: COMPANY_SUGGESTIONS_API_READ,
       validate: isCompanySuggestionsResponse,
       invalidResponseMessage: "A API retornou sugestoes de empresas invalidas.",
+    },
+  )) as CompanySuggestionsResponse;
+}
+
+export async function fetchCompanySuggestionsRoute(
+  q: string,
+  limit = 6,
+  options?: { readyOnly?: boolean },
+): Promise<CompanySuggestionsResponse> {
+  return (await routeFetch<CompanySuggestionsResponse>(
+    `/api/company-search${buildQuery({
+      q,
+      limit,
+      ready_only: options?.readyOnly ? "1" : null,
+    })}`,
+    undefined,
+    {
+      validate: isCompanySuggestionsResponse,
+      invalidResponseMessage:
+        "A rota interna retornou sugestoes invalidas para a busca de empresas.",
     },
   )) as CompanySuggestionsResponse;
 }

--- a/apps/web/lib/company-discovery.ts
+++ b/apps/web/lib/company-discovery.ts
@@ -1,0 +1,99 @@
+import type { CompanyDirectoryItem } from "@/lib/api";
+
+export type CompanyAvailability = {
+  kind: "ready" | "requestable";
+  badge: string;
+  summary: string;
+  detail: string;
+  yearsLabel: string;
+};
+
+function compareCoverageRank(
+  left: number | null,
+  right: number | null,
+): number {
+  if (left === null && right === null) {
+    return 0;
+  }
+  if (left === null) {
+    return 1;
+  }
+  if (right === null) {
+    return -1;
+  }
+  return left - right;
+}
+
+export function getCompanyAvailability(
+  item: CompanyDirectoryItem,
+): CompanyAvailability {
+  const anos = item.anos_disponiveis ?? [];
+  const hasReadableHistory =
+    item.has_financial_data !== false && anos.length > 0;
+
+  if (hasReadableHistory) {
+    return {
+      kind: "ready",
+      badge: "Pronta agora",
+      summary: "Historico anual liberado",
+      detail: "KPIs, demonstracoes e Excel disponiveis agora.",
+      yearsLabel: `${anos.length} ano${anos.length === 1 ? "" : "s"} locais`,
+    };
+  }
+
+  return {
+    kind: "requestable",
+    badge: "Solicitavel",
+    summary: "Ainda sem historico local",
+    detail: "Abra a empresa para disparar a primeira carga on-demand.",
+    yearsLabel: "Sem anos locais",
+  };
+}
+
+export function prioritizeDiscoveryCompanies(
+  items: CompanyDirectoryItem[],
+  limit = items.length,
+): CompanyDirectoryItem[] {
+  return [...items]
+    .sort((left, right) => {
+      const leftReady =
+        left.has_financial_data !== false && (left.anos_disponiveis?.length ?? 0) > 0;
+      const rightReady =
+        right.has_financial_data !== false && (right.anos_disponiveis?.length ?? 0) > 0;
+
+      if (leftReady !== rightReady) {
+        return leftReady ? -1 : 1;
+      }
+
+      const yearsDiff =
+        (right.anos_disponiveis?.length ?? 0) - (left.anos_disponiveis?.length ?? 0);
+      if (yearsDiff !== 0) {
+        return yearsDiff;
+      }
+
+      const rankDiff = compareCoverageRank(left.coverage_rank, right.coverage_rank);
+      if (rankDiff !== 0) {
+        return rankDiff;
+      }
+
+      const rowDiff = (right.total_rows ?? 0) - (left.total_rows ?? 0);
+      if (rowDiff !== 0) {
+        return rowDiff;
+      }
+
+      return left.company_name.localeCompare(right.company_name, "pt-BR");
+    })
+    .slice(0, limit);
+}
+
+export function selectReadyCompareCompanies(
+  items: CompanyDirectoryItem[],
+  limit = 6,
+): CompanyDirectoryItem[] {
+  return prioritizeDiscoveryCompanies(items, items.length)
+    .filter(
+      (item) =>
+        item.has_financial_data !== false && (item.anos_disponiveis?.length ?? 0) > 0,
+    )
+    .slice(0, limit);
+}

--- a/apps/web/lib/company-refresh-state.ts
+++ b/apps/web/lib/company-refresh-state.ts
@@ -61,6 +61,32 @@ function normalizeStatus(status: string | null | undefined): string {
   return String(status || "").trim().toLowerCase();
 }
 
+function getTrackingState(item: RefreshStatusItem | null | undefined): string {
+  const trackingState = normalizeStatus(item?.tracking_state);
+  if (trackingState) {
+    return trackingState;
+  }
+  return normalizeStatus(item?.last_status);
+}
+
+function getProgressMode(item: RefreshStatusItem | null | undefined): string {
+  return normalizeStatus(item?.progress_mode);
+}
+
+function hasReadableData(item: RefreshStatusItem | null | undefined): boolean {
+  return item?.has_readable_current_data === true;
+}
+
+function isActiveRefreshItem(item: RefreshStatusItem | null | undefined): boolean {
+  const trackingState = getTrackingState(item);
+  return (
+    trackingState === "queued" ||
+    trackingState === "running" ||
+    trackingState === "stalled" ||
+    isActiveRefreshStatus(item?.last_status)
+  );
+}
+
 function getStageLabel(item: RefreshStatusItem | null | undefined): string {
   const stage = normalizeStatus(item?.stage);
   switch (stage) {
@@ -87,13 +113,16 @@ function getQueuedMessage(
   const queuePosition = item?.queue_position ?? null;
   if (typeof queuePosition === "number" && queuePosition > 0) {
     return {
-      message: "Solicitacao na fila interna.",
+      message:
+        item?.status_reason_message ?? "Solicitacao na fila interna.",
       detail: `Ha ${queuePosition} job(s) na frente desta empresa no worker interno.`,
     };
   }
 
   return {
-    message: "Solicitacao enviada. Aguardando processamento...",
+    message:
+      item?.status_reason_message ??
+      "Solicitacao enviada. Aguardando processamento...",
     detail:
       item?.progress_message ??
       "Aguardando o worker interno iniciar esta solicitacao.",
@@ -105,7 +134,9 @@ function getRunningMessage(
 ): { message: string; detail: string } {
   return {
     message:
-      item?.progress_message ?? "Atualizando demonstracoes financeiras...",
+      item?.progress_message ??
+      item?.status_reason_message ??
+      "Atualizando demonstracoes financeiras...",
     detail:
       item?.stage
         ? `Etapa atual: ${getStageLabel(item).toLowerCase()}.`
@@ -164,8 +195,17 @@ function formatEstimatedTime(dateIso: string | null | undefined): string | null 
   return ESTIMATE_TIME_FORMATTER.format(date);
 }
 
-function getConfidenceLabel(confidence: string | null | undefined): string | null {
-  switch (normalizeStatus(confidence)) {
+function getConfidenceLabel(item: RefreshStatusItem | null | undefined): string | null {
+  switch (getProgressMode(item)) {
+    case "queue":
+      return "Acompanhando apenas a fila interna ate o job comecar de fato.";
+    case "stalled":
+      return "Mostrando o ultimo progresso conhecido enquanto o status nao retoma.";
+    default:
+      break;
+  }
+
+  switch (normalizeStatus(item?.estimate_confidence)) {
     case "high":
       return "Estimativa baseada no progresso real do job.";
     case "medium":
@@ -181,8 +221,16 @@ function getFallbackProgress(
   phase: RefreshPhase,
   item: RefreshStatusItem | null | undefined,
 ): number {
-  const itemStatus = normalizeStatus(item?.last_status);
+  const progressMode = getProgressMode(item);
+  if (progressMode === "queue") {
+    return 18;
+  }
 
+  if (progressMode === "stalled") {
+    return 58;
+  }
+
+  const itemStatus = normalizeStatus(item?.last_status);
   if (itemStatus === "running") {
     return phase === "delayed" ? 64 : 42;
   }
@@ -227,7 +275,7 @@ function getEstimateIndicatorClassName(phase: RefreshPhase): string {
 function getEstimateReferenceItem(
   state: RefreshMachineState,
 ): RefreshStatusItem | null {
-  if (isActiveRefreshStatus(state.currentItem?.last_status)) {
+  if (isActiveRefreshItem(state.currentItem)) {
     return state.currentItem;
   }
 
@@ -266,34 +314,50 @@ function buildRefreshEstimate(state: RefreshMachineState): RefreshEstimate | nul
     100,
     Math.max(8, item?.estimated_progress_pct ?? fallbackProgress),
   );
-  const totalSeconds = item?.estimated_total_seconds;
-  const elapsedSeconds = item?.elapsed_seconds;
-  const etaSeconds = item?.estimated_eta_seconds;
-  const isOverdue =
-    typeof totalSeconds === "number" &&
-    typeof elapsedSeconds === "number" &&
-    elapsedSeconds > totalSeconds;
+  const progressMode = getProgressMode(item);
   const confidence = normalizeStatus(item?.estimate_confidence);
   const completionTime = formatEstimatedTime(item?.estimated_completion_at);
-  const hasEstimate =
+  const etaSeconds = item?.estimated_eta_seconds;
+
+  if (progressMode === "queue") {
+    return {
+      progress,
+      etaLabel:
+        typeof item?.queue_position === "number" && item.queue_position > 0
+          ? "Aguardando a vez na fila interna"
+          : "Esperando o worker iniciar o job",
+      confidenceLabel: getConfidenceLabel(item) ?? undefined,
+      indicatorClassName: getEstimateIndicatorClassName(state.phase),
+    };
+  }
+
+  if (progressMode === "stalled" || state.phase === "delayed") {
+    return {
+      progress,
+      etaLabel: "Sem novos sinais recentes de progresso",
+      confidenceLabel: getConfidenceLabel(item) ?? undefined,
+      indicatorClassName: getEstimateIndicatorClassName(state.phase),
+    };
+  }
+
+  const hasScheduleSignal =
     typeof etaSeconds === "number" ||
-    typeof totalSeconds === "number" ||
-    typeof elapsedSeconds === "number";
+    typeof item?.estimated_total_seconds === "number" ||
+    typeof item?.estimated_completion_at === "string";
 
   return {
     progress,
-    etaLabel: isOverdue
-      ? "Acima da estimativa, mas ainda em processamento."
-      : typeof etaSeconds === "number" && etaSeconds > 0
+    etaLabel:
+      typeof etaSeconds === "number" && etaSeconds > 0
         ? `~${formatDuration(etaSeconds)} restantes`
-        : hasEstimate
+        : hasScheduleSignal
           ? "Finalizando a atualizacao..."
           : "Estimativa ainda indisponivel",
     completionLabel:
       (confidence === "medium" || confidence === "high") && completionTime
         ? `Previsao: ${completionTime}`
         : undefined,
-    confidenceLabel: getConfidenceLabel(item?.estimate_confidence) ?? undefined,
+    confidenceLabel: getConfidenceLabel(item) ?? undefined,
     indicatorClassName: getEstimateIndicatorClassName(state.phase),
   };
 }
@@ -408,27 +472,71 @@ export function hydrateRefreshState(
   initialStatus: RefreshStatusItem | null | undefined,
   nowMs = Date.now(),
 ): RefreshMachineState {
-  if (isActiveRefreshStatus(initialStatus?.last_status) && initialStatus) {
+  if (!initialStatus) {
+    return createIdleRefreshState();
+  }
+
+  const trackingState = getTrackingState(initialStatus);
+
+  if (trackingState === "queued" || trackingState === "running") {
     return buildActiveState(
-      normalizeStatus(initialStatus.last_status) as "queued" | "running",
+      trackingState as "queued" | "running",
       initialStatus,
       nowMs,
     );
   }
 
-  if (normalizeStatus(initialStatus?.last_status) === "no_data" && initialStatus) {
+  if (trackingState === "stalled") {
+    if (hasReadableData(initialStatus)) {
+      return createIdleRefreshState();
+    }
+
+    return {
+      phase: "delayed",
+      startedAt: parseTimestamp(initialStatus.last_attempt_at) ?? nowMs,
+      currentItem: initialStatus,
+      lastKnownActiveItem: initialStatus,
+      failureCount: 0,
+      canRequestAgain: initialStatus.is_retry_allowed ?? false,
+      notice: initialStatus.status_reason_message ?? null,
+      terminalMessage: null,
+    };
+  }
+
+  if (hasReadableData(initialStatus)) {
+    return createIdleRefreshState();
+  }
+
+  if (trackingState === "no_data") {
     return {
       phase: "no_data",
       startedAt: parseTimestamp(initialStatus.last_attempt_at) ?? nowMs,
       currentItem: initialStatus,
       lastKnownActiveItem: null,
       failureCount: 0,
-      canRequestAgain: true,
+      canRequestAgain: initialStatus.is_retry_allowed ?? true,
       notice: null,
       terminalMessage:
+        initialStatus.status_reason_message ??
         initialStatus.progress_message ??
         initialStatus.last_error ??
         "Nenhuma demonstracao foi encontrada para o intervalo solicitado.",
+    };
+  }
+
+  if (trackingState === "error") {
+    return {
+      phase: "terminal_error",
+      startedAt: parseTimestamp(initialStatus.last_attempt_at) ?? nowMs,
+      currentItem: initialStatus,
+      lastKnownActiveItem: null,
+      failureCount: 0,
+      canRequestAgain: initialStatus.is_retry_allowed ?? false,
+      notice: null,
+      terminalMessage:
+        initialStatus.status_reason_message ??
+        initialStatus.last_error ??
+        "Nao foi possivel concluir a atualizacao desta empresa.",
     };
   }
 
@@ -461,8 +569,11 @@ export function createDelayedRefreshState(
     phase: "delayed",
     currentItem: state.currentItem ?? state.lastKnownActiveItem,
     failureCount: 0,
-    canRequestAgain: false,
-    notice: null,
+    canRequestAgain: state.currentItem?.is_retry_allowed ?? false,
+    notice:
+      state.currentItem?.status_reason_message ??
+      state.notice ??
+      null,
   };
 }
 
@@ -538,8 +649,6 @@ export function applyRefreshStatusResult(
     return state;
   }
 
-  const status = normalizeStatus(item?.last_status);
-
   if (!item) {
     if (source === "manual") {
       return {
@@ -565,56 +674,85 @@ export function applyRefreshStatusResult(
     };
   }
 
-  if (status === "success") {
+  const trackingState = getTrackingState(item);
+
+  if (trackingState === "success") {
     return {
       ...state,
       phase: "success",
       currentItem: item,
       failureCount: 0,
       canRequestAgain: false,
-      notice: null,
+      notice:
+        item.status_reason_message ??
+        (hasReadableData(item)
+          ? "Dados disponiveis! Recarregando..."
+          : "Atualizacao concluida."),
       terminalMessage: null,
     };
   }
 
-  if (status === "no_data") {
+  if (trackingState === "no_data") {
     return {
       ...state,
       phase: "no_data",
       currentItem: item,
       failureCount: 0,
-      canRequestAgain: true,
+      canRequestAgain: item.is_retry_allowed ?? true,
       notice: null,
       terminalMessage:
+        item.status_reason_message ??
         item.progress_message ??
         item.last_error ??
         "Nenhuma demonstracao foi encontrada para o intervalo solicitado.",
     };
   }
 
-  if (TERMINAL_REFRESH_STATUSES.has(status)) {
+  if (trackingState === "error" || TERMINAL_REFRESH_STATUSES.has(trackingState)) {
     return {
       ...state,
       phase: "terminal_error",
       currentItem: item,
       failureCount: 0,
-      canRequestAgain: false,
+      canRequestAgain: item.is_retry_allowed ?? false,
       notice: null,
       terminalMessage:
+        item.status_reason_message ??
         item.last_error ??
         "Nao foi possivel concluir a atualizacao desta empresa.",
     };
   }
 
-  if (status === "queued" || status === "running") {
-    return buildActiveState(status, item, nowMs, state);
+  if (trackingState === "queued" || trackingState === "running") {
+    return buildActiveState(
+      trackingState as "queued" | "running",
+      item,
+      nowMs,
+      state,
+    );
+  }
+
+  if (trackingState === "stalled") {
+    return {
+      ...createDelayedRefreshState(state),
+      currentItem: item,
+      lastKnownActiveItem: item,
+      startedAt:
+        parseTimestamp(item.last_attempt_at) ??
+        state.startedAt ??
+        nowMs,
+      canRequestAgain: item.is_retry_allowed ?? false,
+      notice:
+        item.status_reason_message ??
+        "A ultima solicitacao perdeu previsibilidade.",
+    };
   }
 
   if (source === "manual") {
     return {
       ...createDelayedRefreshState(state),
-      canRequestAgain: true,
-      notice: "Nenhum refresh ativo foi encontrado agora.",
+      canRequestAgain: item.is_retry_allowed ?? true,
+      notice: item.status_reason_message ?? "Nenhum refresh ativo foi encontrado agora.",
     };
   }
 
@@ -625,6 +763,7 @@ export function getRefreshViewModel(
   state: RefreshMachineState,
 ): RefreshViewModel {
   const estimate = buildRefreshEstimate(state);
+  const currentItem = state.currentItem;
 
   switch (state.phase) {
     case "submitting":
@@ -695,20 +834,18 @@ export function getRefreshViewModel(
     case "delayed":
       return {
         showCard: true,
-        title: "Atualizacao em andamento",
-        message: "Esta atualizacao esta demorando mais que o normal.",
-        detail: state.notice
-          ? `${state.notice} ${
-              state.canRequestAgain
-                ? "Se os dados ainda nao apareceram, voce pode solicitar novamente."
-                : ""
-            }`.trim()
-          : "O acompanhamento automatico foi pausado para evitar consultas repetidas. Atualize o status manualmente.",
-        stepLabel: "Demorado",
+        title: "Atualizacao sem sinais recentes",
+        message:
+          state.notice ??
+          "Esta solicitacao perdeu previsibilidade e precisa de uma nova checagem.",
+        detail: state.canRequestAgain
+          ? "Atualize o status agora. Se a solicitacao ja tiver expirado, voce tambem pode pedir novamente."
+          : "Atualize o status manualmente para verificar se o processamento voltou a responder.",
+        stepLabel: "Travado",
         stepClassName: getBadgeClassName(state.phase),
         isDestructive: false,
         estimate,
-        requestButtonLabel: "Atualizacao demorada",
+        requestButtonLabel: "Status em analise",
         requestButtonDisabled: true,
         showManualStatusButton: true,
         showRequestAgainButton: state.canRequestAgain,
@@ -716,12 +853,15 @@ export function getRefreshViewModel(
     case "no_data":
       return {
         showCard: true,
-        title: "Nenhum dado encontrado",
+        title: hasReadableData(currentItem)
+          ? "Nenhum novo demonstrativo encontrado"
+          : "Nenhum dado encontrado",
         message:
           state.terminalMessage ??
           "Nenhuma demonstracao foi encontrada para o intervalo solicitado.",
-        detail:
-          "Esse resultado e terminal e informativo. Voce pode solicitar novamente depois, se necessario.",
+        detail: hasReadableData(currentItem)
+          ? "A leitura atual da empresa continua disponivel. Voce pode tentar novamente se esperar novos documentos."
+          : "Esse resultado e terminal e informativo. Voce pode solicitar novamente depois, se necessario.",
         stepLabel: "Sem dados",
         stepClassName: getBadgeClassName(state.phase),
         isDestructive: false,
@@ -753,10 +893,9 @@ export function getRefreshViewModel(
         showCard: true,
         title: "Atualizacao concluida",
         message: state.notice ?? "Dados disponiveis! Recarregando...",
-        detail:
-          state.notice === null
-            ? "A leitura detalhada desta empresa sera atualizada agora."
-            : "A pagina sera atualizada para refletir o estado mais recente.",
+        detail: hasReadableData(currentItem)
+          ? "A pagina sera atualizada para refletir a nova leitura disponivel."
+          : "A pagina sera atualizada para refletir o estado mais recente.",
         stepLabel: "Concluido",
         stepClassName: getBadgeClassName(state.phase),
         isDestructive: false,
@@ -776,7 +915,7 @@ export function getRefreshViewModel(
         stepClassName: getBadgeClassName("queued"),
         isDestructive: false,
         estimate,
-        requestButtonLabel: "Solicitar dados financeiros",
+        requestButtonLabel: "Atualizar leitura da CVM",
         requestButtonDisabled: false,
         showManualStatusButton: false,
         showRequestAgainButton: false,

--- a/apps/web/tests/api-client.test.ts
+++ b/apps/web/tests/api-client.test.ts
@@ -7,6 +7,7 @@ import {
   fetchCompanyFilters,
   fetchCompanyFreshness,
   fetchCompanyKpis,
+  fetchCompanySuggestionsRoute,
   fetchCompanyStatement,
   fetchCompanySuggestions,
   fetchCompanyYears,
@@ -113,8 +114,10 @@ test("fetchCompanyFilters opts into the backend-aligned revalidate window", asyn
 });
 
 test("fetchCompanySuggestions opts into the backend-aligned revalidate window", async () => {
+  let capturedInput: RequestInfo | URL | undefined;
   let capturedInit: RequestInit | undefined;
-  const restore = withFetchMock((async (_input, init) => {
+  const restore = withFetchMock((async (input, init) => {
+    capturedInput = input;
     capturedInit = init;
 
     return new Response(
@@ -133,8 +136,99 @@ test("fetchCompanySuggestions opts into the backend-aligned revalidate window", 
   try {
     await fetchCompanySuggestions("itub4", 6);
 
+    assert.match(String(capturedInput), /\/companies\/suggestions\?q=itub4&limit=6$/);
     assert.equal(capturedInit?.cache, undefined);
     assert.deepEqual(capturedInit?.next, { revalidate: 60 });
+  } finally {
+    restore();
+  }
+});
+
+test("fetchCompanySuggestions can restrict suggestions to ready companies", async () => {
+  let capturedInput: RequestInfo | URL | undefined;
+  const restore = withFetchMock((async (input) => {
+    capturedInput = input;
+
+    return new Response(
+      JSON.stringify({
+        items: [],
+      }),
+      {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+        },
+      },
+    );
+  }) as FetchMock);
+
+  try {
+    await fetchCompanySuggestions("vale", 6, { readyOnly: true });
+
+    assert.match(
+      String(capturedInput),
+      /\/companies\/suggestions\?q=vale&limit=6&ready_only=1$/,
+    );
+  } finally {
+    restore();
+  }
+});
+
+test("fetchCompanySuggestionsRoute uses the internal same-origin proxy with no-store semantics", async () => {
+  let capturedInput: RequestInfo | URL | undefined;
+  let capturedInit: RequestInit | undefined;
+  const restore = withFetchMock((async (input, init) => {
+    capturedInput = input;
+    capturedInit = init;
+
+    return new Response(
+      JSON.stringify({
+        items: [],
+      }),
+      {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+        },
+      },
+    );
+  }) as FetchMock);
+
+  try {
+    await fetchCompanySuggestionsRoute("itub4", 6);
+
+    assert.match(String(capturedInput), /\/api\/company-search\?q=itub4&limit=6$/);
+    assert.equal(capturedInit?.cache, "no-store");
+  } finally {
+    restore();
+  }
+});
+
+test("fetchCompanySuggestionsRoute forwards ready-only compare lookups", async () => {
+  let capturedInput: RequestInfo | URL | undefined;
+  const restore = withFetchMock((async (input) => {
+    capturedInput = input;
+
+    return new Response(
+      JSON.stringify({
+        items: [],
+      }),
+      {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+        },
+      },
+    );
+  }) as FetchMock);
+
+  try {
+    await fetchCompanySuggestionsRoute("vale", 6, { readyOnly: true });
+
+    assert.match(
+      String(capturedInput),
+      /\/api\/company-search\?q=vale&limit=6&ready_only=1$/,
+    );
   } finally {
     restore();
   }
@@ -392,6 +486,9 @@ test("fetchRequestRefresh accepts the new internal queue payload", async () => {
         job_id: "job-4170",
         accepted_at: "2026-04-21T12:00:00+00:00",
         message: "Solicitacao enfileirada para processamento interno.",
+        status_reason_code: "refresh_queued",
+        status_reason_message: "Solicitacao aceita e aguardando processamento interno.",
+        is_retry_allowed: false,
       }),
       {
         status: 202,
@@ -407,6 +504,8 @@ test("fetchRequestRefresh accepts the new internal queue payload", async () => {
     assert.equal(payload.status, "queued");
     assert.equal(payload.job_id, "job-4170");
     assert.equal(payload.accepted_at, "2026-04-21T12:00:00+00:00");
+    assert.equal(payload.status_reason_code, "refresh_queued");
+    assert.equal(payload.is_retry_allowed, false);
   } finally {
     restore();
   }
@@ -443,6 +542,15 @@ test("fetchRefreshStatus accepts estimated progress fields from the API", async 
           elapsed_seconds: 420,
           estimated_completion_at: "2026-04-21T12:21:00+00:00",
           estimate_confidence: "medium",
+          tracking_state: "queued",
+          progress_mode: "real_progress",
+          is_retry_allowed: false,
+          status_reason_code: "refresh_queued",
+          status_reason_message: "Solicitacao recebida e aguardando processamento interno.",
+          has_readable_current_data: false,
+          readable_years_count: 0,
+          latest_attempt_outcome: "queued",
+          source_label: "Solicitacao on-demand",
         },
       ]),
       {
@@ -464,6 +572,11 @@ test("fetchRefreshStatus accepts estimated progress fields from the API", async 
     assert.equal(payload[0]?.estimated_progress_pct, 31.4);
     assert.equal(payload[0]?.estimated_eta_seconds, 840);
     assert.equal(payload[0]?.estimate_confidence, "medium");
+    assert.equal(payload[0]?.tracking_state, "queued");
+    assert.equal(payload[0]?.progress_mode, "real_progress");
+    assert.equal(payload[0]?.status_reason_code, "refresh_queued");
+    assert.equal(payload[0]?.has_readable_current_data, false);
+    assert.equal(payload[0]?.source_label, "Solicitacao on-demand");
   } finally {
     restore();
   }
@@ -509,6 +622,11 @@ test("fetchRefreshStatus normalizes missing estimate fields from legacy payloads
     assert.equal(payload[0]?.elapsed_seconds, null);
     assert.equal(payload[0]?.estimated_completion_at, null);
     assert.equal(payload[0]?.estimate_confidence, null);
+    assert.equal(payload[0]?.tracking_state, null);
+    assert.equal(payload[0]?.progress_mode, null);
+    assert.equal(payload[0]?.is_retry_allowed, false);
+    assert.equal(payload[0]?.has_readable_current_data, false);
+    assert.equal(payload[0]?.readable_years_count, 0);
   } finally {
     restore();
   }
@@ -548,6 +666,9 @@ test("fetchCompanyFreshness normalizes missing estimate fields from legacy API p
     assert.equal(payload?.estimated_progress_pct, null);
     assert.equal(payload?.estimated_eta_seconds, null);
     assert.equal(payload?.estimate_confidence, null);
+    assert.equal(payload?.tracking_state, null);
+    assert.equal(payload?.status_reason_message, null);
+    assert.equal(payload?.has_readable_current_data, false);
   } finally {
     restore();
   }

--- a/apps/web/tests/company-refresh-state.test.ts
+++ b/apps/web/tests/company-refresh-state.test.ts
@@ -47,6 +47,15 @@ function buildRefreshStatusItem(
     elapsed_seconds: null,
     estimated_completion_at: null,
     estimate_confidence: null,
+    tracking_state: null,
+    progress_mode: null,
+    is_retry_allowed: false,
+    status_reason_code: null,
+    status_reason_message: null,
+    has_readable_current_data: false,
+    readable_years_count: 0,
+    latest_attempt_outcome: null,
+    source_label: null,
     ...overrides,
   };
 }
@@ -240,7 +249,11 @@ test("delayed state appears after the timeout threshold without turning destruct
   assert.equal(delayedState.phase, "delayed");
   assert.equal(view.isDestructive, false);
   assert.equal(view.showManualStatusButton, true);
-  assert.equal(view.message, "Esta atualizacao esta demorando mais que o normal.");
+  assert.equal(
+    view.message,
+    "Esta solicitacao perdeu previsibilidade e precisa de uma nova checagem.",
+  );
+  assert.equal(view.stepLabel, "Travado");
 });
 
 test("manual refresh from delayed enables request again when no active status is found", () => {
@@ -282,6 +295,50 @@ test("no_data is treated as a terminal informative state", () => {
   assert.equal(view.isDestructive, false);
   assert.equal(view.message, "Nenhuma demonstracao encontrada para 2010-2025.");
   assert.equal(view.requestButtonDisabled, false);
+});
+
+test("initial terminal no_data stays neutral when readable data already exists", () => {
+  const state = hydrateRefreshState(
+    buildRefreshStatusItem({
+      last_status: "no_data",
+      tracking_state: "no_data",
+      has_readable_current_data: true,
+      readable_years_count: 8,
+      status_reason_message:
+        "A ultima tentativa nao encontrou novos demonstrativos, mas a leitura atual continua disponivel.",
+    }),
+    Date.now(),
+  );
+
+  assert.equal(state.phase, "idle");
+  assert.equal(getRefreshViewModel(state).showCard, false);
+});
+
+test("stalled tracking state keeps a manual recovery path", () => {
+  const state = applyRefreshStatusResult(
+    createDispatchedRefreshState(Date.now()),
+    buildRefreshStatusItem({
+      last_status: "queued",
+      tracking_state: "stalled",
+      progress_mode: "stalled",
+      estimated_progress_pct: 22,
+      status_reason_message:
+        "A ultima solicitacao nao aparece mais como ativa. Atualize o status ou tente novamente.",
+      is_retry_allowed: true,
+    }),
+    Date.now(),
+  );
+
+  assert.equal(state.phase, "delayed");
+  assert.equal(state.canRequestAgain, true);
+
+  const view = getRefreshViewModel(state);
+  assert.equal(view.showManualStatusButton, true);
+  assert.equal(view.showRequestAgainButton, true);
+  assert.equal(
+    view.message,
+    "A ultima solicitacao nao aparece mais como ativa. Atualize o status ou tente novamente.",
+  );
 });
 
 test("already_current uses the success state for immediate reload", () => {

--- a/apps/web/tests/compare.spec.ts
+++ b/apps/web/tests/compare.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-test("fluxo inicial de comparacao entre empresas", async ({ page }) => {
+test("compare deixa claro quando nao ha sugestoes rapidas prontas", async ({ page }) => {
   await page.goto("/comparar");
 
   await expect(
@@ -9,87 +9,85 @@ test("fluxo inicial de comparacao entre empresas", async ({ page }) => {
     }),
   ).toBeVisible();
 
-  const quickAddButtons = page
-    .getByTestId("compare-quick-add")
-    .filter({ hasNotText: /^--$/ });
-  await expect(quickAddButtons.first()).toBeVisible({ timeout: 15_000 });
-
-  await quickAddButtons.first().click();
-  await expect(page).toHaveURL(/\/comparar\?ids=\d+/i, {
-    timeout: 30_000,
-  });
-
-  const secondRoundButtons = page
-    .getByTestId("compare-quick-add")
-    .filter({ hasNotText: /^--$/ });
-  await expect(secondRoundButtons.first()).toBeVisible({ timeout: 15_000 });
-  await secondRoundButtons.first().click();
-
-  await expect(page).toHaveURL(/\/comparar\?ids=\d+(%2C|,)\d+/i, {
-    timeout: 30_000,
-  });
-  await expect(page.locator("#resultado-comparacao")).toBeVisible({ timeout: 30_000 });
-  await expect(page.locator("#resultado-comparacao table")).toBeVisible();
+  await expect(page.getByTestId("compare-quick-add")).toHaveCount(0);
+  await expect(
+    page.getByText(/nenhuma sugestao rapida pronta agora/i),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: /baixar lote excel/i }),
+  ).toBeDisabled();
 });
 
-test("deep-link com ids reidrata a comparacao", async ({ page }) => {
+test("busca do compare usa o proxy same-origin pronto-only e reidrata a selecao", async ({
+  page,
+}) => {
+  await page.route("**/api/company-search**", async (route) => {
+    const url = new URL(route.request().url());
+    expect(url.searchParams.get("ready_only")).toBe("1");
+    expect(url.searchParams.get("q")).toBe("petro");
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        items: [
+          {
+            cd_cvm: 9512,
+            company_name: "PETROLEO BRASILEIRO S.A. - PETROBRAS",
+            ticker_b3: "PETR4.SA",
+            sector_slug: "petroleo-e-gas",
+          },
+          {
+            cd_cvm: 4170,
+            company_name: "VALE S.A.",
+            ticker_b3: "VALE3.SA",
+            sector_slug: "mineracao",
+          },
+        ],
+      }),
+    });
+  });
+
   await page.goto("/comparar");
 
-  const quickAddButtons = page
-    .getByTestId("compare-quick-add")
-    .filter({ hasNotText: /^--$/ });
-  await expect(quickAddButtons.first()).toBeVisible({ timeout: 15_000 });
+  const searchbox = page.getByRole("searchbox", {
+    name: /buscar empresa para comparar/i,
+  });
+  await searchbox.fill("petro");
 
-  await quickAddButtons.first().click();
-  await expect(page).toHaveURL(/\/comparar\?ids=\d+/i, {
+  const suggestionButtons = page.getByTestId("compare-suggestion-add");
+  await expect(suggestionButtons).toHaveCount(2);
+
+  await suggestionButtons.first().click();
+  await expect(page).toHaveURL(/\/comparar\?ids=9512/i, {
     timeout: 30_000,
   });
+  await expect(page.getByTestId("compare-selected-chip")).toHaveCount(1);
 
-  const secondRoundButtons = page
-    .getByTestId("compare-quick-add")
-    .filter({ hasNotText: /^--$/ });
-  await expect(secondRoundButtons.first()).toBeVisible({ timeout: 15_000 });
-  await secondRoundButtons.first().click();
+  await searchbox.fill("petro");
+  await expect(suggestionButtons).toHaveCount(1);
+  await suggestionButtons.first().click();
 
-  await expect(page).toHaveURL(/\/comparar\?ids=\d+(%2C|,)\d+/i, {
+  await expect(page).toHaveURL(/\/comparar\?ids=9512(%2C|,)4170/i, {
     timeout: 30_000,
   });
-
-  const deepLink = page.url();
-  await page.goto(deepLink);
-
-  await expect(page.locator("#resultado-comparacao")).toBeVisible({ timeout: 30_000 });
   await expect(page.getByTestId("compare-selected-chip")).toHaveCount(2);
+  await expect(page.getByTestId("compare-state-card")).toBeVisible();
 });
 
-test("comparacao multipla dispara download do lote Excel", async ({ page }) => {
-  await page.goto("/comparar");
+test("deep-link com ids mostra estado controlado quando nao ha periodo em comum", async ({
+  page,
+}) => {
+  await page.goto("/comparar?ids=9512,4170");
 
-  const quickAddButtons = page
-    .getByTestId("compare-quick-add")
-    .filter({ hasNotText: /^--$/ });
-  await expect(quickAddButtons.first()).toBeVisible({ timeout: 15_000 });
-
-  await quickAddButtons.first().click();
-  await expect(page).toHaveURL(/\/comparar\?ids=\d+/i, {
-    timeout: 30_000,
-  });
-
-  const secondRoundButtons = page
-    .getByTestId("compare-quick-add")
-    .filter({ hasNotText: /^--$/ });
-  await expect(secondRoundButtons.first()).toBeVisible({ timeout: 15_000 });
-  await secondRoundButtons.first().click();
-
-  await expect(page).toHaveURL(/\/comparar\?ids=\d+(%2C|,)\d+/i, {
-    timeout: 30_000,
-  });
-
-  const downloadPromise = page.waitForEvent("download");
-  await page.getByRole("button", { name: /baixar lote excel/i }).click();
-
-  const download = await downloadPromise;
-  expect(await download.suggestedFilename()).toBe("comparar_excel_lote.zip");
+  await expect(page.getByTestId("compare-selected-chip")).toHaveCount(2);
+  await expect(page.getByTestId("compare-state-card")).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: /sem periodo em comum/i }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: /baixar lote excel/i }),
+  ).toBeVisible();
 });
 
 test("ids invalidos mostram fallback controlado", async ({ page }) => {
@@ -99,4 +97,27 @@ test("ids invalidos mostram fallback controlado", async ({ page }) => {
     page.getByRole("alert").filter({ hasText: /comparacao indisponivel no estado atual/i }),
   ).toBeVisible({ timeout: 30_000 });
   await expect(page.getByRole("link", { name: /abrir diretorio/i })).toBeVisible();
+});
+
+test("busca do compare mostra feedback quando nenhuma empresa pronta e encontrada", async ({
+  page,
+}) => {
+  await page.goto("/comparar");
+
+  const responsePromise = page.waitForResponse((response) =>
+    response.url().includes("/api/company-search"),
+  );
+
+  await page
+    .getByRole("searchbox", { name: /buscar empresa para comparar/i })
+    .fill("petro");
+
+  const response = await responsePromise;
+  expect(response.url()).toContain("/api/company-search");
+  expect(response.url()).toContain("ready_only=1");
+  expect(response.url()).not.toContain(":8000/companies/suggestions");
+
+  await expect(
+    page.getByText(/nenhuma companhia pronta para comparar apareceu com esse termo/i),
+  ).toBeVisible();
 });

--- a/apps/web/tests/smoke.spec.ts
+++ b/apps/web/tests/smoke.spec.ts
@@ -20,11 +20,12 @@ test("fluxo inicial de descoberta por empresa", async ({ page }) => {
     page.getByRole("heading", { name: /todas as companhias abertas/i }),
   ).toBeVisible({ timeout: 30_000 });
 
-  const petrobrasLink = page.getByRole("link").filter({ hasText: /PETROBRAS/i }).first();
+  const petrobrasLink = page.locator('a[href^="/empresas/"]').filter({ hasText: /PETROBRAS/i }).first();
   await expect(petrobrasLink).toBeVisible({ timeout: 30_000 });
-  await petrobrasLink.click();
-
-  await expect(page).toHaveURL(/\/empresas\/\d+/);
+  await Promise.all([
+    page.waitForURL(/\/empresas\/\d+/, { timeout: 30_000 }),
+    petrobrasLink.click(),
+  ]);
   await expect(page.locator("h1").first()).toContainText(/PETROBRAS/i);
 });
 

--- a/apps/web/tests/smoke.spec.ts
+++ b/apps/web/tests/smoke.spec.ts
@@ -5,42 +5,70 @@ test("fluxo inicial de descoberta por empresa", async ({ page }) => {
 
   await expect(
     page.getByRole("heading", {
-      name: /entre por empresa e va direto ao historico que importa/i,
+      name: /analise financeira/i,
     }),
   ).toBeVisible();
 
-  await page
-    .getByRole("searchbox", { name: /buscar empresa/i })
-    .fill("petrobras");
-
-  await page
-    .getByRole("searchbox", { name: /buscar empresa/i })
-    .press("Enter");
+  const searchBox = page.getByLabel(/buscar empresa/i);
+  await searchBox.fill("petrobras");
+  await searchBox.press("Enter");
 
   await expect(page).toHaveURL(/\/empresas\?busca=petrobras/i, {
     timeout: 30_000,
   });
   await expect(
-    page.getByRole("heading", { name: /diretorio publico de empresas/i }),
+    page.getByRole("heading", { name: /todas as companhias abertas/i }),
   ).toBeVisible({ timeout: 30_000 });
 
-  await expect(page.locator("article").first()).toContainText(/PETROBRAS/i);
-  await page.getByRole("link", { name: /ver empresa/i }).first().click();
+  const petrobrasLink = page.getByRole("link").filter({ hasText: /PETROBRAS/i }).first();
+  await expect(petrobrasLink).toBeVisible({ timeout: 30_000 });
+  await petrobrasLink.click();
 
   await expect(page).toHaveURL(/\/empresas\/\d+/);
   await expect(page.locator("h1").first()).toContainText(/PETROBRAS/i);
 });
 
-test("detalhe da empresa dispara download do Excel", async ({ page }) => {
+test("home suggestions usam a rota same-origin", async ({ page }) => {
+  await page.goto("/");
+
+  const responsePromise = page.waitForResponse((response) =>
+    response.url().includes("/api/company-search"),
+  );
+
+  await page.getByLabel(/buscar empresa/i).fill("petro");
+
+  const response = await responsePromise;
+  expect(response.url()).toContain("/api/company-search");
+  expect(response.url()).not.toContain(":8000/companies/suggestions");
+});
+
+test("detalhe sem historico vira experiencia guiada de pre-refresh", async ({ page }) => {
   await page.goto("/empresas/9512");
 
   await expect(page.locator("h1").first()).toContainText(/PETROBRAS/i, {
     timeout: 30_000,
   });
 
-  const downloadPromise = page.waitForEvent("download");
-  await page.getByRole("button", { name: /baixar excel/i }).click();
+  await expect(
+    page.getByText(/historico anual ainda nao liberado/i),
+  ).toBeVisible();
+  await expect(
+    page.getByText(/o que destrava esta pagina/i),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: /atualizar leitura da cvm/i }),
+  ).toBeVisible();
+});
 
-  const download = await downloadPromise;
-  expect(await download.suggestedFilename()).toMatch(/^PETR4(?:\.SA)?_\d{8}\.xlsx$/i);
+test("header mobile preserva navegacao no compare", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/comparar");
+
+  const menuButton = page.getByRole("button", { name: /abrir menu/i });
+  await expect(menuButton).toBeVisible();
+  await menuButton.click();
+
+  const mobileNav = page.locator("#mobile-site-nav");
+  await expect(mobileNav.getByRole("link", { name: /^empresas$/i })).toBeVisible();
+  await expect(mobileNav.getByRole("link", { name: /^comparar$/i })).toBeVisible();
 });

--- a/src/contracts.py
+++ b/src/contracts.py
@@ -144,6 +144,9 @@ class RefreshDispatchDTO:
     job_id: str | None
     accepted_at: str
     message: str
+    status_reason_code: str | None = None
+    status_reason_message: str | None = None
+    is_retry_allowed: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -432,6 +435,15 @@ class RefreshStatusDTO:
     elapsed_seconds: int | None = None
     estimated_completion_at: str | None = None
     estimate_confidence: str | None = None
+    tracking_state: str | None = None
+    progress_mode: str | None = None
+    is_retry_allowed: bool = False
+    status_reason_code: str | None = None
+    status_reason_message: str | None = None
+    has_readable_current_data: bool = False
+    readable_years_count: int = 0
+    latest_attempt_outcome: str | None = None
+    source_label: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)

--- a/src/query_layer.py
+++ b/src/query_layer.py
@@ -27,7 +27,7 @@ import time
 from typing import Optional
 
 import pandas as pd
-from sqlalchemy import Engine, text
+from sqlalchemy import Engine, inspect, text
 
 from src.db import get_engine
 
@@ -449,6 +449,9 @@ class CVMQueryLayer:
             return {}
 
         unique_ids = tuple(sorted({int(cd_cvm) for cd_cvm in cd_cvms}))
+        if not inspect(self.engine).has_table("financial_reports"):
+            return {int(cd_cvm): () for cd_cvm in unique_ids}
+
         placeholders = ", ".join(f":cd{i}" for i in range(len(unique_ids)))
         params = {f"cd{i}": cd_cvm for i, cd_cvm in enumerate(unique_ids)}
         sql = text(

--- a/src/query_layer.py
+++ b/src/query_layer.py
@@ -98,6 +98,15 @@ COALESCE(
 )
 """
 
+_HAS_ANNUAL_HISTORY_SQL = """
+EXISTS (
+    SELECT 1
+    FROM financial_reports fr_ready
+    WHERE fr_ready."CD_CVM" = c.cd_cvm
+      AND fr_ready."PERIOD_LABEL" = CAST(fr_ready."REPORT_YEAR" AS TEXT)
+)
+"""
+
 
 def _period_sort_key(label: str) -> tuple[int, int]:
     m = re.match(r"(\d{4})", label)
@@ -180,7 +189,12 @@ class CVMQueryLayer:
             LEFT JOIN financial_reports fr ON fr."CD_CVM" = c.cd_cvm
             WHERE {where_sql}
             GROUP BY c.cd_cvm, c.company_name, c.ticker_b3, c.setor_analitico, c.setor_cvm, c.coverage_rank
-            ORDER BY c.company_name ASC
+            ORDER BY
+                CASE WHEN COUNT(fr."CD_CVM") > 0 THEN 0 ELSE 1 END ASC,
+                CASE WHEN c.coverage_rank IS NULL THEN 1 ELSE 0 END ASC,
+                c.coverage_rank ASC,
+                COUNT(fr."CD_CVM") DESC,
+                c.company_name ASC
             {paging_sql}
             """
         )
@@ -232,13 +246,20 @@ class CVMQueryLayer:
             result.setdefault(str(row["sector_name"]), []).append(int(row["REPORT_YEAR"]))
         return result
 
-    def get_company_suggestions(self, q: str, limit: int) -> pd.DataFrame:
+    def get_company_suggestions(
+        self,
+        q: str,
+        limit: int,
+        *,
+        ready_only: bool = False,
+    ) -> pd.DataFrame:
         """Returns up to `limit` companies ranked by relevance to query `q`.
 
         Ranking: exact ticker > name prefix > ticker prefix > contains match.
         Empty `q` returns the first `limit` companies alphabetically.
         """
         normalized = q.strip().lower()
+        ready_only_sql = f"WHERE {_HAS_ANNUAL_HISTORY_SQL}" if ready_only else ""
         if not normalized:
             sql = text(
                 f"""
@@ -246,11 +267,20 @@ class CVMQueryLayer:
                        COALESCE(c.ticker_b3, '') AS ticker_b3,
                        {_CANONICAL_SECTOR_SQL} AS sector_name
                 FROM companies c
+                {ready_only_sql}
                 ORDER BY c.company_name ASC
                 LIMIT :limit
                 """
             )
             return pd.read_sql(sql, self.engine, params={"limit": int(limit)}).reset_index(drop=True)
+
+        search_filters = """
+                LOWER(c.company_name) LIKE :contains
+                OR LOWER(COALESCE(c.ticker_b3, '')) LIKE :contains
+                OR CAST(c.cd_cvm AS TEXT) LIKE :contains
+        """
+        if ready_only:
+            search_filters = f"({_HAS_ANNUAL_HISTORY_SQL}) AND ({search_filters})"
 
         sql = text(
             f"""
@@ -259,9 +289,7 @@ class CVMQueryLayer:
                    {_CANONICAL_SECTOR_SQL} AS sector_name
             FROM companies c
             WHERE
-                LOWER(c.company_name) LIKE :contains
-                OR LOWER(COALESCE(c.ticker_b3, '')) LIKE :contains
-                OR CAST(c.cd_cvm AS TEXT) LIKE :contains
+                {search_filters}
             ORDER BY
                 CASE
                     WHEN LOWER(COALESCE(c.ticker_b3, '')) = :exact   THEN 0

--- a/src/read_service.py
+++ b/src/read_service.py
@@ -95,6 +95,12 @@ class CVMReadService:
     REFRESH_ESTIMATE_PROGRESS_FLOOR = 12.0
     REFRESH_ESTIMATE_PROGRESS_CEILING = 92.0
     REFRESH_ESTIMATE_PROGRESS_CAP = 96.0
+    REFRESH_QUEUE_PROGRESS_BASE = 14.0
+    REFRESH_QUEUE_PROGRESS_STEP = 4.0
+    REFRESH_QUEUE_POSITION_STEP_SECONDS = 2 * 60
+    REFRESH_RUNNING_PROGRESS_CAP = 88.0
+    REFRESH_RUNNING_STALL_SECONDS = 3 * 60
+    REFRESH_QUEUE_STALL_SECONDS = 12 * 60
 
     def __init__(self, settings: AppSettings | None = None):
         self.settings = settings or get_settings()
@@ -312,8 +318,18 @@ class CVMReadService:
         )
         return CompanyFiltersDTO(sectors=sectors)
 
-    def suggest_companies(self, q: str, limit: int) -> tuple[CompanySuggestionDTO, ...]:
-        df = self.query_layer.get_company_suggestions(q=q, limit=limit)
+    def suggest_companies(
+        self,
+        q: str,
+        limit: int,
+        *,
+        ready_only: bool = False,
+    ) -> tuple[CompanySuggestionDTO, ...]:
+        df = self.query_layer.get_company_suggestions(
+            q=q,
+            limit=limit,
+            ready_only=ready_only,
+        )
         local_items = tuple(
             CompanySuggestionDTO(
                 cd_cvm=int(row["cd_cvm"]),
@@ -323,7 +339,7 @@ class CVMReadService:
             )
             for _, row in df.iterrows()
         )
-        if not str(q or "").strip() or len(local_items) >= int(limit):
+        if ready_only or not str(q or "").strip() or len(local_items) >= int(limit):
             return local_items[: int(limit)]
 
         seen_codes = {item.cd_cvm for item in local_items}
@@ -658,19 +674,30 @@ class CVMReadService:
         )
         with self.engine.connect() as conn:
             rows = conn.execute(query, {"cd_cvm": int(cd_cvm) if cd_cvm is not None else None}).mappings().all()
+        cd_cvms = [int(row["cd_cvm"]) for row in rows]
+        active_jobs = self._load_active_refresh_jobs_map(cd_cvms)
+        readable_years_map = (
+            self.query_layer.get_company_years_map(cd_cvms)
+            if cd_cvms
+            else {}
+        )
         duration_profile = (
             self._estimate_refresh_duration_profile()
             if any(
                 str(row.get("last_status") or "").strip().lower()
                 in self.ACTIVE_REFRESH_STATUSES
                 for row in rows
-            )
+            ) or active_jobs
             else None
         )
         return [
             self._build_refresh_status_dto(
                 row,
                 duration_profile=duration_profile,
+                active_job=active_jobs.get(int(row["cd_cvm"])),
+                readable_years_count=len(
+                    readable_years_map.get(int(row["cd_cvm"]), ())
+                ),
             )
             for row in rows
         ]
@@ -680,10 +707,28 @@ class CVMReadService:
         row: dict[str, Any],
         *,
         duration_profile: dict[str, Any] | None,
+        active_job: dict[str, Any] | None,
+        readable_years_count: int,
     ) -> RefreshStatusDTO:
+        has_readable_current_data = int(readable_years_count or 0) > 0
+        latest_attempt_outcome = self._normalize_refresh_status(row.get("last_status")) or None
+        tracking_state = self._resolve_refresh_tracking_state(
+            row,
+            active_job=active_job,
+            duration_profile=duration_profile,
+            has_readable_current_data=has_readable_current_data,
+        )
         estimate = self._estimate_refresh_runtime(
             row,
             duration_profile=duration_profile,
+            active_job=active_job,
+            tracking_state=tracking_state,
+        )
+        status_reason_code, status_reason_message = self._build_refresh_status_reason(
+            row,
+            tracking_state=tracking_state,
+            active_job=active_job,
+            has_readable_current_data=has_readable_current_data,
         )
         return RefreshStatusDTO(
             cd_cvm=int(row["cd_cvm"]),
@@ -736,6 +781,21 @@ class CVMReadService:
             elapsed_seconds=estimate["elapsed_seconds"],
             estimated_completion_at=estimate["estimated_completion_at"],
             estimate_confidence=estimate["estimate_confidence"],
+            tracking_state=tracking_state,
+            progress_mode=estimate["progress_mode"],
+            is_retry_allowed=self._is_refresh_retry_allowed(
+                tracking_state=tracking_state,
+                active_job=active_job,
+            ),
+            status_reason_code=status_reason_code,
+            status_reason_message=status_reason_message,
+            has_readable_current_data=has_readable_current_data,
+            readable_years_count=int(readable_years_count or 0),
+            latest_attempt_outcome=latest_attempt_outcome,
+            source_label=self._build_refresh_source_label(
+                row.get("source_scope"),
+                has_readable_current_data=has_readable_current_data,
+            ),
         )
 
     def request_company_refresh(self, cd_cvm: int) -> RefreshDispatchDTO:
@@ -785,6 +845,11 @@ class CVMReadService:
                 job_id=None,
                 accepted_at=str(projection["accepted_at"]),
                 message=str(projection["message"]),
+                status_reason_code="already_current",
+                status_reason_message=(
+                    "Esta empresa ja estava atualizada para a janela padrao."
+                ),
+                is_retry_allowed=False,
             )
 
         job = self.refresh_job_repository.enqueue_job(
@@ -808,6 +873,11 @@ class CVMReadService:
                 job.progress_message
                 or "Solicitacao enfileirada para processamento interno."
             ),
+            status_reason_code="refresh_queued",
+            status_reason_message=(
+                "Solicitacao aceita e aguardando processamento interno."
+            ),
+            is_retry_allowed=False,
         )
 
     def request_top_ranked_historical_refresh(
@@ -1398,6 +1468,214 @@ class CVMReadService:
             for cd_cvm, years in years_map.items()
         }
 
+    @staticmethod
+    def _normalize_refresh_status(value: Any) -> str:
+        return str(value or "").strip().lower()
+
+    def _resolve_refresh_tracking_state(
+        self,
+        row: dict[str, Any],
+        *,
+        active_job: dict[str, Any] | None,
+        duration_profile: dict[str, Any] | None,
+        has_readable_current_data: bool,
+    ) -> str:
+        last_status = self._normalize_refresh_status(row.get("last_status"))
+        if last_status in {"success", "no_data", "error"}:
+            return last_status
+
+        active_state = (
+            self._normalize_refresh_status(active_job.get("state"))
+            if active_job is not None
+            else ""
+        )
+        if active_state in self.ACTIVE_REFRESH_STATUSES:
+            if self._is_refresh_tracking_stalled(
+                row,
+                active_job=active_job,
+                duration_profile=duration_profile,
+                active_state=active_state,
+            ):
+                return "stalled"
+            return active_state
+
+        if last_status in self.ACTIVE_REFRESH_STATUSES:
+            return "stalled"
+
+        return "success" if has_readable_current_data else "idle"
+
+    def _is_refresh_tracking_stalled(
+        self,
+        row: dict[str, Any],
+        *,
+        active_job: dict[str, Any] | None,
+        duration_profile: dict[str, Any] | None,
+        active_state: str,
+    ) -> bool:
+        now = datetime.now(timezone.utc)
+        if active_state == "running":
+            activity_at = (
+                self._parse_timestamp(active_job.get("heartbeat_at"))
+                or self._parse_timestamp(active_job.get("started_at"))
+                or self._parse_timestamp(row.get("heartbeat_at"))
+                or self._parse_timestamp(row.get("started_at"))
+                or self._parse_timestamp(active_job.get("requested_at"))
+                or self._parse_timestamp(row.get("last_attempt_at"))
+            )
+            if activity_at is None:
+                return False
+            return (
+                now - activity_at
+            ).total_seconds() >= self.REFRESH_RUNNING_STALL_SECONDS
+
+        if active_state == "queued":
+            requested_at = (
+                self._parse_timestamp(active_job.get("requested_at"))
+                or self._parse_timestamp(row.get("last_attempt_at"))
+            )
+            if requested_at is None:
+                return False
+            queue_position = (
+                int(row["queue_position"])
+                if row.get("queue_position") is not None
+                else 0
+            )
+            typical_total_seconds = int(
+                round(
+                    float(
+                        (duration_profile or {}).get("typical_total_seconds")
+                        or self.REFRESH_ESTIMATE_DEFAULT_TOTAL_SECONDS
+                    )
+                )
+            )
+            threshold_seconds = max(
+                self.REFRESH_QUEUE_STALL_SECONDS,
+                typical_total_seconds
+                + 120
+                + (min(max(queue_position, 0), 5) * self.REFRESH_QUEUE_POSITION_STEP_SECONDS),
+            )
+            return (
+                now - requested_at
+            ).total_seconds() >= threshold_seconds
+
+        return False
+
+    def _build_refresh_status_reason(
+        self,
+        row: dict[str, Any],
+        *,
+        tracking_state: str,
+        active_job: dict[str, Any] | None,
+        has_readable_current_data: bool,
+    ) -> tuple[str, str]:
+        last_status = self._normalize_refresh_status(row.get("last_status"))
+        progress_message = self._clean_optional_text(row.get("progress_message"))
+        last_error = self._clean_optional_text(row.get("last_error"))
+        normalized_progress_message = str(progress_message or "").lower()
+        normalized_last_error = str(last_error or "").lower()
+
+        if tracking_state == "queued":
+            return (
+                "refresh_queued",
+                "Solicitacao recebida e aguardando processamento interno.",
+            )
+
+        if tracking_state == "running":
+            return (
+                "refresh_running",
+                "Os demonstrativos desta companhia estao sendo atualizados agora.",
+            )
+
+        if tracking_state == "stalled":
+            if active_job is None and last_status in self.ACTIVE_REFRESH_STATUSES:
+                return (
+                    "refresh_tracking_lost",
+                    "A ultima solicitacao nao aparece mais como ativa. Atualize o status ou tente novamente.",
+                )
+            return (
+                "refresh_stalled",
+                "A solicitacao esta acima do esperado e sem sinais recentes de progresso.",
+            )
+
+        if last_status == "success":
+            if "ja atualizada" in normalized_progress_message:
+                return (
+                    "already_current",
+                    "Esta empresa ja estava atualizada para a janela padrao.",
+                )
+            if has_readable_current_data:
+                return (
+                    "refresh_completed",
+                    "Dados prontos para leitura nesta pagina.",
+                )
+            return ("refresh_completed", "Processamento concluido.")
+
+        if last_status == "no_data":
+            if has_readable_current_data:
+                return (
+                    "no_new_financial_history",
+                    "A ultima tentativa nao encontrou novos demonstrativos, mas a leitura atual continua disponivel.",
+                )
+            return (
+                "no_financial_history_found",
+                "Ainda nao foi encontrada uma serie anual suficiente para liberar esta leitura.",
+            )
+
+        if last_status == "error":
+            if "expirou" in normalized_progress_message:
+                return (
+                    "refresh_stalled",
+                    "A solicitacao expirou antes de terminar. Voce pode tentar novamente.",
+                )
+            if "no financial rows found" in normalized_last_error:
+                return (
+                    "no_financial_history_found",
+                    "Nenhuma serie anual utilizavel foi encontrada para esta empresa.",
+                )
+            return (
+                "refresh_failed",
+                "Nao foi possivel concluir a atualizacao desta empresa agora.",
+            )
+
+        if has_readable_current_data:
+            return ("local_data_ready", "Leitura local pronta para consulta.")
+
+        return (
+            "no_local_history_yet",
+            "Esta empresa ainda nao tem historico anual processado na base local.",
+        )
+
+    @staticmethod
+    def _build_refresh_source_label(
+        source_scope: Any,
+        *,
+        has_readable_current_data: bool,
+    ) -> str:
+        normalized_scope = str(source_scope or "").strip().lower()
+        if normalized_scope == "local":
+            return (
+                "Base local materializada"
+                if has_readable_current_data
+                else "Base local"
+            )
+        if normalized_scope == "on_demand":
+            return "Solicitacao on-demand"
+        if normalized_scope == "on_demand_bootstrap":
+            return "Primeira carga on-demand"
+        if normalized_scope == "ranked_backfill":
+            return "Backfill historico"
+        return "Leitura CVM processada"
+
+    @staticmethod
+    def _is_refresh_retry_allowed(
+        *,
+        tracking_state: str,
+        active_job: dict[str, Any] | None,
+    ) -> bool:
+        if tracking_state in {"no_data", "error"}:
+            return True
+        return tracking_state == "stalled" and active_job is None
+
     def _load_refresh_status_map(
         self,
         cd_cvms: list[int] | None = None,
@@ -1421,6 +1699,51 @@ class CVMReadService:
         with self.engine.connect() as conn:
             rows = conn.execute(query, params).mappings().all()
         return {int(row["cd_cvm"]): dict(row) for row in rows}
+
+    def _load_active_refresh_jobs_map(
+        self,
+        cd_cvms: list[int] | None = None,
+    ) -> dict[int, dict[str, Any]]:
+        if not inspect(self.engine).has_table("refresh_jobs"):
+            return {}
+
+        if cd_cvms:
+            query = text(
+                """
+                SELECT *
+                FROM refresh_jobs
+                WHERE state IN ('queued', 'running')
+                  AND cd_cvm IN :cd_cvms
+                ORDER BY
+                    CASE WHEN state = 'running' THEN 0 ELSE 1 END,
+                    requested_at ASC,
+                    id ASC
+                """
+            ).bindparams(bindparam("cd_cvms", expanding=True))
+            params = {"cd_cvms": [int(cd_cvm) for cd_cvm in cd_cvms]}
+        else:
+            query = text(
+                """
+                SELECT *
+                FROM refresh_jobs
+                WHERE state IN ('queued', 'running')
+                ORDER BY
+                    CASE WHEN state = 'running' THEN 0 ELSE 1 END,
+                    requested_at ASC,
+                    id ASC
+                """
+            )
+            params = {}
+
+        with self.engine.connect() as conn:
+            rows = conn.execute(query, params).mappings().all()
+
+        active_jobs: dict[int, dict[str, Any]] = {}
+        for row in rows:
+            cd_cvm = int(row["cd_cvm"])
+            if cd_cvm not in active_jobs:
+                active_jobs[cd_cvm] = dict(row)
+        return active_jobs
 
     def _default_refresh_year_span(self) -> int:
         start_year, end_year = self._resolve_refresh_range(
@@ -1495,9 +1818,15 @@ class CVMReadService:
         row: dict[str, Any],
         *,
         duration_profile: dict[str, Any] | None,
+        active_job: dict[str, Any] | None,
+        tracking_state: str,
     ) -> dict[str, Any]:
-        last_status = str(row.get("last_status") or "").strip().lower()
-        if last_status not in self.ACTIVE_REFRESH_STATUSES:
+        active_state = (
+            self._normalize_refresh_status(active_job.get("state"))
+            if active_job is not None
+            else self._normalize_refresh_status(row.get("last_status"))
+        )
+        if tracking_state not in {"queued", "running", "stalled"}:
             return {
                 "estimated_progress_pct": None,
                 "estimated_eta_seconds": None,
@@ -1505,13 +1834,55 @@ class CVMReadService:
                 "elapsed_seconds": None,
                 "estimated_completion_at": None,
                 "estimate_confidence": None,
+                "progress_mode": "none",
             }
 
-        real_progress_estimate = self._estimate_refresh_runtime_from_real_progress(row)
+        real_progress_estimate = self._estimate_refresh_runtime_from_real_progress(
+            row,
+            tracking_state=tracking_state,
+        )
         if real_progress_estimate is not None:
             return real_progress_estimate
 
-        attempted_at = self._parse_timestamp(row.get("last_attempt_at"))
+        attempted_at = (
+            self._parse_timestamp(row.get("started_at"))
+            or self._parse_timestamp(row.get("last_attempt_at"))
+            or (
+                self._parse_timestamp(active_job.get("requested_at"))
+                if active_job is not None
+                else None
+            )
+        )
+        now = datetime.now(timezone.utc)
+        elapsed_seconds = (
+            max(0, int(round((now - attempted_at).total_seconds())))
+            if attempted_at is not None
+            else None
+        )
+
+        if active_state == "queued" and tracking_state != "running":
+            queue_position = (
+                int(row["queue_position"])
+                if row.get("queue_position") is not None
+                else 0
+            )
+            estimated_progress_pct = min(
+                32.0,
+                self.REFRESH_QUEUE_PROGRESS_BASE
+                + (min(max(queue_position, 0), 4) * self.REFRESH_QUEUE_PROGRESS_STEP),
+            )
+            if tracking_state == "stalled":
+                estimated_progress_pct = max(estimated_progress_pct, 22.0)
+            return {
+                "estimated_progress_pct": round(float(estimated_progress_pct), 1),
+                "estimated_eta_seconds": None,
+                "estimated_total_seconds": None,
+                "elapsed_seconds": elapsed_seconds,
+                "estimated_completion_at": None,
+                "estimate_confidence": "low",
+                "progress_mode": "stalled" if tracking_state == "stalled" else "queue",
+            }
+
         profile = duration_profile or self._estimate_refresh_duration_profile()
         typical_year_span = max(
             1.0,
@@ -1528,13 +1899,6 @@ class CVMReadService:
         estimated_total_seconds = max(
             60,
             int(round(typical_total_seconds * (current_year_span / typical_year_span))),
-        )
-
-        now = datetime.now(timezone.utc)
-        elapsed_seconds = (
-            max(0, int(round((now - attempted_at).total_seconds())))
-            if attempted_at is not None
-            else None
         )
         estimated_completion_at = (
             (
@@ -1560,13 +1924,24 @@ class CVMReadService:
             )
             if ratio > 1.0:
                 estimated_progress_pct = min(
-                    self.REFRESH_ESTIMATE_PROGRESS_CAP,
+                    self.REFRESH_RUNNING_PROGRESS_CAP,
                     estimated_progress_pct + min(6.0, (ratio - 1.0) * 10.0),
                 )
             estimated_eta_seconds = max(0, estimated_total_seconds - elapsed_seconds)
 
-        if last_status == "running":
+        if active_state == "running":
             estimated_progress_pct = max(estimated_progress_pct, 28.0)
+
+        if tracking_state == "stalled":
+            return {
+                "estimated_progress_pct": round(float(estimated_progress_pct), 1),
+                "estimated_eta_seconds": None,
+                "estimated_total_seconds": int(estimated_total_seconds),
+                "elapsed_seconds": elapsed_seconds,
+                "estimated_completion_at": None,
+                "estimate_confidence": str(profile.get("confidence") or "low"),
+                "progress_mode": "stalled",
+            }
 
         return {
             "estimated_progress_pct": round(float(estimated_progress_pct), 1),
@@ -1575,11 +1950,14 @@ class CVMReadService:
             "elapsed_seconds": elapsed_seconds,
             "estimated_completion_at": estimated_completion_at,
             "estimate_confidence": str(profile.get("confidence") or "low"),
+            "progress_mode": "time_window",
         }
 
     def _estimate_refresh_runtime_from_real_progress(
         self,
         row: dict[str, Any],
+        *,
+        tracking_state: str,
     ) -> dict[str, Any] | None:
         stage = str(row.get("stage") or "").strip().lower()
         if stage not in REFRESH_STAGE_WEIGHTS:
@@ -1633,6 +2011,10 @@ class CVMReadService:
                     started_at + timedelta(seconds=int(estimated_total_seconds))
                 ).replace(microsecond=0).isoformat()
 
+        if tracking_state == "stalled":
+            estimated_eta_seconds = None
+            estimated_completion_at = None
+
         return {
             "estimated_progress_pct": round(float(progress_pct), 1),
             "estimated_eta_seconds": estimated_eta_seconds,
@@ -1640,6 +2022,9 @@ class CVMReadService:
             "elapsed_seconds": elapsed_seconds,
             "estimated_completion_at": estimated_completion_at,
             "estimate_confidence": "high",
+            "progress_mode": (
+                "stalled" if tracking_state == "stalled" else "real_progress"
+            ),
         }
 
     def _estimate_refresh_throughput(self) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- route browser-side company suggestions through a same-origin web proxy with graceful fallback
- make refresh and freshness states truthful with additive backend semantics for stalled, mixed-outcome, and readable-data cases
- improve on-demand discovery, no-data guidance, and compare/mobile UX while adding browser and contract coverage

## Compatibilidade
- additive-only: os contratos tocados nesta PR apenas adicionam campos e semantica de leitura; nao removem campos existentes nem alteram comportamento obrigatorio para consumidores atuais.

## Validation
- pytest apps/api/tests/test_api_contract.py
- npm run typecheck
- npm run test:unit
- npm run test:e2e -- tests/smoke.spec.ts tests/compare.spec.ts

Closes #173