### PR TITLE
[Task] FRONTEND: remove stale company-detail handoff

### DIFF
--- a/apps/web/app/empresas/[cd_cvm]/page.tsx
+++ b/apps/web/app/empresas/[cd_cvm]/page.tsx
@@ -26,6 +26,7 @@ import {
   getUserFacingErrorMessage,
   isApiClientError,
 } from "@/lib/api";
+import { getReadableCompanyYears } from "@/lib/company-detail-handoff";
 import { DETAIL_TABS, STATEMENT_OPTIONS } from "@/lib/constants";
 import {
   coerceDetailTab,
@@ -134,14 +135,16 @@ export default async function EmpresaDetailPage({
     notFound();
   }
 
-  if (availableYears.length === 0) {
+  const readableYears = getReadableCompanyYears(company, availableYears);
+
+  if (readableYears.length === 0) {
     return <CompanyNoDataPage company={company} />;
   }
 
   const currentTab = coerceDetailTab(getFirstParam(resolvedSearchParams.aba));
   const currentStatement = coerceStatement(getFirstParam(resolvedSearchParams.stmt));
   const selectedYears = normalizeSelectedYears(
-    availableYears,
+    readableYears,
     getFirstParam(resolvedSearchParams.anos),
   );
 
@@ -186,7 +189,7 @@ export default async function EmpresaDetailPage({
 
       <CompanyPeriodPreset
         pathname={pathname}
-        availableYears={availableYears}
+        availableYears={readableYears}
         selectedYears={selectedYears}
       />
 

--- a/apps/web/components/company/company-freshness-card.tsx
+++ b/apps/web/components/company/company-freshness-card.tsx
@@ -169,13 +169,18 @@ export async function CompanyFreshnessCard({
 
   const summary = getSummaryCopy(freshness);
   const statusBadge = getStatusBadge(freshness);
-  const lastSuccessAt = freshness?.last_success_at ?? null;
+  const materializedAt =
+    freshness?.read_model_updated_at ?? freshness?.last_success_at ?? null;
   const sourceLabel = freshness?.source_label ?? "Leitura CVM processada";
-  const relativeLabel = lastSuccessAt ? formatRelative(lastSuccessAt) : null;
-  const absoluteLabel = lastSuccessAt ? formatAbsolute(lastSuccessAt) : null;
+  const relativeLabel = materializedAt ? formatRelative(materializedAt) : null;
+  const absoluteLabel = materializedAt ? formatAbsolute(materializedAt) : null;
   const readableYearsLabel =
     freshness?.has_readable_current_data
-      ? `${freshness.readable_years_count} ano${freshness.readable_years_count === 1 ? "" : "s"} anuais locais`
+      ? `${freshness.readable_years_count} ano${freshness.readable_years_count === 1 ? "" : "s"} anuais locais${
+          freshness.latest_readable_year
+            ? `, ultimo ${freshness.latest_readable_year}`
+            : ""
+        }`
       : "Nenhum ano anual local";
 
   return (

--- a/apps/web/components/company/company-request-refresh.tsx
+++ b/apps/web/components/company/company-request-refresh.tsx
@@ -15,6 +15,7 @@ import {
   getUserFacingErrorMessage,
   isApiClientError,
 } from "@/lib/api";
+import { getReadableRefreshSuccessKey } from "@/lib/company-detail-handoff";
 import {
   applyManualStatusFailure,
   applyRefreshPollFailure,
@@ -54,6 +55,12 @@ export function CompanyRequestRefresh({
   const isMountedRef = useRef(true);
   const reloadTimerRef = useRef<number | null>(null);
   const view = getRefreshViewModel(state);
+  const successHandoffKey =
+    state.phase === "success"
+      ? state.currentItem
+        ? getReadableRefreshSuccessKey(state.currentItem)
+        : "already-current"
+      : null;
 
   const pollRefreshStatus = useCallback(
     async (source: "auto" | "manual") => {
@@ -111,9 +118,11 @@ export function CompanyRequestRefresh({
   }, [initialStatus]);
 
   useEffect(() => {
-    if (state.phase !== "success") {
+    if (!successHandoffKey) {
       return;
     }
+
+    router.refresh();
 
     reloadTimerRef.current = window.setTimeout(() => {
       router.refresh();
@@ -125,7 +134,7 @@ export function CompanyRequestRefresh({
         reloadTimerRef.current = null;
       }
     };
-  }, [router, state.phase]);
+  }, [router, successHandoffKey]);
 
   useEffect(() => {
     if (!isAutoPollingPhase(state.phase)) {

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -69,6 +69,10 @@ export type CompanyInfo = {
   sector_slug: string;
   company_type: string | null;
   ticker_b3: string | null;
+  read_model_updated_at: string | null;
+  has_readable_current_data: boolean;
+  readable_years_count: number;
+  latest_readable_year: number | null;
 };
 
 export type RefreshDispatchResponse = {
@@ -103,6 +107,7 @@ export type RefreshStatusItem = {
   heartbeat_at: string | null;
   finished_at: string | null;
   updated_at: string | null;
+  read_model_updated_at: string | null;
   estimated_progress_pct: number | null;
   estimated_eta_seconds: number | null;
   estimated_total_seconds: number | null;
@@ -116,12 +121,27 @@ export type RefreshStatusItem = {
   status_reason_message: string | null;
   has_readable_current_data: boolean;
   readable_years_count: number;
+  latest_readable_year: number | null;
   latest_attempt_outcome: string | null;
   source_label: string | null;
 };
 
+type RawCompanyInfo = Omit<
+  CompanyInfo,
+  | "read_model_updated_at"
+  | "has_readable_current_data"
+  | "readable_years_count"
+  | "latest_readable_year"
+> & {
+  read_model_updated_at?: string | null;
+  has_readable_current_data?: boolean;
+  readable_years_count?: number;
+  latest_readable_year?: number | null;
+};
+
 type RawRefreshStatusItem = Omit<
   RefreshStatusItem,
+  | "read_model_updated_at"
   | "estimated_progress_pct"
   | "estimated_eta_seconds"
   | "estimated_total_seconds"
@@ -135,6 +155,7 @@ type RawRefreshStatusItem = Omit<
   | "status_reason_message"
   | "has_readable_current_data"
   | "readable_years_count"
+  | "latest_readable_year"
   | "latest_attempt_outcome"
   | "source_label"
 > & {
@@ -147,6 +168,7 @@ type RawRefreshStatusItem = Omit<
   started_at?: string | null;
   heartbeat_at?: string | null;
   finished_at?: string | null;
+  read_model_updated_at?: string | null;
   estimated_progress_pct?: number | null;
   estimated_eta_seconds?: number | null;
   estimated_total_seconds?: number | null;
@@ -160,6 +182,7 @@ type RawRefreshStatusItem = Omit<
   status_reason_message?: string | null;
   has_readable_current_data?: boolean;
   readable_years_count?: number;
+  latest_readable_year?: number | null;
   latest_attempt_outcome?: string | null;
   source_label?: string | null;
 };
@@ -413,13 +436,18 @@ function isCompanySuggestionsResponse(value: unknown): value is CompanySuggestio
   );
 }
 
-function isCompanyInfo(value: unknown): value is CompanyInfo {
+function isCompanyInfo(value: unknown): value is RawCompanyInfo {
   return (
     isRecord(value) &&
     typeof value.cd_cvm === "number" &&
     typeof value.company_name === "string" &&
     typeof value.sector_name === "string" &&
-    typeof value.sector_slug === "string"
+    typeof value.sector_slug === "string" &&
+    isOptionalNullableString(value.read_model_updated_at) &&
+    isOptionalBoolean(value.has_readable_current_data) &&
+    (value.readable_years_count === undefined ||
+      typeof value.readable_years_count === "number") &&
+    isOptionalNullableNumber(value.latest_readable_year)
   );
 }
 
@@ -495,6 +523,7 @@ function isRefreshStatusItem(value: unknown): value is RawRefreshStatusItem {
     isOptionalNullableString(value.heartbeat_at) &&
     isOptionalNullableString(value.finished_at) &&
     isNullableString(value.updated_at) &&
+    isOptionalNullableString(value.read_model_updated_at) &&
     isOptionalNullableNumber(value.estimated_progress_pct) &&
     isOptionalNullableNumber(value.estimated_eta_seconds) &&
     isOptionalNullableNumber(value.estimated_total_seconds) &&
@@ -509,6 +538,7 @@ function isRefreshStatusItem(value: unknown): value is RawRefreshStatusItem {
     isOptionalBoolean(value.has_readable_current_data) &&
     (value.readable_years_count === undefined ||
       typeof value.readable_years_count === "number") &&
+    isOptionalNullableNumber(value.latest_readable_year) &&
     isOptionalNullableString(value.latest_attempt_outcome) &&
     isOptionalNullableString(value.source_label)
   );
@@ -532,6 +562,7 @@ function normalizeRefreshStatusItem(
     started_at: item.started_at ?? null,
     heartbeat_at: item.heartbeat_at ?? null,
     finished_at: item.finished_at ?? null,
+    read_model_updated_at: item.read_model_updated_at ?? null,
     estimated_progress_pct: item.estimated_progress_pct ?? null,
     estimated_eta_seconds: item.estimated_eta_seconds ?? null,
     estimated_total_seconds: item.estimated_total_seconds ?? null,
@@ -545,8 +576,19 @@ function normalizeRefreshStatusItem(
     status_reason_message: item.status_reason_message ?? null,
     has_readable_current_data: item.has_readable_current_data ?? false,
     readable_years_count: item.readable_years_count ?? 0,
+    latest_readable_year: item.latest_readable_year ?? null,
     latest_attempt_outcome: item.latest_attempt_outcome ?? null,
     source_label: item.source_label ?? null,
+  };
+}
+
+function normalizeCompanyInfo(company: RawCompanyInfo): CompanyInfo {
+  return {
+    ...company,
+    read_model_updated_at: company.read_model_updated_at ?? null,
+    has_readable_current_data: company.has_readable_current_data ?? false,
+    readable_years_count: company.readable_years_count ?? 0,
+    latest_readable_year: company.latest_readable_year ?? null,
   };
 }
 
@@ -984,12 +1026,14 @@ export async function fetchCompanyInfo(
   cdCvm: number,
   options?: { request?: ApiReadRequestInit },
 ): Promise<CompanyInfo | null> {
-  return apiFetch<CompanyInfo>(`/companies/${cdCvm}`, {
+  const company = await apiFetch<RawCompanyInfo>(`/companies/${cdCvm}`, {
     allowNotFound: true,
     request: options?.request ?? COMPANY_INFO_API_READ,
     validate: isCompanyInfo,
     invalidResponseMessage: "A API retornou um detalhe de empresa invalido.",
   });
+
+  return company ? normalizeCompanyInfo(company) : null;
 }
 
 export async function fetchCompanyYears(

--- a/apps/web/lib/company-detail-handoff.ts
+++ b/apps/web/lib/company-detail-handoff.ts
@@ -1,0 +1,71 @@
+import type { CompanyInfo, RefreshStatusItem } from "@/lib/api";
+
+function normalizeStatus(value: string | null | undefined): string {
+  return String(value || "").trim().toLowerCase();
+}
+
+function hasReadableYearSignal(item: RefreshStatusItem): boolean {
+  return (
+    item.readable_years_count > 0 ||
+    typeof item.latest_readable_year === "number"
+  );
+}
+
+export function getReadableCompanyYears(
+  company: CompanyInfo,
+  availableYears: number[],
+): number[] {
+  const normalizedYears = Array.from(
+    new Set(availableYears.filter((year) => Number.isInteger(year))),
+  ).sort((a, b) => a - b);
+
+  if (normalizedYears.length > 0) {
+    return normalizedYears;
+  }
+
+  if (
+    company.has_readable_current_data &&
+    typeof company.latest_readable_year === "number"
+  ) {
+    return [company.latest_readable_year];
+  }
+
+  return [];
+}
+
+export function isReadableRefreshSuccess(
+  item: RefreshStatusItem | null | undefined,
+): boolean {
+  if (!item?.has_readable_current_data || !hasReadableYearSignal(item)) {
+    return false;
+  }
+
+  const trackingState = normalizeStatus(item.tracking_state);
+  const latestOutcome = normalizeStatus(item.latest_attempt_outcome);
+  const lastStatus = normalizeStatus(item.last_status);
+
+  return (
+    trackingState === "success" ||
+    latestOutcome === "success" ||
+    lastStatus === "success"
+  );
+}
+
+export function getReadableRefreshSuccessKey(
+  item: RefreshStatusItem | null | undefined,
+): string | null {
+  if (!item || !isReadableRefreshSuccess(item)) {
+    return null;
+  }
+
+  return [
+    item.cd_cvm,
+    item.read_model_updated_at ??
+      item.last_success_at ??
+      item.finished_at ??
+      item.updated_at ??
+      "readable",
+    item.latest_readable_year ?? "yearless",
+    item.job_id ?? "no-job",
+  ].join(":");
+}

--- a/apps/web/lib/company-refresh-state.ts
+++ b/apps/web/lib/company-refresh-state.ts
@@ -1,4 +1,5 @@
 import type { RefreshStatusItem } from "@/lib/api";
+import { isReadableRefreshSuccess } from "./company-detail-handoff.ts";
 
 export type RefreshPhase =
   | "idle"
@@ -503,6 +504,25 @@ export function hydrateRefreshState(
     };
   }
 
+  if (trackingState === "success") {
+    if (isReadableRefreshSuccess(initialStatus)) {
+      return createIdleRefreshState();
+    }
+
+    return {
+      phase: "delayed",
+      startedAt: parseTimestamp(initialStatus.last_attempt_at) ?? nowMs,
+      currentItem: initialStatus,
+      lastKnownActiveItem: null,
+      failureCount: 0,
+      canRequestAgain: initialStatus.is_retry_allowed ?? false,
+      notice:
+        initialStatus.status_reason_message ??
+        "Atualizacao concluida, aguardando a leitura ficar disponivel.",
+      terminalMessage: null,
+    };
+  }
+
   if (hasReadableData(initialStatus)) {
     return createIdleRefreshState();
   }
@@ -677,6 +697,20 @@ export function applyRefreshStatusResult(
   const trackingState = getTrackingState(item);
 
   if (trackingState === "success") {
+    if (!isReadableRefreshSuccess(item)) {
+      return {
+        ...state,
+        phase: "delayed",
+        currentItem: item,
+        failureCount: 0,
+        canRequestAgain: item.is_retry_allowed ?? false,
+        notice:
+          item.status_reason_message ??
+          "Atualizacao concluida, aguardando a leitura ficar disponivel.",
+        terminalMessage: null,
+      };
+    }
+
     return {
       ...state,
       phase: "success",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "eslint",
     "typecheck": "tsc --noEmit",
-    "test:unit": "node --experimental-strip-types --experimental-specifier-resolution=node --test tests/api-client.test.ts tests/companies-page-data.test.ts tests/company-period-range.test.ts tests/company-refresh-state.test.ts tests/compare-utils.test.ts tests/compare-page-data.test.ts tests/sectors-page-data.test.ts",
+    "test:unit": "node --experimental-strip-types --experimental-specifier-resolution=node --test tests/api-client.test.ts tests/companies-page-data.test.ts tests/company-detail-handoff.test.ts tests/company-period-range.test.ts tests/company-refresh-state.test.ts tests/compare-utils.test.ts tests/compare-page-data.test.ts tests/sectors-page-data.test.ts",
     "test:e2e": "playwright test"
   },
   "dependencies": {

--- a/apps/web/tests/api-client.test.ts
+++ b/apps/web/tests/api-client.test.ts
@@ -6,6 +6,7 @@ import {
   fetchCompanies,
   fetchCompanyFilters,
   fetchCompanyFreshness,
+  fetchCompanyInfo,
   fetchCompanyKpis,
   fetchCompanySuggestionsRoute,
   fetchCompanyStatement,
@@ -229,6 +230,87 @@ test("fetchCompanySuggestionsRoute forwards ready-only compare lookups", async (
       String(capturedInput),
       /\/api\/company-search\?q=vale&limit=6&ready_only=1$/,
     );
+  } finally {
+    restore();
+  }
+});
+
+test("fetchCompanyInfo accepts readable handoff fields from company detail", async () => {
+  let capturedInit: RequestInit | undefined;
+  const restore = withFetchMock((async (_input, init) => {
+    capturedInit = init;
+
+    return new Response(
+      JSON.stringify({
+        cd_cvm: 9512,
+        company_name: "PETROBRAS",
+        nome_comercial: "Petrobras",
+        cnpj: "33.000.167/0001-01",
+        setor_cvm: "Energia",
+        setor_analitico: "Energia",
+        sector_name: "Energia",
+        sector_slug: "energia",
+        company_type: "comercial",
+        ticker_b3: "PETR4",
+        read_model_updated_at: "2026-04-21T12:05:00+00:00",
+        has_readable_current_data: true,
+        readable_years_count: 2,
+        latest_readable_year: 2024,
+      }),
+      {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+        },
+      },
+    );
+  }) as FetchMock);
+
+  try {
+    const payload = await fetchCompanyInfo(9512, {
+      request: { cache: "no-store" },
+    });
+
+    assert.equal(capturedInit?.cache, "no-store");
+    assert.equal(payload?.has_readable_current_data, true);
+    assert.equal(payload?.readable_years_count, 2);
+    assert.equal(payload?.latest_readable_year, 2024);
+    assert.equal(payload?.read_model_updated_at, "2026-04-21T12:05:00+00:00");
+  } finally {
+    restore();
+  }
+});
+
+test("fetchCompanyInfo normalizes missing readable handoff fields", async () => {
+  const restore = withFetchMock((async () =>
+    new Response(
+      JSON.stringify({
+        cd_cvm: 19348,
+        company_name: "ITAU UNIBANCO HOLDING S.A.",
+        nome_comercial: "Itau Unibanco",
+        cnpj: "60.872.504/0001-23",
+        setor_cvm: "Financeiro",
+        setor_analitico: null,
+        sector_name: "Financeiro",
+        sector_slug: "financeiro",
+        company_type: "comercial",
+        ticker_b3: "ITUB4",
+      }),
+      {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+        },
+      },
+    )) as FetchMock);
+
+  try {
+    const payload = await fetchCompanyInfo(19348);
+
+    assert.equal(payload?.has_readable_current_data, false);
+    assert.equal(payload?.readable_years_count, 0);
+    assert.equal(payload?.latest_readable_year, null);
+    assert.equal(payload?.read_model_updated_at, null);
   } finally {
     restore();
   }
@@ -536,6 +618,7 @@ test("fetchRefreshStatus accepts estimated progress fields from the API", async 
           heartbeat_at: "2026-04-21T12:04:00+00:00",
           finished_at: null,
           updated_at: "2026-04-21T12:00:00+00:00",
+          read_model_updated_at: "2026-04-21T12:05:00+00:00",
           estimated_progress_pct: 31.4,
           estimated_eta_seconds: 840,
           estimated_total_seconds: 1260,
@@ -549,6 +632,7 @@ test("fetchRefreshStatus accepts estimated progress fields from the API", async 
           status_reason_message: "Solicitacao recebida e aguardando processamento interno.",
           has_readable_current_data: false,
           readable_years_count: 0,
+          latest_readable_year: 2024,
           latest_attempt_outcome: "queued",
           source_label: "Solicitacao on-demand",
         },
@@ -576,6 +660,8 @@ test("fetchRefreshStatus accepts estimated progress fields from the API", async 
     assert.equal(payload[0]?.progress_mode, "real_progress");
     assert.equal(payload[0]?.status_reason_code, "refresh_queued");
     assert.equal(payload[0]?.has_readable_current_data, false);
+    assert.equal(payload[0]?.latest_readable_year, 2024);
+    assert.equal(payload[0]?.read_model_updated_at, "2026-04-21T12:05:00+00:00");
     assert.equal(payload[0]?.source_label, "Solicitacao on-demand");
   } finally {
     restore();
@@ -627,6 +713,8 @@ test("fetchRefreshStatus normalizes missing estimate fields from legacy payloads
     assert.equal(payload[0]?.is_retry_allowed, false);
     assert.equal(payload[0]?.has_readable_current_data, false);
     assert.equal(payload[0]?.readable_years_count, 0);
+    assert.equal(payload[0]?.latest_readable_year, null);
+    assert.equal(payload[0]?.read_model_updated_at, null);
   } finally {
     restore();
   }
@@ -669,6 +757,8 @@ test("fetchCompanyFreshness normalizes missing estimate fields from legacy API p
     assert.equal(payload?.tracking_state, null);
     assert.equal(payload?.status_reason_message, null);
     assert.equal(payload?.has_readable_current_data, false);
+    assert.equal(payload?.latest_readable_year, null);
+    assert.equal(payload?.read_model_updated_at, null);
   } finally {
     restore();
   }

--- a/apps/web/tests/company-detail-handoff.test.ts
+++ b/apps/web/tests/company-detail-handoff.test.ts
@@ -1,0 +1,132 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { CompanyInfo, RefreshStatusItem } from "../lib/api.ts";
+import {
+  getReadableCompanyYears,
+  getReadableRefreshSuccessKey,
+  isReadableRefreshSuccess,
+} from "../lib/company-detail-handoff.ts";
+
+function buildCompanyInfo(overrides: Partial<CompanyInfo> = {}): CompanyInfo {
+  return {
+    cd_cvm: 9512,
+    company_name: "PETROBRAS",
+    nome_comercial: "Petrobras",
+    cnpj: "33.000.167/0001-01",
+    setor_cvm: "Energia",
+    setor_analitico: "Energia",
+    sector_name: "Energia",
+    sector_slug: "energia",
+    company_type: "comercial",
+    ticker_b3: "PETR4",
+    read_model_updated_at: null,
+    has_readable_current_data: false,
+    readable_years_count: 0,
+    latest_readable_year: null,
+    ...overrides,
+  };
+}
+
+function buildRefreshStatusItem(
+  overrides: Partial<RefreshStatusItem> = {},
+): RefreshStatusItem {
+  return {
+    cd_cvm: 9512,
+    company_name: "PETROBRAS",
+    source_scope: "on_demand",
+    job_id: "job-9512",
+    stage: null,
+    queue_position: null,
+    last_attempt_at: "2026-04-21T12:00:00+00:00",
+    last_success_at: "2026-04-21T12:05:00+00:00",
+    last_status: "success",
+    last_error: null,
+    last_start_year: 2010,
+    last_end_year: 2024,
+    last_rows_inserted: 120,
+    progress_current: null,
+    progress_total: null,
+    progress_message: null,
+    started_at: "2026-04-21T12:00:00+00:00",
+    heartbeat_at: "2026-04-21T12:04:00+00:00",
+    finished_at: "2026-04-21T12:05:00+00:00",
+    updated_at: "2026-04-21T12:05:01+00:00",
+    read_model_updated_at: "2026-04-21T12:05:02+00:00",
+    estimated_progress_pct: null,
+    estimated_eta_seconds: null,
+    estimated_total_seconds: null,
+    elapsed_seconds: null,
+    estimated_completion_at: null,
+    estimate_confidence: null,
+    tracking_state: "success",
+    progress_mode: "none",
+    is_retry_allowed: false,
+    status_reason_code: "refresh_completed",
+    status_reason_message: "Dados prontos para leitura nesta pagina.",
+    has_readable_current_data: true,
+    readable_years_count: 2,
+    latest_readable_year: 2024,
+    latest_attempt_outcome: "success",
+    source_label: "Base local materializada",
+    ...overrides,
+  };
+}
+
+test("getReadableCompanyYears keeps explicit years when the years endpoint is ready", () => {
+  const years = getReadableCompanyYears(
+    buildCompanyInfo({
+      has_readable_current_data: true,
+      readable_years_count: 2,
+      latest_readable_year: 2024,
+    }),
+    [2024, 2023, 2024],
+  );
+
+  assert.deepEqual(years, [2023, 2024]);
+});
+
+test("getReadableCompanyYears falls back to company detail readable metadata", () => {
+  const years = getReadableCompanyYears(
+    buildCompanyInfo({
+      has_readable_current_data: true,
+      readable_years_count: 1,
+      latest_readable_year: 2024,
+    }),
+    [],
+  );
+
+  assert.deepEqual(years, [2024]);
+});
+
+test("getReadableCompanyYears stays empty without a readable completion signal", () => {
+  const years = getReadableCompanyYears(buildCompanyInfo(), []);
+
+  assert.deepEqual(years, []);
+});
+
+test("isReadableRefreshSuccess requires terminal success and readable data", () => {
+  assert.equal(isReadableRefreshSuccess(buildRefreshStatusItem()), true);
+  assert.equal(
+    isReadableRefreshSuccess(
+      buildRefreshStatusItem({ has_readable_current_data: false }),
+    ),
+    false,
+  );
+  assert.equal(
+    isReadableRefreshSuccess(
+      buildRefreshStatusItem({
+        tracking_state: "running",
+        latest_attempt_outcome: "queued",
+        last_status: "running",
+      }),
+    ),
+    false,
+  );
+});
+
+test("getReadableRefreshSuccessKey uses the read-model materialization stamp", () => {
+  const key = getReadableRefreshSuccessKey(buildRefreshStatusItem());
+
+  assert.equal(key, "9512:2026-04-21T12:05:02+00:00:2024:job-9512");
+});

--- a/apps/web/tests/company-refresh-state.test.ts
+++ b/apps/web/tests/company-refresh-state.test.ts
@@ -41,6 +41,7 @@ function buildRefreshStatusItem(
     heartbeat_at: null,
     finished_at: null,
     updated_at: "2026-04-21T12:00:00+00:00",
+    read_model_updated_at: null,
     estimated_progress_pct: null,
     estimated_eta_seconds: null,
     estimated_total_seconds: null,
@@ -54,6 +55,7 @@ function buildRefreshStatusItem(
     status_reason_message: null,
     has_readable_current_data: false,
     readable_years_count: 0,
+    latest_readable_year: null,
     latest_attempt_outcome: null,
     source_label: null,
     ...overrides,
@@ -339,6 +341,54 @@ test("stalled tracking state keeps a manual recovery path", () => {
     view.message,
     "A ultima solicitacao nao aparece mais como ativa. Atualize o status ou tente novamente.",
   );
+});
+
+test("technical success without readable data does not trigger success handoff", () => {
+  const state = applyRefreshStatusResult(
+    createDispatchedRefreshState(Date.now()),
+    buildRefreshStatusItem({
+      last_status: "success",
+      tracking_state: "success",
+      status_reason_message:
+        "Atualizacao concluida, aguardando a leitura ficar disponivel.",
+      has_readable_current_data: false,
+      readable_years_count: 0,
+      latest_readable_year: null,
+    }),
+    Date.now(),
+  );
+
+  assert.equal(state.phase, "delayed");
+
+  const view = getRefreshViewModel(state);
+  assert.equal(view.isDestructive, false);
+  assert.equal(view.showManualStatusButton, true);
+  assert.equal(
+    view.message,
+    "Atualizacao concluida, aguardando a leitura ficar disponivel.",
+  );
+});
+
+test("readable terminal success enters success handoff", () => {
+  const state = applyRefreshStatusResult(
+    createDispatchedRefreshState(Date.now()),
+    buildRefreshStatusItem({
+      last_status: "success",
+      tracking_state: "success",
+      status_reason_message: "Dados prontos para leitura nesta pagina.",
+      has_readable_current_data: true,
+      readable_years_count: 2,
+      latest_readable_year: 2024,
+      read_model_updated_at: "2026-04-21T12:05:00+00:00",
+    }),
+    Date.now(),
+  );
+
+  assert.equal(state.phase, "success");
+
+  const view = getRefreshViewModel(state);
+  assert.equal(view.requestButtonDisabled, true);
+  assert.equal(view.message, "Dados prontos para leitura nesta pagina.");
 });
 
 test("already_current uses the success state for immediate reload", () => {

--- a/apps/web/tests/compare-page-data.test.ts
+++ b/apps/web/tests/compare-page-data.test.ts
@@ -20,6 +20,10 @@ function buildCompany(
     sector_slug: "energia",
     company_type: "comercial",
     ticker_b3: ticker,
+    read_model_updated_at: null,
+    has_readable_current_data: true,
+    readable_years_count: 2,
+    latest_readable_year: 2024,
   };
 }
 

--- a/apps/web/tests/compare-utils.test.ts
+++ b/apps/web/tests/compare-utils.test.ts
@@ -26,6 +26,10 @@ function buildCompany(
     sector_slug: "energia",
     company_type: "comercial",
     ticker_b3: ticker,
+    read_model_updated_at: null,
+    has_readable_current_data: true,
+    readable_years_count: 1,
+    latest_readable_year: 2024,
   };
 }
 


### PR DESCRIPTION
Closes #176

## Summary
- Consume the readable completion fields from #175 on company detail and refresh-status payloads.
- Refresh the company route immediately when polling reaches a terminal readable success, with a delayed second refresh as a fallback.
- Prevent non-readable technical success payloads from showing the final success handoff, and keep them in a non-destructive delayed state instead.
- Allow the company detail page to leave the no-data surface when `/companies/{cd_cvm}` reports a readable current model even if `/years` is momentarily stale.
- Update the freshness card to display read-model materialization timing and latest readable year.

## Validation
- `npm run test:unit` -> 68 passed
- `npm run typecheck`
- `npm run lint`
- `npm run build`