### PR TITLE
[Task] BACKEND: finalize refresh reason taxonomy

### DIFF
--- a/apps/api/app/presenters.py
+++ b/apps/api/app/presenters.py
@@ -78,6 +78,8 @@ class CompanyInfoPayload(BaseModel):
     has_readable_current_data: bool = False
     readable_years_count: int = 0
     latest_readable_year: int | None = None
+    read_availability_code: str | None = None
+    read_availability_message: str | None = None
 
 
 class CompanyDirectoryPaginationPayload(BaseModel):
@@ -269,6 +271,14 @@ class RefreshStatusPayload(BaseModel):
     readable_years_count: int = 0
     latest_readable_year: int | None = None
     latest_attempt_outcome: str | None = None
+    latest_attempt_reason_code: str | None = None
+    latest_attempt_reason_message: str | None = None
+    latest_attempt_retryable: bool = False
+    read_availability_code: str | None = None
+    read_availability_message: str | None = None
+    freshness_summary_code: str | None = None
+    freshness_summary_message: str | None = None
+    freshness_summary_severity: str | None = None
     source_label: str | None = None
 
 

--- a/apps/api/tests/test_api_contract.py
+++ b/apps/api/tests/test_api_contract.py
@@ -791,6 +791,8 @@ def test_company_detail_returns_metadata(client: TestClient):
     assert payload["readable_years_count"] == 2
     assert payload["latest_readable_year"] == 2024
     assert payload["read_model_updated_at"] == "2026-04-08T08:55:00"
+    assert payload["read_availability_code"] == "readable_history_available"
+    assert payload["read_availability_message"] == "Leitura anual disponivel ate 2024."
 
 
 def test_company_detail_uses_catalog_fallback_for_unknown_local_company(
@@ -821,6 +823,11 @@ def test_company_detail_uses_catalog_fallback_for_unknown_local_company(
     assert payload["readable_years_count"] == 0
     assert payload["latest_readable_year"] is None
     assert payload["read_model_updated_at"] is None
+    assert payload["read_availability_code"] == "no_readable_annual_history"
+    assert (
+        payload["read_availability_message"]
+        == "Ainda nao ha historico anual legivel para esta companhia."
+    )
 
 
 def test_company_detail_uses_sector_fallback_when_analytical_sector_is_missing(client: TestClient):
@@ -1074,6 +1081,20 @@ def test_refresh_status_returns_operational_rows(client: TestClient):
     assert payload[0]["latest_readable_year"] == 2024
     assert payload[0]["read_model_updated_at"] == "2026-04-08T08:55:00"
     assert payload[0]["latest_attempt_outcome"] == "success"
+    assert payload[0]["latest_attempt_reason_code"] == "refresh_completed"
+    assert (
+        payload[0]["latest_attempt_reason_message"]
+        == "Dados prontos para leitura nesta pagina."
+    )
+    assert payload[0]["latest_attempt_retryable"] is False
+    assert payload[0]["read_availability_code"] == "readable_history_available"
+    assert payload[0]["read_availability_message"] == "Leitura anual disponivel ate 2024."
+    assert payload[0]["freshness_summary_code"] == "refresh_completed_readable"
+    assert (
+        payload[0]["freshness_summary_message"]
+        == "Dados prontos para leitura nesta pagina."
+    )
+    assert payload[0]["freshness_summary_severity"] == "success"
     assert payload[0]["source_label"] == "Base local materializada"
 
 
@@ -1123,7 +1144,131 @@ def test_refresh_status_exposes_terminal_no_data_state(client: TestClient):
     assert payload[0]["has_readable_current_data"] is True
     assert payload[0]["readable_years_count"] == 1
     assert payload[0]["latest_attempt_outcome"] == "no_data"
+    assert payload[0]["latest_attempt_reason_code"] == "no_new_financial_history"
+    assert payload[0]["latest_attempt_retryable"] is True
+    assert payload[0]["read_availability_code"] == "readable_history_available"
+    assert payload[0]["read_availability_message"] == "Leitura anual disponivel ate 2024."
+    assert payload[0]["freshness_summary_code"] == "mixed_no_new_data_readable"
+    assert (
+        payload[0]["freshness_summary_message"]
+        == "A ultima tentativa nao encontrou novos demonstrativos; a leitura atual continua disponivel."
+    )
+    assert payload[0]["freshness_summary_severity"] == "info"
     assert payload[0]["source_label"] == "Solicitacao on-demand"
+
+
+def test_refresh_status_exposes_no_annual_history_without_readable_data(
+    client: TestClient,
+):
+    from sqlalchemy import text as sa_text
+
+    with client.app.state.read_service.engine.begin() as conn:
+        conn.execute(
+            sa_text(
+                """
+                INSERT INTO company_refresh_status (
+                    cd_cvm, company_name, source_scope, last_attempt_at, last_success_at,
+                    last_status, last_error, last_start_year, last_end_year,
+                    last_rows_inserted, updated_at, progress_message, finished_at
+                ) VALUES (
+                    77889, 'SEM DADOS', 'on_demand', '2026-04-21T12:00:00+00:00', NULL,
+                    'no_data', NULL, 2010, 2025,
+                    NULL, '2026-04-21T12:01:00+00:00', 'Nenhuma demonstracao encontrada para 2010-2025.',
+                    '2026-04-21T12:01:00+00:00'
+                )
+                ON CONFLICT (cd_cvm) DO UPDATE SET
+                    last_status = excluded.last_status,
+                    progress_message = excluded.progress_message,
+                    finished_at = excluded.finished_at,
+                    updated_at = excluded.updated_at
+                """
+            )
+        )
+
+    response = client.get("/refresh-status", params={"cd_cvm": 77889})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload) == 1
+    assert payload[0]["last_status"] == "no_data"
+    assert payload[0]["has_readable_current_data"] is False
+    assert payload[0]["readable_years_count"] == 0
+    assert payload[0]["latest_readable_year"] is None
+    assert payload[0]["status_reason_code"] == "no_financial_history_found"
+    assert payload[0]["latest_attempt_outcome"] == "no_data"
+    assert payload[0]["latest_attempt_reason_code"] == "no_annual_history"
+    assert (
+        payload[0]["latest_attempt_reason_message"]
+        == "Nenhuma serie anual legivel foi encontrada para esta companhia."
+    )
+    assert payload[0]["latest_attempt_retryable"] is True
+    assert payload[0]["read_availability_code"] == "no_readable_annual_history"
+    assert (
+        payload[0]["read_availability_message"]
+        == "Ainda nao ha historico anual legivel para esta companhia."
+    )
+    assert payload[0]["freshness_summary_code"] == "no_annual_history"
+    assert (
+        payload[0]["freshness_summary_message"]
+        == "Nenhuma serie anual legivel foi encontrada para esta companhia."
+    )
+    assert payload[0]["freshness_summary_severity"] == "info"
+
+
+def test_refresh_status_exposes_retryable_error_without_hiding_readable_data(
+    client: TestClient,
+):
+    from sqlalchemy import text as sa_text
+
+    with client.app.state.read_service.engine.begin() as conn:
+        conn.execute(
+            sa_text(
+                """
+                INSERT INTO company_refresh_status (
+                    cd_cvm, company_name, source_scope, last_attempt_at, last_success_at,
+                    last_status, last_error, last_start_year, last_end_year,
+                    last_rows_inserted, updated_at, progress_message, finished_at
+                ) VALUES (
+                    4170, 'VALE', 'on_demand', '2026-04-21T12:00:00+00:00', NULL,
+                    'error', 'HTTP 500 ao consultar CVM', 2010, 2025,
+                    NULL, '2026-04-21T12:01:00+00:00', 'Falha temporaria no download.',
+                    '2026-04-21T12:01:00+00:00'
+                )
+                ON CONFLICT (cd_cvm) DO UPDATE SET
+                    last_status = excluded.last_status,
+                    last_error = excluded.last_error,
+                    progress_message = excluded.progress_message,
+                    finished_at = excluded.finished_at,
+                    updated_at = excluded.updated_at
+                """
+            )
+        )
+
+    response = client.get("/refresh-status", params={"cd_cvm": 4170})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload) == 1
+    assert payload[0]["last_status"] == "error"
+    assert payload[0]["tracking_state"] == "error"
+    assert payload[0]["is_retry_allowed"] is True
+    assert payload[0]["has_readable_current_data"] is True
+    assert payload[0]["readable_years_count"] == 1
+    assert payload[0]["status_reason_code"] == "refresh_failed"
+    assert payload[0]["latest_attempt_outcome"] == "error"
+    assert payload[0]["latest_attempt_reason_code"] == "refresh_failed_retryable"
+    assert (
+        payload[0]["latest_attempt_reason_message"]
+        == "Nao foi possivel concluir a atualizacao desta empresa agora."
+    )
+    assert payload[0]["latest_attempt_retryable"] is True
+    assert payload[0]["read_availability_code"] == "readable_history_available"
+    assert payload[0]["freshness_summary_code"] == "mixed_retryable_error_readable"
+    assert (
+        payload[0]["freshness_summary_message"]
+        == "A leitura atual continua disponivel, mas a ultima atualizacao falhou e pode ser tentada novamente."
+    )
+    assert payload[0]["freshness_summary_severity"] == "warning"
 
 
 def test_refresh_status_returns_real_progress_fields_for_active_refresh(client: TestClient):
@@ -1346,6 +1491,10 @@ def test_refresh_status_returns_real_progress_fields_for_active_refresh(client: 
     assert payload[0]["has_readable_current_data"] is True
     assert payload[0]["readable_years_count"] == 1
     assert payload[0]["latest_attempt_outcome"] == "queued"
+    assert payload[0]["latest_attempt_reason_code"] == "refresh_running"
+    assert payload[0]["latest_attempt_retryable"] is False
+    assert payload[0]["freshness_summary_code"] == "refresh_running"
+    assert payload[0]["freshness_summary_severity"] == "info"
     assert payload[0]["source_label"] == "Solicitacao on-demand"
 
 

--- a/src/contracts.py
+++ b/src/contracts.py
@@ -199,6 +199,8 @@ class CompanyInfoDTO:
     has_readable_current_data: bool = False
     readable_years_count: int = 0
     latest_readable_year: int | None = None
+    read_availability_code: str | None = None
+    read_availability_message: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -449,6 +451,14 @@ class RefreshStatusDTO:
     readable_years_count: int = 0
     latest_readable_year: int | None = None
     latest_attempt_outcome: str | None = None
+    latest_attempt_reason_code: str | None = None
+    latest_attempt_reason_message: str | None = None
+    latest_attempt_retryable: bool = False
+    read_availability_code: str | None = None
+    read_availability_message: str | None = None
+    freshness_summary_code: str | None = None
+    freshness_summary_message: str | None = None
+    freshness_summary_severity: str | None = None
     source_label: str | None = None
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/read_service.py
+++ b/src/read_service.py
@@ -211,16 +211,25 @@ class CVMReadService:
             int(dto.cd_cvm),
             {},
         )
+        readable_years_count = int(state.get("readable_years_count") or 0)
+        latest_readable_year = (
+            int(state["latest_readable_year"])
+            if state.get("latest_readable_year") is not None
+            else None
+        )
+        read_availability = self._build_read_availability_summary(
+            has_readable_current_data=bool(state.get("has_readable_current_data")),
+            readable_years_count=readable_years_count,
+            latest_readable_year=latest_readable_year,
+        )
         return replace(
             dto,
             read_model_updated_at=state.get("read_model_updated_at"),
             has_readable_current_data=bool(state.get("has_readable_current_data")),
-            readable_years_count=int(state.get("readable_years_count") or 0),
-            latest_readable_year=(
-                int(state["latest_readable_year"])
-                if state.get("latest_readable_year") is not None
-                else None
-            ),
+            readable_years_count=readable_years_count,
+            latest_readable_year=latest_readable_year,
+            read_availability_code=read_availability["code"],
+            read_availability_message=read_availability["message"],
         )
 
     def _ensure_company_catalog_metadata(self, cd_cvm: int) -> bool:
@@ -844,6 +853,29 @@ class CVMReadService:
             active_job=active_job,
             has_readable_current_data=has_readable_current_data,
         )
+        read_availability = self._build_read_availability_summary(
+            has_readable_current_data=has_readable_current_data,
+            readable_years_count=readable_years_count,
+            latest_readable_year=(
+                int(latest_readable_year)
+                if latest_readable_year is not None
+                else None
+            ),
+        )
+        latest_attempt_reason = self._build_latest_attempt_reason(
+            row,
+            tracking_state=tracking_state,
+            active_job=active_job,
+            has_readable_current_data=has_readable_current_data,
+        )
+        freshness_summary = self._build_freshness_summary(
+            row,
+            tracking_state=tracking_state,
+            has_readable_current_data=has_readable_current_data,
+            status_reason_code=status_reason_code,
+            status_reason_message=status_reason_message,
+            latest_attempt_reason=latest_attempt_reason,
+        )
         return RefreshStatusDTO(
             cd_cvm=int(row["cd_cvm"]),
             company_name=str(row["company_name"] or ""),
@@ -916,6 +948,14 @@ class CVMReadService:
                 else None
             ),
             latest_attempt_outcome=latest_attempt_outcome,
+            latest_attempt_reason_code=latest_attempt_reason["code"],
+            latest_attempt_reason_message=latest_attempt_reason["message"],
+            latest_attempt_retryable=bool(latest_attempt_reason["retryable"]),
+            read_availability_code=read_availability["code"],
+            read_availability_message=read_availability["message"],
+            freshness_summary_code=freshness_summary["code"],
+            freshness_summary_message=freshness_summary["message"],
+            freshness_summary_severity=freshness_summary["severity"],
             source_label=self._build_refresh_source_label(
                 row.get("source_scope"),
                 has_readable_current_data=has_readable_current_data,
@@ -1683,6 +1723,271 @@ class CVMReadService:
             ).total_seconds() >= threshold_seconds
 
         return False
+
+    @staticmethod
+    def _build_read_availability_summary(
+        *,
+        has_readable_current_data: bool,
+        readable_years_count: int,
+        latest_readable_year: int | None,
+    ) -> dict[str, str]:
+        if has_readable_current_data:
+            if latest_readable_year is not None:
+                return {
+                    "code": "readable_history_available",
+                    "message": (
+                        f"Leitura anual disponivel ate {int(latest_readable_year)}."
+                    ),
+                }
+            return {
+                "code": "readable_history_available",
+                "message": "Leitura anual disponivel nesta pagina.",
+            }
+
+        return {
+            "code": "no_readable_annual_history",
+            "message": (
+                "Ainda nao ha historico anual legivel para esta companhia."
+            ),
+        }
+
+    def _build_latest_attempt_reason(
+        self,
+        row: dict[str, Any],
+        *,
+        tracking_state: str,
+        active_job: dict[str, Any] | None,
+        has_readable_current_data: bool,
+    ) -> dict[str, Any]:
+        last_status = self._normalize_refresh_status(row.get("last_status"))
+        progress_message = self._clean_optional_text(row.get("progress_message"))
+        last_error = self._clean_optional_text(row.get("last_error"))
+        normalized_progress_message = str(progress_message or "").lower()
+        normalized_last_error = str(last_error or "").lower()
+
+        if tracking_state == "queued":
+            return {
+                "code": "refresh_queued",
+                "message": (
+                    "Solicitacao recebida e aguardando processamento interno."
+                ),
+                "retryable": False,
+            }
+
+        if tracking_state == "running":
+            return {
+                "code": "refresh_running",
+                "message": (
+                    "Os demonstrativos desta companhia estao sendo atualizados agora."
+                ),
+                "retryable": False,
+            }
+
+        if tracking_state == "stalled":
+            if active_job is None and last_status in self.ACTIVE_REFRESH_STATUSES:
+                return {
+                    "code": "refresh_tracking_lost",
+                    "message": (
+                        "A ultima solicitacao nao aparece mais como ativa."
+                    ),
+                    "retryable": True,
+                }
+            return {
+                "code": "refresh_stalled",
+                "message": (
+                    "A solicitacao esta acima do esperado e sem sinais recentes de progresso."
+                ),
+                "retryable": active_job is None,
+            }
+
+        if last_status == "success":
+            if "ja atualizada" in normalized_progress_message:
+                return {
+                    "code": "already_current",
+                    "message": (
+                        "Esta empresa ja estava atualizada para a janela padrao."
+                    ),
+                    "retryable": False,
+                }
+            if has_readable_current_data:
+                return {
+                    "code": "refresh_completed",
+                    "message": "Dados prontos para leitura nesta pagina.",
+                    "retryable": False,
+                }
+            return {
+                "code": "refresh_completed_without_readable_data",
+                "message": (
+                    "A ultima atualizacao terminou, mas a leitura anual ainda nao ficou disponivel."
+                ),
+                "retryable": False,
+            }
+
+        if last_status == "no_data":
+            if has_readable_current_data:
+                return {
+                    "code": "no_new_financial_history",
+                    "message": (
+                        "A ultima tentativa nao encontrou novos demonstrativos."
+                    ),
+                    "retryable": True,
+                }
+            return {
+                "code": "no_annual_history",
+                "message": (
+                    "Nenhuma serie anual legivel foi encontrada para esta companhia."
+                ),
+                "retryable": True,
+            }
+
+        if last_status == "error":
+            if "expirou" in normalized_progress_message:
+                return {
+                    "code": "refresh_expired",
+                    "message": (
+                        "A solicitacao expirou antes de terminar."
+                    ),
+                    "retryable": True,
+                }
+            if "no financial rows found" in normalized_last_error:
+                return {
+                    "code": "no_annual_history",
+                    "message": (
+                        "Nenhuma serie anual legivel foi encontrada para esta companhia."
+                    ),
+                    "retryable": True,
+                }
+            return {
+                "code": "refresh_failed_retryable",
+                "message": (
+                    "Nao foi possivel concluir a atualizacao desta empresa agora."
+                ),
+                "retryable": True,
+            }
+
+        if has_readable_current_data:
+            return {
+                "code": "local_data_ready",
+                "message": "Leitura local pronta para consulta.",
+                "retryable": False,
+            }
+
+        return {
+            "code": "no_local_history_yet",
+            "message": (
+                "Esta empresa ainda nao tem historico anual processado na base local."
+            ),
+            "retryable": False,
+        }
+
+    def _build_freshness_summary(
+        self,
+        row: dict[str, Any],
+        *,
+        tracking_state: str,
+        has_readable_current_data: bool,
+        status_reason_code: str,
+        status_reason_message: str,
+        latest_attempt_reason: dict[str, Any],
+    ) -> dict[str, str]:
+        last_status = self._normalize_refresh_status(row.get("last_status"))
+        attempt_code = str(latest_attempt_reason.get("code") or "")
+
+        if tracking_state in {"queued", "running"}:
+            return {
+                "code": status_reason_code,
+                "message": status_reason_message,
+                "severity": "info",
+            }
+
+        if tracking_state == "stalled":
+            if has_readable_current_data:
+                return {
+                    "code": "mixed_refresh_stalled_readable",
+                    "message": (
+                        "A leitura atual continua disponivel, mas a ultima solicitacao esta sem sinais recentes."
+                    ),
+                    "severity": "warning",
+                }
+            return {
+                "code": "refresh_stalled_no_readable",
+                "message": (
+                    "A solicitacao esta sem sinais recentes e ainda nao ha leitura anual disponivel."
+                ),
+                "severity": "warning",
+            }
+
+        if last_status == "success":
+            if attempt_code == "already_current":
+                return {
+                    "code": "already_current",
+                    "message": (
+                        "A leitura local ja estava atualizada para a janela padrao."
+                    ),
+                    "severity": "success",
+                }
+            if has_readable_current_data:
+                return {
+                    "code": "refresh_completed_readable",
+                    "message": "Dados prontos para leitura nesta pagina.",
+                    "severity": "success",
+                }
+            return {
+                "code": "refresh_completed_no_readable",
+                "message": (
+                    "A atualizacao terminou, mas a leitura anual ainda nao esta disponivel."
+                ),
+                "severity": "warning",
+            }
+
+        if last_status == "no_data":
+            if has_readable_current_data:
+                return {
+                    "code": "mixed_no_new_data_readable",
+                    "message": (
+                        "A ultima tentativa nao encontrou novos demonstrativos; a leitura atual continua disponivel."
+                    ),
+                    "severity": "info",
+                }
+            return {
+                "code": "no_annual_history",
+                "message": (
+                    "Nenhuma serie anual legivel foi encontrada para esta companhia."
+                ),
+                "severity": "info",
+            }
+
+        if last_status == "error":
+            if has_readable_current_data:
+                return {
+                    "code": "mixed_retryable_error_readable",
+                    "message": (
+                        "A leitura atual continua disponivel, mas a ultima atualizacao falhou e pode ser tentada novamente."
+                    ),
+                    "severity": "warning",
+                }
+            return {
+                "code": "refresh_failed_retryable",
+                "message": (
+                    "A ultima atualizacao falhou e ainda nao ha leitura anual disponivel."
+                ),
+                "severity": "error",
+            }
+
+        if has_readable_current_data:
+            return {
+                "code": "readable_history_available",
+                "message": "Leitura local pronta para consulta.",
+                "severity": "success",
+            }
+
+        return {
+            "code": "no_readable_annual_history",
+            "message": (
+                "Ainda nao ha historico anual legivel para esta companhia."
+            ),
+            "severity": "info",
+        }
 
     def _build_refresh_status_reason(
         self,


### PR DESCRIPTION
﻿Closes #178

## Summary
- Add additive read availability fields to company metadata so the UI can tell readable annual history from no annual history.
- Add additive refresh-status taxonomy fields for latest attempt reason, retryability, read availability, and mixed-outcome freshness summary.
- Keep existing `status_reason_*`, `is_retry_allowed`, and `latest_attempt_outcome` behavior intact while covering `already_current`, `no_annual_history`, active, terminal, and mixed retryable states.
- Extend API contract tests for readable success, no-data with existing read model, no annual history, retryable error with readable data, and active refresh.

## Compatibilidade
additive-only: public payloads received only optional/additive fields. Existing fields and status values remain compatible.

## Validation
- `pytest apps/api/tests/test_api_contract.py -q`
- `pytest apps/api/tests/test_presenters.py tests/test_read_service.py -q`
- `pytest apps/api/tests tests/test_read_service.py -q`
- `pytest tests/test_refresh_jobs.py -q`
- `python -m compileall src apps/api tests/test_read_service.py apps/api/tests/test_api_contract.py`
- `git diff --check`
