### PR TITLE
[Task] FRONTEND: clarify requestable discovery hierarchy

### DIFF
--- a/apps/web/app/comparar/page.tsx
+++ b/apps/web/app/comparar/page.tsx
@@ -117,7 +117,7 @@ export default async function ComparePage({ searchParams }: ComparePageProps) {
         eyebrow="PG-04 - Comparar"
         title="Comparacao de empresas"
         titleAs="h1"
-        description="Monte uma comparacao lado a lado com empresas da base e use a primeira selecao como referencia de deltas."
+        description="Monte uma comparacao lado a lado apenas com empresas prontas. Se uma companhia ainda for solicitavel ou tiver sinal fraco, abra o diretorio primeiro."
         meta={
           <InfoChip tone="muted">
             {compareData.comparedCompanies.length >= 2

--- a/apps/web/components/companies/companies-directory-client.tsx
+++ b/apps/web/components/companies/companies-directory-client.tsx
@@ -25,6 +25,29 @@ type CompaniesDirectoryPageContentProps = Pick<
   data: CompaniesPageData;
 };
 
+const DISCOVERY_LEGEND = [
+  {
+    label: "Pronta agora",
+    description: "Leitura anual suficiente para KPIs, demonstracoes e Excel.",
+    className: "border-emerald-500/20 bg-emerald-500/8 text-emerald-700 dark:text-emerald-300",
+  },
+  {
+    label: "Solicitar dados",
+    description: "Sem historico local; abra a pagina para pedir on-demand.",
+    className: "border-primary/20 bg-primary/8 text-primary/80",
+  },
+  {
+    label: "Baixo sinal",
+    description: "Tem dados locais, mas cobertura curta para comparacao forte.",
+    className: "border-amber-500/24 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+  },
+  {
+    label: "Estagnada",
+    description: "Historico local existe, mas parece defasado.",
+    className: "border-destructive/25 bg-destructive/8 text-destructive",
+  },
+] as const;
+
 export function CompaniesDirectoryPageContent({
   page: currentPage,
   pageSize,
@@ -107,15 +130,15 @@ export function CompaniesDirectoryPageContent({
       <div className="flex flex-wrap items-end justify-between gap-4">
         <div>
           <p className="mb-1 text-[0.72rem] font-medium uppercase tracking-[0.26em] text-muted-foreground">
-            Diretorio · CVM
+            Diretorio / CVM
           </p>
           <h1 className="font-heading text-[clamp(1.75rem,4vw,2.5rem)] font-medium leading-tight tracking-[-0.04em] text-foreground">
             Todas as companhias abertas
           </h1>
           <p className="mt-1.5 text-[0.9rem] text-muted-foreground">
             {formatCompactInteger(directory.pagination.total_items)} empresas
-            {currentSearch ? ` · "${currentSearch}"` : ""}
-            {currentSector ? ` · ${currentSector}` : ""}
+            {currentSearch ? ` / "${currentSearch}"` : ""}
+            {currentSector ? ` / ${currentSector}` : ""}
           </p>
         </div>
 
@@ -172,6 +195,27 @@ export function CompaniesDirectoryPageContent({
         </Alert>
       ) : null}
 
+      <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
+        {DISCOVERY_LEGEND.map((item) => (
+          <div
+            key={item.label}
+            className="rounded-[1.1rem] border border-border/60 bg-background/80 px-4 py-3"
+          >
+            <span
+              className={cn(
+                "inline-flex rounded-full border px-2 py-0.5 text-[0.62rem] font-medium uppercase tracking-[0.14em]",
+                item.className,
+              )}
+            >
+              {item.label}
+            </span>
+            <p className="mt-2 text-xs leading-5 text-muted-foreground">
+              {item.description}
+            </p>
+          </div>
+        ))}
+      </div>
+
       <CompanyDirectoryFilters
         key={`${currentSearch}|${currentSector ?? "all"}|${filtersError ? "filters-down" : "filters-up"}`}
         currentSearch={currentSearch}
@@ -187,6 +231,7 @@ export function CompaniesDirectoryPageContent({
           hasActiveFilters={Boolean(currentSearch || currentSector)}
           clearHref={clearHref}
           fallbackSuggestions={data.fallbackSuggestions?.items ?? []}
+          fallbackSuggestionsError={data.fallbackSuggestionsError}
           searchTerm={currentSearch}
           showCatalogFallback={!currentSector}
         />

--- a/apps/web/components/companies/company-card.tsx
+++ b/apps/web/components/companies/company-card.tsx
@@ -24,6 +24,21 @@ type CompanyCardProps = {
   item: CompanyDirectoryItem;
 };
 
+function getAvailabilityBadgeClassName(
+  kind: ReturnType<typeof getCompanyAvailability>["kind"],
+): string {
+  switch (kind) {
+    case "ready":
+      return "border-emerald-500/20 bg-emerald-500/8 text-emerald-700 dark:text-emerald-300";
+    case "requestable":
+      return "border-primary/20 bg-primary/8 text-primary/80";
+    case "low_signal":
+      return "border-amber-500/24 bg-amber-500/10 text-amber-700 dark:text-amber-300";
+    case "stalled":
+      return "border-destructive/25 bg-destructive/8 text-destructive";
+  }
+}
+
 export function CompanyCard({ item }: CompanyCardProps) {
   const color = getSectorColor(item.sector_name);
   const anos = item.anos_disponiveis ?? [];
@@ -71,9 +86,7 @@ export function CompanyCard({ item }: CompanyCardProps) {
         <span
           className={cn(
             "rounded-full border px-2.5 py-1 text-[0.64rem] font-medium uppercase tracking-[0.14em]",
-            availability.kind === "ready"
-              ? "border-emerald-500/20 bg-emerald-500/8 text-emerald-700 dark:text-emerald-300"
-              : "border-primary/20 bg-primary/8 text-primary/80",
+            getAvailabilityBadgeClassName(availability.kind),
           )}
         >
           {availability.badge}
@@ -115,10 +128,7 @@ export function CompanyCard({ item }: CompanyCardProps) {
             { label: "Historico", value: yearsRange },
             {
               label: "Entrada",
-              value:
-                availability.kind === "ready"
-                  ? "KPIs + DRE"
-                  : "Pedir on-demand",
+              value: availability.actionLabel,
             },
           ] as const
         ).map(({ label, value }) => (

--- a/apps/web/components/companies/company-directory-list.tsx
+++ b/apps/web/components/companies/company-directory-list.tsx
@@ -15,6 +15,7 @@ type CompanyDirectoryListProps = {
   hasActiveFilters: boolean;
   clearHref: string;
   fallbackSuggestions?: CompanySuggestionItem[];
+  fallbackSuggestionsError?: string | null;
   searchTerm?: string;
   showCatalogFallback?: boolean;
 };
@@ -25,6 +26,7 @@ export function CompanyDirectoryList({
   hasActiveFilters,
   clearHref,
   fallbackSuggestions = [],
+  fallbackSuggestionsError = null,
   searchTerm = "",
   showCatalogFallback = false,
 }: CompanyDirectoryListProps) {
@@ -44,9 +46,15 @@ export function CompanyDirectoryList({
         </p>
         <p className="max-w-sm text-sm leading-7 text-muted-foreground">
           {hasCatalogFallback
-            ? "O diretorio local ainda nao tem dados processados para essa busca, mas o catalogo CVM abaixo permite abrir a pagina e solicitar o bootstrap on-demand."
+            ? "O diretorio local ainda nao tem dados processados para essa busca, mas o catalogo CVM abaixo permite abrir a pagina e solicitar dados on-demand."
             : "Ajuste o termo de busca ou remova o filtro setorial para ampliar o diretorio disponivel."}
         </p>
+
+        {fallbackSuggestionsError ? (
+          <div className="max-w-lg rounded-[1rem] border border-border/70 bg-background/85 px-4 py-3 text-left text-sm leading-6 text-muted-foreground">
+            O catalogo CVM tambem oscilou agora: {fallbackSuggestionsError}
+          </div>
+        ) : null}
 
         {hasCatalogFallback ? (
           <div className="grid w-full max-w-2xl gap-3 text-left">
@@ -58,9 +66,17 @@ export function CompanyDirectoryList({
               >
                 <div className="flex flex-wrap items-center justify-between gap-3">
                   <div className="min-w-0 space-y-1">
-                    <p className="truncate font-medium text-foreground">{item.company_name}</p>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <p className="truncate font-medium text-foreground">{item.company_name}</p>
+                      <span className="rounded-full border border-primary/20 bg-primary/8 px-2 py-0.5 text-[0.62rem] font-medium uppercase tracking-[0.14em] text-primary/80">
+                        Solicitar dados
+                      </span>
+                    </div>
                     <p className="text-sm text-muted-foreground">
                       {getSectorNameFromSlug(item.sector_slug) ?? "Setor nao informado"}
+                    </p>
+                    <p className="text-xs leading-5 text-muted-foreground">
+                      Sem historico local neste filtro. A pagina da empresa libera o pedido on-demand.
                     </p>
                   </div>
                   <div className="text-right">
@@ -70,6 +86,7 @@ export function CompanyDirectoryList({
                       </p>
                     ) : null}
                     <p className="font-mono text-sm text-foreground">CVM {item.cd_cvm}</p>
+                    <p className="mt-1 text-xs text-muted-foreground">Abrir e solicitar</p>
                   </div>
                 </div>
               </Link>

--- a/apps/web/components/companies/company-row.tsx
+++ b/apps/web/components/companies/company-row.tsx
@@ -25,6 +25,21 @@ type CompanyRowProps = {
   item: CompanyDirectoryItem;
 };
 
+function getAvailabilityBadgeClassName(
+  kind: ReturnType<typeof getCompanyAvailability>["kind"],
+): string {
+  switch (kind) {
+    case "ready":
+      return "border-emerald-500/20 bg-emerald-500/8 text-emerald-700 dark:text-emerald-300";
+    case "requestable":
+      return "border-primary/20 bg-primary/8 text-primary/80";
+    case "low_signal":
+      return "border-amber-500/24 bg-amber-500/10 text-amber-700 dark:text-amber-300";
+    case "stalled":
+      return "border-destructive/25 bg-destructive/8 text-destructive";
+  }
+}
+
 export function CompanyRow({ item }: CompanyRowProps) {
   const color = getSectorColor(item.sector_name);
   const anos = item.anos_disponiveis ?? [];
@@ -78,9 +93,7 @@ export function CompanyRow({ item }: CompanyRowProps) {
           <span
             className={cn(
               "shrink-0 rounded-full border px-2 py-0.5 text-[0.62rem] font-medium uppercase tracking-[0.14em]",
-              availability.kind === "ready"
-                ? "border-emerald-500/20 bg-emerald-500/8 text-emerald-700 dark:text-emerald-300"
-                : "border-primary/20 bg-primary/8 text-primary/80",
+              getAvailabilityBadgeClassName(availability.kind),
             )}
           >
             {availability.badge}

--- a/apps/web/components/compare/compare-selector.tsx
+++ b/apps/web/components/compare/compare-selector.tsx
@@ -222,7 +222,7 @@ export function CompareSelector({
             Selecao da comparacao
           </p>
           <p className="text-sm leading-7 text-muted-foreground">
-            Escolha entre 2 e {maxCompanies} empresas para comparar os indicadores no mesmo periodo.
+            Escolha entre 2 e {maxCompanies} empresas prontas para comparar indicadores no mesmo periodo.
           </p>
         </div>
         <InfoChip tone="muted">
@@ -244,7 +244,7 @@ export function CompareSelector({
             />
           </div>
           <p className="text-xs text-muted-foreground">
-            Digite ao menos 2 caracteres para receber sugestoes e adicionar empresas.
+            Digite ao menos 2 caracteres. A busca do comparador mostra apenas companhias com historico anual local.
           </p>
         </div>
 
@@ -286,7 +286,7 @@ export function CompareSelector({
         suggestions.length === 0 &&
         !suggestionError ? (
           <p className="text-sm text-muted-foreground">
-            Nenhuma companhia pronta para comparar apareceu com esse termo. A comparacao mostra apenas empresas com historico anual local.
+            Nenhuma companhia pronta e comparavel apareceu com esse termo. Abra o diretorio para solicitar dados on-demand antes de comparar.
           </p>
         ) : null}
 
@@ -305,7 +305,10 @@ export function CompareSelector({
                   )}
                   onClick={() => addCompany(company)}
                 >
-                  {company.company_name}
+                  <span className="max-w-[14rem] truncate">{company.company_name}</span>
+                  <span className="rounded-full border border-emerald-500/20 bg-emerald-500/8 px-1.5 py-0.5 text-[0.58rem] uppercase tracking-[0.14em] text-emerald-700 dark:text-emerald-300">
+                    Pronta
+                  </span>
                 </button>
               ))}
             </div>
@@ -322,6 +325,12 @@ export function CompareSelector({
             <p className="mt-1 text-sm leading-6 text-muted-foreground">
               Esta comparacao so lista companhias com historico anual local suficiente. Quando o slice atual nao tiver empresas prontas, use a busca para conferir uma companhia especifica ou abra o diretorio.
             </p>
+            <Link
+              href="/empresas"
+              className="mt-3 inline-flex text-sm font-medium text-primary hover:underline"
+            >
+              Ver empresas solicitaveis no diretorio
+            </Link>
           </div>
         ) : null}
       </div>

--- a/apps/web/components/home/company-search-hero.tsx
+++ b/apps/web/components/home/company-search-hero.tsx
@@ -211,6 +211,9 @@ export function CompanySearchHero() {
                     <p className="text-[0.8rem] text-muted-foreground mt-0.5">
                       {sectorName ?? "Setor nao informado"}
                     </p>
+                    <p className="text-[0.72rem] text-muted-foreground mt-1">
+                      Abra a pagina; se faltar historico local, solicite dados on-demand.
+                    </p>
                   </div>
                   <div className="text-right shrink-0">
                     <p className="text-[0.72rem] uppercase tracking-[0.15em] text-muted-foreground">

--- a/apps/web/components/home/discovery-section.tsx
+++ b/apps/web/components/home/discovery-section.tsx
@@ -21,6 +21,21 @@ type DiscoverySectionProps = {
   topCompanies: CompanyDirectoryItem[];
 };
 
+function getAvailabilityBadgeClassName(
+  kind: ReturnType<typeof getCompanyAvailability>["kind"],
+): string {
+  switch (kind) {
+    case "ready":
+      return "border-emerald-500/20 bg-emerald-500/8 text-emerald-700 dark:text-emerald-300";
+    case "requestable":
+      return "border-primary/20 bg-primary/8 text-primary/80";
+    case "low_signal":
+      return "border-amber-500/24 bg-amber-500/10 text-amber-700 dark:text-amber-300";
+    case "stalled":
+      return "border-destructive/25 bg-destructive/8 text-destructive";
+  }
+}
+
 function buildSparkPoints(anos: number[], W = 70, H = 32): string {
   if (!anos || anos.length < 2) return "";
   const sorted = [...anos].sort((a, b) => a - b);
@@ -65,9 +80,7 @@ function CompanyCard({ co }: { co: CompanyDirectoryItem }) {
             <span
               className={cn(
                 "rounded-full border px-2 py-0.5 text-[0.62rem] font-medium uppercase tracking-[0.14em]",
-                availability.kind === "ready"
-                  ? "border-emerald-500/20 bg-emerald-500/8 text-emerald-700 dark:text-emerald-300"
-                  : "border-primary/20 bg-primary/8 text-primary/80",
+                getAvailabilityBadgeClassName(availability.kind),
               )}
             >
               {availability.badge}
@@ -118,7 +131,7 @@ function CompanyCard({ co }: { co: CompanyDirectoryItem }) {
           </p>
         </div>
         <div className="flex items-center gap-1 text-[0.8rem] font-medium text-muted-foreground transition-colors group-hover:text-primary">
-          <span>{availability.summary}</span>
+          <span>{availability.actionLabel}</span>
           <ArrowRightIcon className="size-3.5" />
         </div>
       </div>
@@ -131,7 +144,7 @@ function DestaquCard({ co, rank }: { co: CompanyDirectoryItem; rank: number }) {
   const anos = co.anos_disponiveis ?? [];
   const sparkPts = buildSparkPoints(anos, 54, 22);
   const availability = getCompanyAvailability(co);
-  const isTop = rank < 3;
+  const sparkColor = availability.kind === "ready" ? "var(--chart-1)" : color;
 
   return (
     <button
@@ -160,7 +173,7 @@ function DestaquCard({ co, rank }: { co: CompanyDirectoryItem; rank: number }) {
           <polyline
             points={sparkPts}
             fill="none"
-            stroke={isTop ? "var(--chart-1)" : "var(--destructive)"}
+            stroke={sparkColor}
             strokeWidth="1.5"
             strokeLinecap="round"
             strokeLinejoin="round"
@@ -168,8 +181,10 @@ function DestaquCard({ co, rank }: { co: CompanyDirectoryItem; rank: number }) {
         </svg>
       ) : null}
       <span
-        className="shrink-0 text-[0.78rem] font-medium"
-        style={{ color: isTop ? "var(--chart-1)" : "var(--destructive)" }}
+        className={cn(
+          "shrink-0 rounded-full border px-2 py-0.5 text-[0.62rem] font-medium uppercase tracking-[0.14em]",
+          getAvailabilityBadgeClassName(availability.kind),
+        )}
       >
         {availability.badge}
       </span>
@@ -180,8 +195,12 @@ function DestaquCard({ co, rank }: { co: CompanyDirectoryItem; rank: number }) {
 export function DiscoverySection({ topCompanies }: DiscoverySectionProps) {
   const [activeTab, setActiveTab] = useState<Tab>("populares");
 
-  const topHalf = topCompanies.slice(0, Math.ceil(topCompanies.length / 2));
-  const bottomHalf = topCompanies.slice(Math.ceil(topCompanies.length / 2));
+  const readyCompanies = topCompanies
+    .filter((company) => getCompanyAvailability(company).kind === "ready")
+    .slice(0, 4);
+  const attentionCompanies = topCompanies
+    .filter((company) => getCompanyAvailability(company).kind !== "ready")
+    .slice(0, 4);
 
   return (
     <section className="w-full max-w-5xl mx-auto space-y-6 text-left">
@@ -194,8 +213,8 @@ export function DiscoverySection({ topCompanies }: DiscoverySectionProps) {
             Por onde comecar
           </h2>
           <p className="mt-2 max-w-2xl text-sm leading-7 text-muted-foreground">
-            A home prioriza companhias com leitura pronta e deixa claro quando a
-            pagina ainda depende de uma carga on-demand.
+            A home separa empresas prontas, solicitaveis e sinais fracos antes
+            do clique, para voce saber se vai analisar agora ou pedir uma carga.
           </p>
         </div>
         <div className="inline-flex items-center gap-0.5 rounded-full border border-border bg-muted p-1">
@@ -230,23 +249,31 @@ export function DiscoverySection({ topCompanies }: DiscoverySectionProps) {
           <div className="rounded-[1.25rem] border border-border/60 bg-card p-5">
             <div className="mb-3 flex items-center gap-2">
               <TrendingUpIcon className="size-4 text-[color:var(--chart-1)]" />
-              <span className="text-[0.95rem] font-semibold">Leitura pronta agora</span>
+              <span className="text-[0.95rem] font-semibold">Prontas para analisar</span>
             </div>
             <div className="flex flex-col gap-0.5">
-              {topHalf.map((co, i) => (
+              {readyCompanies.length > 0 ? readyCompanies.map((co, i) => (
                 <DestaquCard key={co.cd_cvm} co={co} rank={i + 1} />
-              ))}
+              )) : (
+                <p className="px-3 py-2 text-sm leading-6 text-muted-foreground">
+                  Nenhuma sugestao forte apareceu neste recorte inicial.
+                </p>
+              )}
             </div>
           </div>
           <div className="rounded-[1.25rem] border border-border/60 bg-muted/30 p-5">
             <div className="mb-3 flex items-center gap-2">
               <TrendingDownIcon className="size-4 text-destructive" />
-              <span className="text-[0.95rem] font-semibold">Outras entradas</span>
+              <span className="text-[0.95rem] font-semibold">On-demand e sinais fracos</span>
             </div>
             <div className="flex flex-col gap-0.5">
-              {bottomHalf.map((co, i) => (
+              {attentionCompanies.length > 0 ? attentionCompanies.map((co, i) => (
                 <DestaquCard key={co.cd_cvm} co={co} rank={i + 1} />
-              ))}
+              )) : (
+                <p className="px-3 py-2 text-sm leading-6 text-muted-foreground">
+                  O recorte atual esta concentrado em empresas prontas.
+                </p>
+              )}
             </div>
           </div>
         </div>

--- a/apps/web/lib/company-discovery.ts
+++ b/apps/web/lib/company-discovery.ts
@@ -1,12 +1,55 @@
 import type { CompanyDirectoryItem } from "@/lib/api";
 
+export type CompanyDiscoveryStateKind =
+  | "ready"
+  | "requestable"
+  | "stalled"
+  | "low_signal";
+
 export type CompanyAvailability = {
-  kind: "ready" | "requestable";
+  kind: CompanyDiscoveryStateKind;
   badge: string;
   summary: string;
   detail: string;
   yearsLabel: string;
+  actionLabel: string;
+  compareEligible: boolean;
 };
+
+type CompanyAvailabilityOptions = {
+  referenceYear?: number;
+};
+
+const MIN_READY_YEARS = 2;
+const MIN_READY_ROWS = 24;
+const STALE_YEAR_LAG = 2;
+
+const DISCOVERY_ORDER: Record<CompanyDiscoveryStateKind, number> = {
+  ready: 0,
+  requestable: 1,
+  low_signal: 2,
+  stalled: 3,
+};
+
+function getReferenceYear(options?: CompanyAvailabilityOptions): number {
+  return options?.referenceYear ?? new Date().getFullYear();
+}
+
+function getSortedYears(item: CompanyDirectoryItem): number[] {
+  return [...(item.anos_disponiveis ?? [])].sort((left, right) => left - right);
+}
+
+function getYearsLabel(years: number[]): string {
+  if (years.length === 0) {
+    return "Sem anos locais";
+  }
+
+  if (years.length === 1) {
+    return `${years[0]} local`;
+  }
+
+  return `${years[0]}-${years[years.length - 1]}`;
+}
 
 function compareCoverageRank(
   left: number | null,
@@ -26,27 +69,66 @@ function compareCoverageRank(
 
 export function getCompanyAvailability(
   item: CompanyDirectoryItem,
+  options?: CompanyAvailabilityOptions,
 ): CompanyAvailability {
-  const anos = item.anos_disponiveis ?? [];
-  const hasReadableHistory =
-    item.has_financial_data !== false && anos.length > 0;
+  const anos = getSortedYears(item);
+  const yearsLabel = getYearsLabel(anos);
+  const latestYear = anos[anos.length - 1] ?? null;
+  const hasReadableHistory = item.has_financial_data !== false && anos.length > 0;
 
-  if (hasReadableHistory) {
+  if (!hasReadableHistory) {
     return {
-      kind: "ready",
-      badge: "Pronta agora",
-      summary: "Historico anual liberado",
-      detail: "KPIs, demonstracoes e Excel disponiveis agora.",
-      yearsLabel: `${anos.length} ano${anos.length === 1 ? "" : "s"} locais`,
+      kind: "requestable",
+      badge: "Solicitar dados",
+      summary: "Carga on-demand",
+      detail:
+        "Ainda sem historico local. Abra a pagina para solicitar a primeira carga.",
+      yearsLabel,
+      actionLabel: "Abrir e solicitar",
+      compareEligible: false,
+    };
+  }
+
+  const referenceYear = getReferenceYear(options);
+  const isStalled = latestYear !== null && latestYear < referenceYear - STALE_YEAR_LAG;
+  const isLowSignal =
+    anos.length < MIN_READY_YEARS ||
+    (item.total_rows ?? 0) < MIN_READY_ROWS;
+
+  if (isStalled) {
+    return {
+      kind: "stalled",
+      badge: "Estagnada",
+      summary: "Historico antigo",
+      detail:
+        "Existe leitura local, mas o ano mais recente parece defasado para analise atual.",
+      yearsLabel,
+      actionLabel: "Revisar historico",
+      compareEligible: false,
+    };
+  }
+
+  if (isLowSignal) {
+    return {
+      kind: "low_signal",
+      badge: "Baixo sinal",
+      summary: "Leitura limitada",
+      detail:
+        "Ha dados locais, mas a cobertura ainda e curta para comparacoes fortes.",
+      yearsLabel,
+      actionLabel: "Conferir dados",
+      compareEligible: false,
     };
   }
 
   return {
-    kind: "requestable",
-    badge: "Solicitavel",
-    summary: "Ainda sem historico local",
-    detail: "Abra a empresa para disparar a primeira carga on-demand.",
-    yearsLabel: "Sem anos locais",
+    kind: "ready",
+    badge: "Pronta agora",
+    summary: "Analise completa",
+    detail: "KPIs, demonstracoes e Excel disponiveis agora.",
+    yearsLabel,
+    actionLabel: "Analisar agora",
+    compareEligible: true,
   };
 }
 
@@ -56,13 +138,13 @@ export function prioritizeDiscoveryCompanies(
 ): CompanyDirectoryItem[] {
   return [...items]
     .sort((left, right) => {
-      const leftReady =
-        left.has_financial_data !== false && (left.anos_disponiveis?.length ?? 0) > 0;
-      const rightReady =
-        right.has_financial_data !== false && (right.anos_disponiveis?.length ?? 0) > 0;
+      const leftAvailability = getCompanyAvailability(left);
+      const rightAvailability = getCompanyAvailability(right);
+      const stateDiff =
+        DISCOVERY_ORDER[leftAvailability.kind] - DISCOVERY_ORDER[rightAvailability.kind];
 
-      if (leftReady !== rightReady) {
-        return leftReady ? -1 : 1;
+      if (stateDiff !== 0) {
+        return stateDiff;
       }
 
       const yearsDiff =
@@ -91,9 +173,6 @@ export function selectReadyCompareCompanies(
   limit = 6,
 ): CompanyDirectoryItem[] {
   return prioritizeDiscoveryCompanies(items, items.length)
-    .filter(
-      (item) =>
-        item.has_financial_data !== false && (item.anos_disponiveis?.length ?? 0) > 0,
-    )
+    .filter((item) => getCompanyAvailability(item).compareEligible)
     .slice(0, limit);
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "eslint",
     "typecheck": "tsc --noEmit",
-    "test:unit": "node --experimental-strip-types --experimental-specifier-resolution=node --test tests/api-client.test.ts tests/companies-page-data.test.ts tests/company-detail-handoff.test.ts tests/company-period-range.test.ts tests/company-refresh-state.test.ts tests/compare-utils.test.ts tests/compare-page-data.test.ts tests/sectors-page-data.test.ts",
+    "test:unit": "node --experimental-strip-types --experimental-specifier-resolution=node --test tests/api-client.test.ts tests/companies-page-data.test.ts tests/company-detail-handoff.test.ts tests/company-discovery.test.ts tests/company-period-range.test.ts tests/company-refresh-state.test.ts tests/compare-utils.test.ts tests/compare-page-data.test.ts tests/sectors-page-data.test.ts",
     "test:e2e": "playwright test"
   },
   "dependencies": {

--- a/apps/web/tests/company-discovery.test.ts
+++ b/apps/web/tests/company-discovery.test.ts
@@ -1,0 +1,113 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { CompanyDirectoryItem } from "../lib/api.ts";
+import {
+  getCompanyAvailability,
+  prioritizeDiscoveryCompanies,
+  selectReadyCompareCompanies,
+} from "../lib/company-discovery.ts";
+
+function buildCompany(
+  cdCvm: number,
+  overrides: Partial<CompanyDirectoryItem> = {},
+): CompanyDirectoryItem {
+  return {
+    cd_cvm: cdCvm,
+    company_name: `Empresa ${cdCvm}`,
+    ticker_b3: `T${cdCvm}`,
+    setor_analitico: "Energia",
+    setor_cvm: "Energia",
+    sector_name: "Energia",
+    sector_slug: "energia",
+    has_financial_data: true,
+    coverage_rank: 1,
+    anos_disponiveis: [2023, 2024],
+    total_rows: 120,
+    ...overrides,
+  };
+}
+
+test("getCompanyAvailability marks strong local history as ready", () => {
+  const state = getCompanyAvailability(buildCompany(1), { referenceYear: 2026 });
+
+  assert.equal(state.kind, "ready");
+  assert.equal(state.badge, "Pronta agora");
+  assert.equal(state.yearsLabel, "2023-2024");
+  assert.equal(state.compareEligible, true);
+});
+
+test("getCompanyAvailability marks empty local history as requestable", () => {
+  const state = getCompanyAvailability(
+    buildCompany(2, {
+      has_financial_data: false,
+      anos_disponiveis: [],
+      total_rows: 0,
+      coverage_rank: null,
+    }),
+    { referenceYear: 2026 },
+  );
+
+  assert.equal(state.kind, "requestable");
+  assert.equal(state.summary, "Carga on-demand");
+  assert.equal(state.compareEligible, false);
+});
+
+test("getCompanyAvailability distinguishes low signal local coverage", () => {
+  const state = getCompanyAvailability(
+    buildCompany(3, {
+      anos_disponiveis: [2024],
+      total_rows: 120,
+    }),
+    { referenceYear: 2026 },
+  );
+
+  assert.equal(state.kind, "low_signal");
+  assert.equal(state.badge, "Baixo sinal");
+});
+
+test("getCompanyAvailability flags stale local history as stalled", () => {
+  const state = getCompanyAvailability(
+    buildCompany(4, {
+      anos_disponiveis: [2020, 2021],
+      total_rows: 120,
+    }),
+    { referenceYear: 2026 },
+  );
+
+  assert.equal(state.kind, "stalled");
+  assert.equal(state.summary, "Historico antigo");
+});
+
+test("prioritizeDiscoveryCompanies keeps strong entries ahead of weak suggestions", () => {
+  const items = [
+    buildCompany(4, { anos_disponiveis: [2020, 2021], total_rows: 120 }),
+    buildCompany(2, {
+      has_financial_data: false,
+      anos_disponiveis: [],
+      total_rows: 0,
+      coverage_rank: null,
+    }),
+    buildCompany(3, { anos_disponiveis: [2024], total_rows: 120 }),
+    buildCompany(1),
+  ];
+
+  const orderedIds = prioritizeDiscoveryCompanies(items).map((item) => item.cd_cvm);
+
+  assert.deepEqual(orderedIds, [1, 2, 3, 4]);
+});
+
+test("selectReadyCompareCompanies only returns companies eligible for compare", () => {
+  const result = selectReadyCompareCompanies([
+    buildCompany(1),
+    buildCompany(2, { anos_disponiveis: [2024], total_rows: 120 }),
+    buildCompany(3, {
+      has_financial_data: false,
+      anos_disponiveis: [],
+      total_rows: 0,
+      coverage_rank: null,
+    }),
+  ]);
+
+  assert.deepEqual(result.map((item) => item.cd_cvm), [1]);
+});

--- a/apps/web/tests/compare.spec.ts
+++ b/apps/web/tests/compare.spec.ts
@@ -118,6 +118,6 @@ test("busca do compare mostra feedback quando nenhuma empresa pronta e encontrad
   expect(response.url()).not.toContain(":8000/companies/suggestions");
 
   await expect(
-    page.getByText(/nenhuma companhia pronta para comparar apareceu com esse termo/i),
+    page.getByText(/nenhuma companhia pronta e comparavel apareceu com esse termo/i),
   ).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- Centralizes company discovery state into ready, requestable, low-signal, and stalled states.
- Reuses that hierarchy across home discovery cards, the companies directory, catalog fallback results, and compare entry copy.
- Adds deterministic unit coverage for state derivation and compare eligibility.

## Validation
- npm run test:unit
- npm run typecheck
- npm run lint
- npm run build
- git diff --check

Closes #177