### PR TITLE
[Task] FRONTEND: tighten mixed outcome freshness copy

### DIFF
--- a/apps/web/components/company/company-freshness-card.tsx
+++ b/apps/web/components/company/company-freshness-card.tsx
@@ -5,6 +5,10 @@ import {
   getUserFacingErrorMessage,
   type RefreshStatusItem,
 } from "@/lib/api";
+import {
+  type FreshnessBadgeTone,
+  getCompanyFreshnessCopy,
+} from "@/lib/company-refresh-state";
 import { cn } from "@/lib/utils";
 
 type CompanyFreshnessCardProps = {
@@ -69,96 +73,25 @@ function formatAbsolute(dateIso: string): string | null {
   return ABSOLUTE_TIME_FORMATTER.format(target);
 }
 
-function getStatusBadge(freshness: RefreshStatusItem | null) {
-  const trackingState = String(freshness?.tracking_state ?? "").toLowerCase();
-
-  if (trackingState === "queued" || trackingState === "running") {
-    return {
-      label: "Atualizando agora",
-      className:
-        "border-sky-500/25 bg-sky-500/10 text-sky-700 dark:text-sky-300",
-    };
+function getStatusBadgeClassName(tone: FreshnessBadgeTone): string {
+  switch (tone) {
+    case "active":
+      return "border-sky-500/25 bg-sky-500/10 text-sky-700 dark:text-sky-300";
+    case "ready":
+      return "border-emerald-500/25 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300";
+    case "warning":
+      return "border-amber-500/25 bg-amber-500/10 text-amber-700 dark:text-amber-300";
+    case "neutral":
+      return "border-border/70 bg-muted/55 text-muted-foreground";
+    default:
+      return "border-primary/20 bg-primary/8 text-primary/80";
   }
-
-  if (trackingState === "stalled") {
-    return {
-      label: "Sem sinais recentes",
-      className:
-        "border-amber-500/25 bg-amber-500/10 text-amber-700 dark:text-amber-300",
-    };
-  }
-
-  if (freshness?.has_readable_current_data) {
-    return {
-      label: "Leitura pronta",
-      className:
-        "border-emerald-500/25 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
-    };
-  }
-
-  return {
-    label: "Historico pendente",
-    className:
-      "border-primary/20 bg-primary/8 text-primary/80",
-  };
-}
-
-function getSummaryCopy(freshness: RefreshStatusItem | null): {
-  title: string;
-  description: string;
-} {
-  const trackingState = String(freshness?.tracking_state ?? "").toLowerCase();
-  const latestOutcome = String(
-    freshness?.latest_attempt_outcome ?? freshness?.last_status ?? "",
-  ).toLowerCase();
-
-  if (trackingState === "queued" || trackingState === "running") {
-    return {
-      title: "Atualizacao em andamento",
-      description:
-        freshness?.status_reason_message ??
-        "A leitura atual continua disponivel enquanto o refresh acompanha a fila interna e o processamento.",
-    };
-  }
-
-  if (trackingState === "stalled") {
-    return {
-      title: "Atualizacao sem previsao firme",
-      description:
-        freshness?.status_reason_message ??
-        "A ultima solicitacao perdeu sinais recentes de progresso. O acompanhamento abaixo permite conferir se vale tentar de novo.",
-    };
-  }
-
-  if (freshness?.has_readable_current_data && latestOutcome === "no_data") {
-    return {
-      title: "Leitura atual continua valida",
-      description:
-        freshness?.status_reason_message ??
-        "A ultima tentativa nao encontrou novos demonstrativos, mas a pagina continua com uma leitura local utilizavel.",
-    };
-  }
-
-  if (freshness?.has_readable_current_data) {
-    return {
-      title: "Dados prontos para leitura",
-      description:
-        "Use este controle quando quiser confirmar se houve novos demonstrativos ou atualizar a serie local desta empresa.",
-    };
-  }
-
-  return {
-    title: "Primeira leitura ainda pendente",
-    description:
-      freshness?.status_reason_message ??
-      "Esta empresa ainda nao tem historico anual liberado na base local. A solicitacao abaixo dispara a primeira carga on-demand.",
-  };
 }
 
 export async function CompanyFreshnessCard({
   cdCvm,
 }: CompanyFreshnessCardProps) {
-  let freshness = null;
+  let freshness: RefreshStatusItem | null = null;
   let fetchError: string | null = null;
 
   try {
@@ -167,8 +100,7 @@ export async function CompanyFreshnessCard({
     fetchError = getUserFacingErrorMessage(error);
   }
 
-  const summary = getSummaryCopy(freshness);
-  const statusBadge = getStatusBadge(freshness);
+  const summary = getCompanyFreshnessCopy(freshness);
   const materializedAt =
     freshness?.read_model_updated_at ?? freshness?.last_success_at ?? null;
   const sourceLabel = freshness?.source_label ?? "Leitura CVM processada";
@@ -190,10 +122,10 @@ export async function CompanyFreshnessCard({
           <span
             className={cn(
               "rounded-full border px-2.5 py-1 text-[0.64rem] font-medium uppercase tracking-[0.16em]",
-              statusBadge.className,
+              getStatusBadgeClassName(summary.badgeTone),
             )}
           >
-            {statusBadge.label}
+            {summary.badgeLabel}
           </span>
           <span className="rounded-full border border-border/65 px-2.5 py-1 text-[0.64rem] font-medium uppercase tracking-[0.16em] text-muted-foreground">
             {sourceLabel}
@@ -235,11 +167,19 @@ export async function CompanyFreshnessCard({
           <dd className="text-right text-foreground">{readableYearsLabel}</dd>
         </div>
         <div className="flex items-baseline justify-between gap-3">
-          <dt className="text-muted-foreground">Ultimo resultado</dt>
+          <dt className="text-muted-foreground">{summary.latestResultLabel}</dt>
           <dd className="max-w-[18rem] text-right text-foreground/85">
-            {freshness?.status_reason_message ?? "Sem tentativa recente registrada"}
+            {summary.latestResultDescription}
           </dd>
         </div>
+        {summary.retryHint ? (
+          <div className="flex items-baseline justify-between gap-3">
+            <dt className="text-muted-foreground">Proximo passo</dt>
+            <dd className="max-w-[18rem] text-right text-foreground/85">
+              {summary.retryHint}
+            </dd>
+          </div>
+        ) : null}
       </dl>
 
       {fetchError ? (

--- a/apps/web/components/company/company-no-data.tsx
+++ b/apps/web/components/company/company-no-data.tsx
@@ -10,7 +10,12 @@ import {
 import { CompanyRequestRefreshLazy } from "@/components/company/company-request-refresh-lazy";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { buttonVariants } from "@/components/ui/button";
-import { fetchCompanyFreshness, type CompanyInfo } from "@/lib/api";
+import {
+  fetchCompanyFreshness,
+  type CompanyInfo,
+  type RefreshStatusItem,
+} from "@/lib/api";
+import { getCompanyFreshnessCopy } from "@/lib/company-refresh-state";
 import { cn } from "@/lib/utils";
 
 type CompanyNoDataPageProps = {
@@ -50,7 +55,7 @@ function ExpectationCard({ title, description }: ExpectationCardProps) {
 export async function CompanyNoDataPage({ company }: CompanyNoDataPageProps) {
   const sectorLabel =
     company.sector_name || company.setor_analitico || company.setor_cvm || "Setor nao informado";
-  let initialFreshness = null;
+  let initialFreshness: RefreshStatusItem | null = null;
 
   try {
     initialFreshness = await fetchCompanyFreshness(company.cd_cvm);
@@ -58,8 +63,10 @@ export async function CompanyNoDataPage({ company }: CompanyNoDataPageProps) {
     initialFreshness = null;
   }
 
-  const lastOutcomeMessage =
-    initialFreshness?.status_reason_message ?? null;
+  const freshnessCopy = initialFreshness
+    ? getCompanyFreshnessCopy(initialFreshness)
+    : null;
+  const lastOutcomeMessage = freshnessCopy?.latestResultDescription ?? null;
 
   return (
     <PageShell density="relaxed" className="max-w-5xl">
@@ -112,6 +119,7 @@ export async function CompanyNoDataPage({ company }: CompanyNoDataPageProps) {
             <AlertTitle>O que destrava esta pagina</AlertTitle>
             <AlertDescription>
               A solicitacao on-demand busca uma serie anual utilizavel na CVM e, quando encontra material suficiente, libera esta mesma aba para leitura. Se a CVM nao tiver historico anual processavel, o resultado aparece aqui de forma clara em vez de falhar em silencio.
+              {freshnessCopy?.retryHint ? ` ${freshnessCopy.retryHint}` : ""}
             </AlertDescription>
           </Alert>
 

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -73,6 +73,8 @@ export type CompanyInfo = {
   has_readable_current_data: boolean;
   readable_years_count: number;
   latest_readable_year: number | null;
+  read_availability_code: string | null;
+  read_availability_message: string | null;
 };
 
 export type RefreshDispatchResponse = {
@@ -123,6 +125,14 @@ export type RefreshStatusItem = {
   readable_years_count: number;
   latest_readable_year: number | null;
   latest_attempt_outcome: string | null;
+  latest_attempt_reason_code: string | null;
+  latest_attempt_reason_message: string | null;
+  latest_attempt_retryable: boolean;
+  read_availability_code: string | null;
+  read_availability_message: string | null;
+  freshness_summary_code: string | null;
+  freshness_summary_message: string | null;
+  freshness_summary_severity: string | null;
   source_label: string | null;
 };
 
@@ -132,11 +142,15 @@ type RawCompanyInfo = Omit<
   | "has_readable_current_data"
   | "readable_years_count"
   | "latest_readable_year"
+  | "read_availability_code"
+  | "read_availability_message"
 > & {
   read_model_updated_at?: string | null;
   has_readable_current_data?: boolean;
   readable_years_count?: number;
   latest_readable_year?: number | null;
+  read_availability_code?: string | null;
+  read_availability_message?: string | null;
 };
 
 type RawRefreshStatusItem = Omit<
@@ -157,6 +171,14 @@ type RawRefreshStatusItem = Omit<
   | "readable_years_count"
   | "latest_readable_year"
   | "latest_attempt_outcome"
+  | "latest_attempt_reason_code"
+  | "latest_attempt_reason_message"
+  | "latest_attempt_retryable"
+  | "read_availability_code"
+  | "read_availability_message"
+  | "freshness_summary_code"
+  | "freshness_summary_message"
+  | "freshness_summary_severity"
   | "source_label"
 > & {
   job_id?: string | null;
@@ -184,6 +206,14 @@ type RawRefreshStatusItem = Omit<
   readable_years_count?: number;
   latest_readable_year?: number | null;
   latest_attempt_outcome?: string | null;
+  latest_attempt_reason_code?: string | null;
+  latest_attempt_reason_message?: string | null;
+  latest_attempt_retryable?: boolean;
+  read_availability_code?: string | null;
+  read_availability_message?: string | null;
+  freshness_summary_code?: string | null;
+  freshness_summary_message?: string | null;
+  freshness_summary_severity?: string | null;
   source_label?: string | null;
 };
 
@@ -447,7 +477,9 @@ function isCompanyInfo(value: unknown): value is RawCompanyInfo {
     isOptionalBoolean(value.has_readable_current_data) &&
     (value.readable_years_count === undefined ||
       typeof value.readable_years_count === "number") &&
-    isOptionalNullableNumber(value.latest_readable_year)
+    isOptionalNullableNumber(value.latest_readable_year) &&
+    isOptionalNullableString(value.read_availability_code) &&
+    isOptionalNullableString(value.read_availability_message)
   );
 }
 
@@ -540,6 +572,14 @@ function isRefreshStatusItem(value: unknown): value is RawRefreshStatusItem {
       typeof value.readable_years_count === "number") &&
     isOptionalNullableNumber(value.latest_readable_year) &&
     isOptionalNullableString(value.latest_attempt_outcome) &&
+    isOptionalNullableString(value.latest_attempt_reason_code) &&
+    isOptionalNullableString(value.latest_attempt_reason_message) &&
+    isOptionalBoolean(value.latest_attempt_retryable) &&
+    isOptionalNullableString(value.read_availability_code) &&
+    isOptionalNullableString(value.read_availability_message) &&
+    isOptionalNullableString(value.freshness_summary_code) &&
+    isOptionalNullableString(value.freshness_summary_message) &&
+    isOptionalNullableString(value.freshness_summary_severity) &&
     isOptionalNullableString(value.source_label)
   );
 }
@@ -578,6 +618,14 @@ function normalizeRefreshStatusItem(
     readable_years_count: item.readable_years_count ?? 0,
     latest_readable_year: item.latest_readable_year ?? null,
     latest_attempt_outcome: item.latest_attempt_outcome ?? null,
+    latest_attempt_reason_code: item.latest_attempt_reason_code ?? null,
+    latest_attempt_reason_message: item.latest_attempt_reason_message ?? null,
+    latest_attempt_retryable: item.latest_attempt_retryable ?? false,
+    read_availability_code: item.read_availability_code ?? null,
+    read_availability_message: item.read_availability_message ?? null,
+    freshness_summary_code: item.freshness_summary_code ?? null,
+    freshness_summary_message: item.freshness_summary_message ?? null,
+    freshness_summary_severity: item.freshness_summary_severity ?? null,
     source_label: item.source_label ?? null,
   };
 }
@@ -589,6 +637,8 @@ function normalizeCompanyInfo(company: RawCompanyInfo): CompanyInfo {
     has_readable_current_data: company.has_readable_current_data ?? false,
     readable_years_count: company.readable_years_count ?? 0,
     latest_readable_year: company.latest_readable_year ?? null,
+    read_availability_code: company.read_availability_code ?? null,
+    read_availability_message: company.read_availability_message ?? null,
   };
 }
 

--- a/apps/web/lib/company-refresh-state.ts
+++ b/apps/web/lib/company-refresh-state.ts
@@ -8,6 +8,7 @@ export type RefreshPhase =
   | "running"
   | "reconnecting"
   | "delayed"
+  | "mixed_outcome"
   | "no_data"
   | "terminal_error"
   | "success";
@@ -46,6 +47,23 @@ export type RefreshViewModel = {
   showRequestAgainButton: boolean;
 };
 
+export type FreshnessBadgeTone =
+  | "active"
+  | "ready"
+  | "warning"
+  | "pending"
+  | "neutral";
+
+export type CompanyFreshnessCopy = {
+  badgeLabel: string;
+  badgeTone: FreshnessBadgeTone;
+  title: string;
+  description: string;
+  latestResultLabel: string;
+  latestResultDescription: string;
+  retryHint: string | null;
+};
+
 export const POLL_INTERVAL_MS = 5_000;
 export const POLL_TIMEOUT_MS = 15 * 60 * 1_000;
 export const RELOAD_DELAY_MS = 1_200;
@@ -62,6 +80,11 @@ function normalizeStatus(status: string | null | undefined): string {
   return String(status || "").trim().toLowerCase();
 }
 
+function cleanText(value: string | null | undefined): string | null {
+  const text = String(value ?? "").trim();
+  return text ? text : null;
+}
+
 function getTrackingState(item: RefreshStatusItem | null | undefined): string {
   const trackingState = normalizeStatus(item?.tracking_state);
   if (trackingState) {
@@ -76,6 +99,60 @@ function getProgressMode(item: RefreshStatusItem | null | undefined): string {
 
 function hasReadableData(item: RefreshStatusItem | null | undefined): boolean {
   return item?.has_readable_current_data === true;
+}
+
+function getFreshnessSummaryCode(
+  item: RefreshStatusItem | null | undefined,
+): string {
+  return normalizeStatus(item?.freshness_summary_code);
+}
+
+function getLatestAttemptReasonCode(
+  item: RefreshStatusItem | null | undefined,
+): string {
+  return normalizeStatus(
+    item?.latest_attempt_reason_code ?? item?.status_reason_code,
+  );
+}
+
+function getFreshnessSummaryMessage(
+  item: RefreshStatusItem | null | undefined,
+): string | null {
+  return (
+    cleanText(item?.freshness_summary_message) ??
+    cleanText(item?.status_reason_message)
+  );
+}
+
+function getLatestAttemptMessage(
+  item: RefreshStatusItem | null | undefined,
+): string | null {
+  return (
+    cleanText(item?.latest_attempt_reason_message) ??
+    cleanText(item?.status_reason_message) ??
+    cleanText(item?.progress_message) ??
+    cleanText(item?.last_error)
+  );
+}
+
+function isReadableMixedOutcome(
+  item: RefreshStatusItem | null | undefined,
+): boolean {
+  if (!item || !hasReadableData(item)) {
+    return false;
+  }
+
+  const summaryCode = getFreshnessSummaryCode(item);
+  const trackingState = getTrackingState(item);
+  const latestOutcome = normalizeStatus(item.latest_attempt_outcome);
+
+  return (
+    summaryCode.startsWith("mixed_") ||
+    trackingState === "no_data" ||
+    trackingState === "error" ||
+    latestOutcome === "no_data" ||
+    latestOutcome === "error"
+  );
 }
 
 function isActiveRefreshItem(item: RefreshStatusItem | null | undefined): boolean {
@@ -135,13 +212,14 @@ function getRunningMessage(
 ): { message: string; detail: string } {
   return {
     message:
-      item?.progress_message ??
       item?.status_reason_message ??
+      item?.progress_message ??
       "Atualizando demonstracoes financeiras...",
     detail:
-      item?.stage
+      item?.progress_message ??
+      (item?.stage
         ? `Etapa atual: ${getStageLabel(item).toLowerCase()}.`
-        : "Os dados desta companhia estao sendo processados agora.",
+        : "Os dados desta companhia estao sendo processados agora."),
   };
 }
 
@@ -152,6 +230,7 @@ function getBadgeClassName(phase: RefreshPhase): string {
     case "reconnecting":
       return "border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-300";
     case "delayed":
+    case "mixed_outcome":
       return "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300";
     case "no_data":
       return "border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-300";
@@ -287,6 +366,7 @@ function buildRefreshEstimate(state: RefreshMachineState): RefreshEstimate | nul
   if (
     state.phase === "idle" ||
     state.phase === "terminal_error" ||
+    state.phase === "mixed_outcome" ||
     state.phase === "no_data"
   ) {
     return null;
@@ -584,16 +664,33 @@ export function hasRefreshTimedOut(
 export function createDelayedRefreshState(
   state: RefreshMachineState,
 ): RefreshMachineState {
+  const item = state.currentItem ?? state.lastKnownActiveItem;
+
   return {
     ...state,
     phase: "delayed",
-    currentItem: state.currentItem ?? state.lastKnownActiveItem,
+    currentItem: item,
     failureCount: 0,
-    canRequestAgain: state.currentItem?.is_retry_allowed ?? false,
+    canRequestAgain: item?.is_retry_allowed ?? false,
     notice:
-      state.currentItem?.status_reason_message ??
+      getFreshnessSummaryMessage(item) ??
       state.notice ??
       null,
+  };
+}
+
+function createMixedOutcomeRefreshState(
+  state: RefreshMachineState,
+  item: RefreshStatusItem,
+): RefreshMachineState {
+  return {
+    ...state,
+    phase: "mixed_outcome",
+    currentItem: item,
+    failureCount: 0,
+    canRequestAgain: item.is_retry_allowed || item.latest_attempt_retryable,
+    notice: getFreshnessSummaryMessage(item),
+    terminalMessage: null,
   };
 }
 
@@ -727,6 +824,10 @@ export function applyRefreshStatusResult(
   }
 
   if (trackingState === "no_data") {
+    if (isReadableMixedOutcome(item)) {
+      return createMixedOutcomeRefreshState(state, item);
+    }
+
     return {
       ...state,
       phase: "no_data",
@@ -743,6 +844,10 @@ export function applyRefreshStatusResult(
   }
 
   if (trackingState === "error" || TERMINAL_REFRESH_STATUSES.has(trackingState)) {
+    if (isReadableMixedOutcome(item)) {
+      return createMixedOutcomeRefreshState(state, item);
+    }
+
     return {
       ...state,
       phase: "terminal_error",
@@ -777,7 +882,7 @@ export function applyRefreshStatusResult(
         nowMs,
       canRequestAgain: item.is_retry_allowed ?? false,
       notice:
-        item.status_reason_message ??
+        getFreshnessSummaryMessage(item) ??
         "A ultima solicitacao perdeu previsibilidade.",
     };
   }
@@ -868,14 +973,14 @@ export function getRefreshViewModel(
     case "delayed":
       return {
         showCard: true,
-        title: "Atualizacao sem sinais recentes",
+        title: "Atualizacao demorando mais que o normal",
         message:
           state.notice ??
-          "Esta solicitacao perdeu previsibilidade e precisa de uma nova checagem.",
+          "Esta atualizacao esta demorando mais que o normal.",
         detail: state.canRequestAgain
           ? "Atualize o status agora. Se a solicitacao ja tiver expirado, voce tambem pode pedir novamente."
           : "Atualize o status manualmente para verificar se o processamento voltou a responder.",
-        stepLabel: "Travado",
+        stepLabel: "Demorado",
         stepClassName: getBadgeClassName(state.phase),
         isDestructive: false,
         estimate,
@@ -884,19 +989,42 @@ export function getRefreshViewModel(
         showManualStatusButton: true,
         showRequestAgainButton: state.canRequestAgain,
       };
+    case "mixed_outcome":
+      return {
+        showCard: true,
+        title: "Leitura atual preservada",
+        message:
+          state.notice ??
+          "A ultima tentativa nao substituiu a leitura que ja esta disponivel.",
+        detail: state.canRequestAgain
+          ? "Voce pode solicitar novamente se esperar documentos novos ou se a falha parecer temporaria."
+          : "Nao ha acao obrigatoria agora: os dados ja materializados continuam disponiveis.",
+        stepLabel:
+          getLatestAttemptReasonCode(currentItem) === "refresh_failed_retryable"
+            ? "Retry possivel"
+            : "Leitura preservada",
+        stepClassName: getBadgeClassName(state.phase),
+        isDestructive: false,
+        estimate,
+        requestButtonLabel: "Solicitar novamente",
+        requestButtonDisabled: false,
+        showManualStatusButton: false,
+        showRequestAgainButton: false,
+      };
     case "no_data":
       return {
         showCard: true,
         title: hasReadableData(currentItem)
-          ? "Nenhum novo demonstrativo encontrado"
-          : "Nenhum dado encontrado",
+          ? "Leitura atual preservada"
+          : "Sem historico anual legivel",
         message:
+          getFreshnessSummaryMessage(currentItem) ??
           state.terminalMessage ??
           "Nenhuma demonstracao foi encontrada para o intervalo solicitado.",
         detail: hasReadableData(currentItem)
-          ? "A leitura atual da empresa continua disponivel. Voce pode tentar novamente se esperar novos documentos."
-          : "Esse resultado e terminal e informativo. Voce pode solicitar novamente depois, se necessario.",
-        stepLabel: "Sem dados",
+          ? "A ultima tentativa nao encontrou novos demonstrativos; a leitura atual continua disponivel."
+          : "Tentar novamente so deve ajudar se a CVM publicar ou corrigir novos documentos.",
+        stepLabel: hasReadableData(currentItem) ? "Sem novos dados" : "Sem dados",
         stepClassName: getBadgeClassName(state.phase),
         isDestructive: false,
         estimate,
@@ -908,11 +1036,12 @@ export function getRefreshViewModel(
     case "terminal_error":
       return {
         showCard: true,
-        title: "Refresh indisponivel",
+        title: "Atualizacao nao concluida",
         message:
+          getLatestAttemptMessage(currentItem) ??
           state.terminalMessage ??
           "Nao foi possivel concluir a atualizacao desta empresa.",
-        detail: "Voce pode solicitar novamente em instantes.",
+        detail: "Se a falha for temporaria, solicite novamente em instantes.",
         stepLabel: "Falha",
         stepClassName: getBadgeClassName(state.phase),
         isDestructive: true,
@@ -926,10 +1055,13 @@ export function getRefreshViewModel(
       return {
         showCard: true,
         title: "Atualizacao concluida",
-        message: state.notice ?? "Dados disponiveis! Recarregando...",
+        message:
+          getFreshnessSummaryMessage(currentItem) ??
+          state.notice ??
+          "Dados disponiveis! Recarregando...",
         detail: hasReadableData(currentItem)
           ? "A pagina sera atualizada para refletir a nova leitura disponivel."
-          : "A pagina sera atualizada para refletir o estado mais recente.",
+          : "A pagina sera atualizada para confirmar o estado mais recente.",
         stepLabel: "Concluido",
         stepClassName: getBadgeClassName(state.phase),
         isDestructive: false,
@@ -955,4 +1087,214 @@ export function getRefreshViewModel(
         showRequestAgainButton: false,
       };
   }
+}
+
+function getLatestResultLabel(
+  item: RefreshStatusItem | null | undefined,
+): string {
+  const reasonCode = getLatestAttemptReasonCode(item);
+
+  switch (reasonCode) {
+    case "already_current":
+      return "Ja atualizado";
+    case "refresh_completed":
+      return "Concluido";
+    case "no_new_financial_history":
+      return "Sem novos demonstrativos";
+    case "no_annual_history":
+    case "no_financial_history_found":
+      return "Sem serie anual";
+    case "refresh_failed":
+    case "refresh_failed_retryable":
+      return "Falha retryable";
+    case "refresh_tracking_lost":
+    case "refresh_stalled":
+    case "refresh_expired":
+      return "Sem sinais recentes";
+    case "refresh_queued":
+    case "refresh_running":
+      return "Em andamento";
+    default:
+      return item ? "Ultima tentativa" : "Sem tentativa";
+  }
+}
+
+export function getCompanyFreshnessCopy(
+  freshness: RefreshStatusItem | null,
+): CompanyFreshnessCopy {
+  const trackingState = getTrackingState(freshness);
+  const summaryCode = getFreshnessSummaryCode(freshness);
+  const reasonCode = getLatestAttemptReasonCode(freshness);
+  const summaryMessage = getFreshnessSummaryMessage(freshness);
+  const latestResultDescription =
+    getLatestAttemptMessage(freshness) ?? "Sem tentativa recente registrada.";
+  const latestResultLabel = getLatestResultLabel(freshness);
+
+  if (!freshness) {
+    return {
+      badgeLabel: "Historico pendente",
+      badgeTone: "pending",
+      title: "Primeira leitura ainda pendente",
+      description:
+        "Esta empresa ainda nao tem uma leitura anual registrada na base local.",
+      latestResultLabel,
+      latestResultDescription,
+      retryHint:
+        "Solicite a carga on-demand para tentar materializar a primeira leitura.",
+    };
+  }
+
+  if (trackingState === "queued" || trackingState === "running") {
+    return {
+      badgeLabel: "Atualizando agora",
+      badgeTone: "active",
+      title: "Atualizacao em andamento",
+      description:
+        summaryMessage ??
+        "A leitura atual continua disponivel enquanto o refresh acompanha a fila interna e o processamento.",
+      latestResultLabel,
+      latestResultDescription,
+      retryHint: null,
+    };
+  }
+
+  if (summaryCode === "already_current" || reasonCode === "already_current") {
+    return {
+      badgeLabel: "Ja atualizada",
+      badgeTone: "ready",
+      title: "Leitura ja atualizada",
+      description:
+        summaryMessage ??
+        "A ultima verificacao confirmou que nao havia dados novos para baixar.",
+      latestResultLabel,
+      latestResultDescription,
+      retryHint:
+        "Solicite novamente apenas se voce espera uma publicacao nova na CVM.",
+    };
+  }
+
+  if (summaryCode === "mixed_no_new_data_readable") {
+    return {
+      badgeLabel: "Sem novos dados",
+      badgeTone: "neutral",
+      title: "Leitura atual preservada",
+      description:
+        summaryMessage ??
+        "A ultima tentativa nao encontrou novos demonstrativos; a leitura atual continua disponivel.",
+      latestResultLabel,
+      latestResultDescription,
+      retryHint:
+        "Tente novamente somente se houver expectativa de documentos novos.",
+    };
+  }
+
+  if (summaryCode === "mixed_retryable_error_readable") {
+    return {
+      badgeLabel: "Leitura preservada",
+      badgeTone: "warning",
+      title: "Leitura atual preservada",
+      description:
+        summaryMessage ??
+        "A leitura atual continua disponivel, mas a ultima atualizacao falhou e pode ser tentada novamente.",
+      latestResultLabel,
+      latestResultDescription,
+      retryHint:
+        "Como a falha e retryable, vale solicitar novamente em instantes.",
+    };
+  }
+
+  if (summaryCode === "mixed_refresh_stalled_readable") {
+    return {
+      badgeLabel: "Leitura preservada",
+      badgeTone: "warning",
+      title: "Leitura atual disponivel",
+      description:
+        summaryMessage ??
+        "A leitura atual continua disponivel, mas a ultima solicitacao ficou sem sinais recentes.",
+      latestResultLabel,
+      latestResultDescription,
+      retryHint:
+        "Atualize o status antes de solicitar novamente para evitar duplicar trabalho.",
+    };
+  }
+
+  if (
+    summaryCode === "no_annual_history" ||
+    reasonCode === "no_annual_history" ||
+    reasonCode === "no_financial_history_found"
+  ) {
+    return {
+      badgeLabel: "Sem serie anual",
+      badgeTone: "neutral",
+      title: "Sem historico anual legivel",
+      description:
+        summaryMessage ??
+        "Nenhuma serie anual legivel foi encontrada para esta companhia.",
+      latestResultLabel,
+      latestResultDescription,
+      retryHint:
+        "Tentar novamente so deve ajudar se a CVM publicar ou corrigir documentos.",
+    };
+  }
+
+  if (
+    summaryCode === "refresh_failed_retryable" ||
+    reasonCode === "refresh_failed_retryable" ||
+    reasonCode === "refresh_failed"
+  ) {
+    return {
+      badgeLabel: "Falha retryable",
+      badgeTone: "warning",
+      title: "Atualizacao nao concluida",
+      description:
+        summaryMessage ??
+        "A ultima atualizacao falhou e ainda nao ha leitura anual disponivel.",
+      latestResultLabel,
+      latestResultDescription,
+      retryHint: "Solicite novamente em instantes se a API da CVM ja estiver estavel.",
+    };
+  }
+
+  if (summaryCode === "refresh_completed_no_readable") {
+    return {
+      badgeLabel: "Leitura pendente",
+      badgeTone: "warning",
+      title: "Atualizacao concluida sem leitura",
+      description:
+        summaryMessage ??
+        "A atualizacao terminou, mas a leitura anual ainda nao esta disponivel.",
+      latestResultLabel,
+      latestResultDescription,
+      retryHint:
+        "Atualize novamente apenas se houver motivo para esperar novos dados.",
+    };
+  }
+
+  if (hasReadableData(freshness)) {
+    return {
+      badgeLabel: "Leitura pronta",
+      badgeTone: "ready",
+      title: "Dados prontos para leitura",
+      description:
+        freshness.read_availability_message ??
+        "Use este controle quando quiser confirmar se houve novos demonstrativos ou atualizar a serie local desta empresa.",
+      latestResultLabel,
+      latestResultDescription,
+      retryHint:
+        "Uma nova solicitacao verifica documentos recentes sem remover a leitura atual.",
+    };
+  }
+
+  return {
+    badgeLabel: "Historico pendente",
+    badgeTone: "pending",
+    title: "Primeira leitura ainda pendente",
+    description:
+      summaryMessage ??
+      "Esta empresa ainda nao tem historico anual liberado na base local.",
+    latestResultLabel,
+    latestResultDescription,
+    retryHint:
+      "Solicite a carga on-demand para tentar materializar a primeira leitura.",
+  };
 }

--- a/apps/web/tests/api-client.test.ts
+++ b/apps/web/tests/api-client.test.ts
@@ -256,6 +256,8 @@ test("fetchCompanyInfo accepts readable handoff fields from company detail", asy
         has_readable_current_data: true,
         readable_years_count: 2,
         latest_readable_year: 2024,
+        read_availability_code: "readable_history_available",
+        read_availability_message: "Leitura anual disponivel ate 2024.",
       }),
       {
         status: 200,
@@ -276,6 +278,8 @@ test("fetchCompanyInfo accepts readable handoff fields from company detail", asy
     assert.equal(payload?.readable_years_count, 2);
     assert.equal(payload?.latest_readable_year, 2024);
     assert.equal(payload?.read_model_updated_at, "2026-04-21T12:05:00+00:00");
+    assert.equal(payload?.read_availability_code, "readable_history_available");
+    assert.equal(payload?.read_availability_message, "Leitura anual disponivel ate 2024.");
   } finally {
     restore();
   }
@@ -311,6 +315,8 @@ test("fetchCompanyInfo normalizes missing readable handoff fields", async () => 
     assert.equal(payload?.readable_years_count, 0);
     assert.equal(payload?.latest_readable_year, null);
     assert.equal(payload?.read_model_updated_at, null);
+    assert.equal(payload?.read_availability_code, null);
+    assert.equal(payload?.read_availability_message, null);
   } finally {
     restore();
   }
@@ -634,6 +640,16 @@ test("fetchRefreshStatus accepts estimated progress fields from the API", async 
           readable_years_count: 0,
           latest_readable_year: 2024,
           latest_attempt_outcome: "queued",
+          latest_attempt_reason_code: "refresh_queued",
+          latest_attempt_reason_message:
+            "Solicitacao recebida e aguardando processamento interno.",
+          latest_attempt_retryable: false,
+          read_availability_code: "readable_history_available",
+          read_availability_message: "Leitura anual disponivel ate 2024.",
+          freshness_summary_code: "refresh_queued",
+          freshness_summary_message:
+            "Solicitacao recebida e aguardando processamento interno.",
+          freshness_summary_severity: "info",
           source_label: "Solicitacao on-demand",
         },
       ]),
@@ -661,6 +677,15 @@ test("fetchRefreshStatus accepts estimated progress fields from the API", async 
     assert.equal(payload[0]?.status_reason_code, "refresh_queued");
     assert.equal(payload[0]?.has_readable_current_data, false);
     assert.equal(payload[0]?.latest_readable_year, 2024);
+    assert.equal(payload[0]?.latest_attempt_reason_code, "refresh_queued");
+    assert.equal(
+      payload[0]?.latest_attempt_reason_message,
+      "Solicitacao recebida e aguardando processamento interno.",
+    );
+    assert.equal(payload[0]?.latest_attempt_retryable, false);
+    assert.equal(payload[0]?.read_availability_code, "readable_history_available");
+    assert.equal(payload[0]?.freshness_summary_code, "refresh_queued");
+    assert.equal(payload[0]?.freshness_summary_severity, "info");
     assert.equal(payload[0]?.read_model_updated_at, "2026-04-21T12:05:00+00:00");
     assert.equal(payload[0]?.source_label, "Solicitacao on-demand");
   } finally {
@@ -715,6 +740,14 @@ test("fetchRefreshStatus normalizes missing estimate fields from legacy payloads
     assert.equal(payload[0]?.readable_years_count, 0);
     assert.equal(payload[0]?.latest_readable_year, null);
     assert.equal(payload[0]?.read_model_updated_at, null);
+    assert.equal(payload[0]?.latest_attempt_reason_code, null);
+    assert.equal(payload[0]?.latest_attempt_reason_message, null);
+    assert.equal(payload[0]?.latest_attempt_retryable, false);
+    assert.equal(payload[0]?.read_availability_code, null);
+    assert.equal(payload[0]?.read_availability_message, null);
+    assert.equal(payload[0]?.freshness_summary_code, null);
+    assert.equal(payload[0]?.freshness_summary_message, null);
+    assert.equal(payload[0]?.freshness_summary_severity, null);
   } finally {
     restore();
   }
@@ -759,6 +792,14 @@ test("fetchCompanyFreshness normalizes missing estimate fields from legacy API p
     assert.equal(payload?.has_readable_current_data, false);
     assert.equal(payload?.latest_readable_year, null);
     assert.equal(payload?.read_model_updated_at, null);
+    assert.equal(payload?.latest_attempt_reason_code, null);
+    assert.equal(payload?.latest_attempt_reason_message, null);
+    assert.equal(payload?.latest_attempt_retryable, false);
+    assert.equal(payload?.read_availability_code, null);
+    assert.equal(payload?.read_availability_message, null);
+    assert.equal(payload?.freshness_summary_code, null);
+    assert.equal(payload?.freshness_summary_message, null);
+    assert.equal(payload?.freshness_summary_severity, null);
   } finally {
     restore();
   }

--- a/apps/web/tests/company-detail-handoff.test.ts
+++ b/apps/web/tests/company-detail-handoff.test.ts
@@ -24,6 +24,8 @@ function buildCompanyInfo(overrides: Partial<CompanyInfo> = {}): CompanyInfo {
     has_readable_current_data: false,
     readable_years_count: 0,
     latest_readable_year: null,
+    read_availability_code: null,
+    read_availability_message: null,
     ...overrides,
   };
 }
@@ -68,6 +70,14 @@ function buildRefreshStatusItem(
     readable_years_count: 2,
     latest_readable_year: 2024,
     latest_attempt_outcome: "success",
+    latest_attempt_reason_code: "refresh_completed",
+    latest_attempt_reason_message: "Dados prontos para leitura nesta pagina.",
+    latest_attempt_retryable: false,
+    read_availability_code: "readable_history_available",
+    read_availability_message: "Leitura anual disponivel ate 2024.",
+    freshness_summary_code: "refresh_completed_readable",
+    freshness_summary_message: "Dados prontos para leitura nesta pagina.",
+    freshness_summary_severity: "success",
     source_label: "Base local materializada",
     ...overrides,
   };

--- a/apps/web/tests/company-refresh-state.test.ts
+++ b/apps/web/tests/company-refresh-state.test.ts
@@ -10,6 +10,7 @@ import {
   createDispatchedRefreshState,
   getNextPollingDelayMs,
   getReconnectDelayMs,
+  getCompanyFreshnessCopy,
   getRefreshViewModel,
   hasRefreshTimedOut,
   hydrateRefreshState,
@@ -57,6 +58,14 @@ function buildRefreshStatusItem(
     readable_years_count: 0,
     latest_readable_year: null,
     latest_attempt_outcome: null,
+    latest_attempt_reason_code: null,
+    latest_attempt_reason_message: null,
+    latest_attempt_retryable: false,
+    read_availability_code: null,
+    read_availability_message: null,
+    freshness_summary_code: null,
+    freshness_summary_message: null,
+    freshness_summary_severity: null,
     source_label: null,
     ...overrides,
   };
@@ -253,9 +262,9 @@ test("delayed state appears after the timeout threshold without turning destruct
   assert.equal(view.showManualStatusButton, true);
   assert.equal(
     view.message,
-    "Esta solicitacao perdeu previsibilidade e precisa de uma nova checagem.",
+    "Esta atualizacao esta demorando mais que o normal.",
   );
-  assert.equal(view.stepLabel, "Travado");
+  assert.equal(view.stepLabel, "Demorado");
 });
 
 test("manual refresh from delayed enables request again when no active status is found", () => {
@@ -297,6 +306,102 @@ test("no_data is treated as a terminal informative state", () => {
   assert.equal(view.isDestructive, false);
   assert.equal(view.message, "Nenhuma demonstracao encontrada para 2010-2025.");
   assert.equal(view.requestButtonDisabled, false);
+});
+
+test("mixed no-data freshness copy preserves the readable current data", () => {
+  const copy = getCompanyFreshnessCopy(
+    buildRefreshStatusItem({
+      last_status: "no_data",
+      tracking_state: "no_data",
+      has_readable_current_data: true,
+      readable_years_count: 8,
+      latest_readable_year: 2024,
+      latest_attempt_outcome: "no_data",
+      latest_attempt_reason_code: "no_new_financial_history",
+      latest_attempt_reason_message:
+        "A ultima tentativa nao encontrou novos demonstrativos.",
+      freshness_summary_code: "mixed_no_new_data_readable",
+      freshness_summary_message:
+        "A ultima tentativa nao encontrou novos demonstrativos; a leitura atual continua disponivel.",
+      freshness_summary_severity: "info",
+      is_retry_allowed: true,
+      latest_attempt_retryable: true,
+    }),
+  );
+
+  assert.equal(copy.badgeLabel, "Sem novos dados");
+  assert.equal(copy.title, "Leitura atual preservada");
+  assert.equal(
+    copy.description,
+    "A ultima tentativa nao encontrou novos demonstrativos; a leitura atual continua disponivel.",
+  );
+  assert.equal(copy.latestResultLabel, "Sem novos demonstrativos");
+});
+
+test("mixed retryable error stays non-destructive when readable data exists", () => {
+  const item = buildRefreshStatusItem({
+    last_status: "error",
+    tracking_state: "error",
+    last_error: "HTTP 500 ao consultar CVM",
+    has_readable_current_data: true,
+    readable_years_count: 8,
+    latest_readable_year: 2024,
+    latest_attempt_outcome: "error",
+    latest_attempt_reason_code: "refresh_failed_retryable",
+    latest_attempt_reason_message:
+      "Nao foi possivel concluir a atualizacao desta empresa agora.",
+    latest_attempt_retryable: true,
+    freshness_summary_code: "mixed_retryable_error_readable",
+    freshness_summary_message:
+      "A leitura atual continua disponivel, mas a ultima atualizacao falhou e pode ser tentada novamente.",
+    freshness_summary_severity: "warning",
+    is_retry_allowed: true,
+  });
+  const state = applyRefreshStatusResult(
+    createDispatchedRefreshState(Date.now()),
+    item,
+    Date.now(),
+  );
+
+  assert.equal(state.phase, "mixed_outcome");
+
+  const view = getRefreshViewModel(state);
+  assert.equal(view.isDestructive, false);
+  assert.equal(view.requestButtonDisabled, false);
+  assert.equal(view.stepLabel, "Retry possivel");
+  assert.equal(
+    view.message,
+    "A leitura atual continua disponivel, mas a ultima atualizacao falhou e pode ser tentada novamente.",
+  );
+
+  const copy = getCompanyFreshnessCopy(item);
+  assert.equal(copy.badgeLabel, "Leitura preservada");
+  assert.equal(copy.title, "Leitura atual preservada");
+});
+
+test("no annual history copy sets a clear terminal expectation", () => {
+  const copy = getCompanyFreshnessCopy(
+    buildRefreshStatusItem({
+      last_status: "no_data",
+      tracking_state: "no_data",
+      status_reason_code: "no_financial_history_found",
+      latest_attempt_outcome: "no_data",
+      latest_attempt_reason_code: "no_annual_history",
+      latest_attempt_reason_message:
+        "Nenhuma serie anual legivel foi encontrada para esta companhia.",
+      freshness_summary_code: "no_annual_history",
+      freshness_summary_message:
+        "Nenhuma serie anual legivel foi encontrada para esta companhia.",
+      freshness_summary_severity: "info",
+      is_retry_allowed: true,
+      latest_attempt_retryable: true,
+    }),
+  );
+
+  assert.equal(copy.badgeLabel, "Sem serie anual");
+  assert.equal(copy.title, "Sem historico anual legivel");
+  assert.equal(copy.latestResultLabel, "Sem serie anual");
+  assert.match(copy.retryHint ?? "", /CVM/);
 });
 
 test("initial terminal no_data stays neutral when readable data already exists", () => {
@@ -400,4 +505,34 @@ test("already_current uses the success state for immediate reload", () => {
   assert.equal(state.phase, "success");
   assert.equal(view.message, "Empresa ja atualizada para 2010-2025.");
   assert.equal(view.requestButtonDisabled, true);
+});
+
+test("already_current freshness copy avoids implying a new download", () => {
+  const copy = getCompanyFreshnessCopy(
+    buildRefreshStatusItem({
+      last_status: "success",
+      tracking_state: "success",
+      has_readable_current_data: true,
+      readable_years_count: 8,
+      latest_readable_year: 2024,
+      status_reason_code: "already_current",
+      status_reason_message:
+        "Esta empresa ja estava atualizada para a janela padrao.",
+      latest_attempt_outcome: "success",
+      latest_attempt_reason_code: "already_current",
+      latest_attempt_reason_message:
+        "Esta empresa ja estava atualizada para a janela padrao.",
+      freshness_summary_code: "already_current",
+      freshness_summary_message:
+        "A leitura local ja estava atualizada para a janela padrao.",
+      freshness_summary_severity: "success",
+    }),
+  );
+
+  assert.equal(copy.badgeLabel, "Ja atualizada");
+  assert.equal(copy.title, "Leitura ja atualizada");
+  assert.equal(
+    copy.description,
+    "A leitura local ja estava atualizada para a janela padrao.",
+  );
 });

--- a/apps/web/tests/compare-page-data.test.ts
+++ b/apps/web/tests/compare-page-data.test.ts
@@ -24,6 +24,8 @@ function buildCompany(
     has_readable_current_data: true,
     readable_years_count: 2,
     latest_readable_year: 2024,
+    read_availability_code: "readable_history_available",
+    read_availability_message: "Leitura anual disponivel ate 2024.",
   };
 }
 

--- a/apps/web/tests/compare-utils.test.ts
+++ b/apps/web/tests/compare-utils.test.ts
@@ -30,6 +30,8 @@ function buildCompany(
     has_readable_current_data: true,
     readable_years_count: 1,
     latest_readable_year: 2024,
+    read_availability_code: "readable_history_available",
+    read_availability_message: "Leitura anual disponivel ate 2024.",
   };
 }
 


### PR DESCRIPTION
## Summary
- consume refresh/readability reason fields from #178 in the web API client
- derive freshness-card copy from semantic outcome codes instead of raw status heuristics
- keep readable local data calm/non-destructive when the latest refresh has no new data or a retryable error
- improve retry guidance for already-current, no-annual-history, mixed, delayed, and terminal states

## Validation
- npm run test:unit
- npm run typecheck
- npm run lint
- npm run build
- git diff --check

Closes #179