### PR TITLE
[Task #181] Document on-demand release evidence

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -8,7 +8,7 @@
 
 ---
 
-## Estado Atual (2026-04-18)
+## Estado Atual (2026-04-23)
 
 ### Dashboard
 - **3 abas renderizadas** em `dashboard/app.py`: `Visao Geral`, `Demonstracoes`, `Download`
@@ -41,7 +41,8 @@
 
 ### Testes
 - `pytest tests/ -q` — V1; `pytest apps/api/tests -q` — V2 API
-- `apps/web`: `npm run lint`, `npm run typecheck`, `npm run build`, `npm run test:e2e`
+- `apps/web`: `npm run lint`, `npm run typecheck`, `npm run build`, `npm run test:unit`, `npm run test:e2e`
+- CI `test-web` tambem gateia `tests/smoke.spec.ts` com seed SQLite isolado para on-demand
 
 ### URLs Publicas
 - **API (Railway):** `https://analisys-production.up.railway.app`
@@ -85,11 +86,10 @@
 - `scripts/register_jules_pr.ps1` deixa de fazer parte do fluxo oficial
 - Configuracao de governanca do Jules versionada em `.github/guardrails/path-policy.json`
 
-### Sessao 38 - 2026-04-12 (governanca retroativa para PRs do Jules)
-- Workflow dedicado criado para detectar PRs do Jules e orientar regularizacao da governanca
-- `PR Issue Guardrails` aceita `PR-first` somente quando autoria for do Jules e issue retroativa estiver vinculada
-- Tasks retroativas usam `Workspace da task = jules://github/pr/<numero>` e label `automation:jules`
-- `scripts/register_jules_pr.ps1` criado para criar task retroativa e atualizar a PR
+### Sessao 49 - 2026-04-23 (on-demand regression gates e checklist de evidencia)
+- CI `test-web` passa a rodar `npm run test:unit` e `tests/smoke.spec.ts`
+- `scripts/seed_web_smoke_db.py` cria seed SQLite isolado para o smoke web
+- Checklist duravel de evidencia on-demand vive em `docs/governance/on-demand-release-evidence.md`
 
 ---
 

--- a/docs/governance/on-demand-release-evidence.md
+++ b/docs/governance/on-demand-release-evidence.md
@@ -1,0 +1,60 @@
+# On-Demand Release Evidence
+
+Este checklist define a barra minima para mudancas estrategicas no fluxo
+on-demand. Ele complementa os gates automatizados; nao substitui testes.
+
+## Quando usar
+
+Use este checklist em PRs que alterem busca/entrada, detalhe de companhia sem
+dados, polling/wait state, handoff de sucesso, outcomes terminais, mensagens de
+freshness ou continuidade mobile do fluxo on-demand.
+
+Mudancas sem impacto no on-demand podem apenas declarar "nao aplicavel" no PR.
+
+## Gates automatizados
+
+O job `test-web` do workflow `CI` deve passar com estes passos:
+
+- `Run web unit tests`: executa `npm run test:unit`.
+- `Seed web smoke database`: executa `python ../../scripts/seed_web_smoke_db.py`.
+- `Run on-demand Playwright smoke`: executa `npm run test:e2e -- tests/smoke.spec.ts`.
+
+O smoke cobre entrada por busca, sugestoes same-origin, detalhe sem historico e
+navegacao mobile critica. Os unitarios cobrem polling/wait, handoff de sucesso,
+outcomes terminais e cenarios mistos de dados legiveis.
+
+## Checklist de aceitacao
+
+- Search/entry: busca da home ou do compare chega ao destino certo sem CORS ou
+  chamada direta para host externo.
+- Wait/polling: estados `queued`, `running`, reconnecting e delayed mantem
+  feedback nao destrutivo e caminho de recuperacao.
+- Success handoff: sucesso tecnico so vira sucesso de leitura quando existe
+  `has_readable_current_data` ou sinal equivalente.
+- Mobile continuity: navegacao essencial continua acessivel no viewport mobile.
+- Terminal outcomes: `success`, `no_data`, `error`, stalled e already-current
+  mostram copy e CTA coerentes.
+- Mixed readable outcomes: erro/no-data retryable preserva a leitura existente
+  quando `has_readable_current_data=true`.
+- CI evidence: linkar o run do workflow `CI` com `test-web` verde.
+- Manual evidence: anexar screenshot/trace apenas quando a PR muda UI visivel
+  ou comportamento de navegacao que o smoke nao consegue demonstrar sozinho.
+
+## Evidencia minima no PR
+
+Inclua no corpo ou comentario final do PR:
+
+- Issue/task vinculada.
+- Comandos locais executados, quando aplicavel.
+- Link para o run de CI.
+- Resultado dos gates de on-demand.
+- Riscos ou lacunas assumidas, incluindo itens future-stage only.
+
+## Future-stage only
+
+Nao bloquear releases atuais por itens que ainda nao existem no produto:
+
+- progresso realtime por SSE/websockets;
+- notificacoes email, push ou inbox;
+- session replay ou analytics pagos;
+- historico detalhado de jobs para usuario final.

--- a/docs/releases/on-demand-hardening-evidence-template.md
+++ b/docs/releases/on-demand-hardening-evidence-template.md
@@ -1,0 +1,40 @@
+# On-Demand Hardening Evidence Template
+
+Use este template em release notes ou PRs que entreguem mudancas estrategicas no
+fluxo on-demand.
+
+## Escopo validado
+
+- Issue/PR:
+- Tipo de mudanca:
+- Rotas ou endpoints afetados:
+- Fora de escopo declarado:
+
+## Gates obrigatorios
+
+- `CI / test-web / Run web unit tests`:
+- `CI / test-web / Seed web smoke database`:
+- `CI / test-web / Run on-demand Playwright smoke`:
+- `PR Issue Guardrails`:
+- `perf-guardrails`:
+
+## Checklist funcional
+
+- Search/entry:
+- Wait/polling:
+- Success handoff:
+- Mobile continuity:
+- Terminal outcomes:
+- Mixed readable outcomes:
+
+## Evidencia manual, se aplicavel
+
+Anexe screenshots, traces ou notas de navegacao somente quando a mudanca altera
+UI visivel, copy critica, layout mobile ou um fluxo que os gates automatizados
+nao demonstram sozinho.
+
+## Lacunas aceitas
+
+- Future-stage only:
+- Risco residual:
+- Follow-up issue, se houver:


### PR DESCRIPTION
## Summary
- Documents the durable on-demand release evidence checklist under governance docs.
- Adds a release-facing evidence template for future on-demand hardening PRs/releases.
- Updates docs/AGENTS.md with the merged #180 gate names while keeping the file at 150 lines.

## Validation
- python scripts/sync_docs_check.py
- git diff --check
- Verified documented gate names/commands against .github/workflows/ci.yml from #180.

Closes #181
