### PR TITLE
[Task] Productionize #189 on company pages and formalize #190 as the real home

### DIFF
--- a/apps/web/app/demo-analysis/layout.tsx
+++ b/apps/web/app/demo-analysis/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "Demo Analysis (Internal)",
+  description: "Laboratorio interno de composicao visual para o dashboard de analise.",
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+type DemoAnalysisLayoutProps = {
+  children: ReactNode;
+};
+
+export default function DemoAnalysisLayout({
+  children,
+}: DemoAnalysisLayoutProps) {
+  return children;
+}

--- a/apps/web/app/empresas/[cd_cvm]/page.tsx
+++ b/apps/web/app/empresas/[cd_cvm]/page.tsx
@@ -202,7 +202,12 @@ export default async function EmpresaDetailPage({
 
       {currentTab === "visao-geral" ? (
         bundle ? (
-          <CompanyOverview bundle={bundle} cdCvm={cdCvm} />
+          <CompanyOverview
+            company={company}
+            bundle={bundle}
+            cdCvm={cdCvm}
+            selectedYears={selectedYears}
+          />
         ) : (
           <Alert className="rounded-[1.75rem] border border-destructive/25 bg-destructive/6 px-5 py-5 text-left">
             <AlertTitle>Visao geral indisponivel</AlertTitle>

--- a/apps/web/app/empresas/[cd_cvm]/page.tsx
+++ b/apps/web/app/empresas/[cd_cvm]/page.tsx
@@ -122,7 +122,15 @@ export default async function EmpresaDetailPage({
   try {
     [company, availableYears] = await Promise.all([
       fetchCompanyInfo(cdCvm, { request: DETAIL_PAGE_MUTABLE_API_READ }),
-      fetchCompanyYears(cdCvm, { request: DETAIL_PAGE_MUTABLE_API_READ }),
+      fetchCompanyYears(cdCvm, { request: DETAIL_PAGE_MUTABLE_API_READ }).catch(
+        (error) => {
+          if (isApiClientError(error) && error.code === "not_found") {
+            return [];
+          }
+
+          throw error;
+        },
+      ),
     ]);
   } catch (error) {
     if (isApiClientError(error) && error.code === "not_found") {

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -2,6 +2,7 @@ import { BentoFeatures } from "@/components/home/bento-features";
 import { CompanySearchHero } from "@/components/home/company-search-hero";
 import { CtaSection } from "@/components/home/cta-section";
 import { DiscoverySectionLazy } from "@/components/home/discovery-section-lazy";
+import { HomeTrustStrip } from "@/components/home/home-trust-strip";
 import { StatsStrip } from "@/components/home/stats-strip";
 import { PageShell } from "@/components/shared/design-system-recipes";
 import { fetchCompanies } from "@/lib/api";
@@ -27,6 +28,9 @@ export default async function HomePage() {
 
       {/* Stats Strip */}
       <StatsStrip totalCompanies={totalCompanies} />
+
+      {/* Trust and live health */}
+      <HomeTrustStrip totalCompanies={totalCompanies} />
 
       {/* Bento Features Grid */}
       <BentoFeatures />

--- a/apps/web/components/company/company-analysis-chart.tsx
+++ b/apps/web/components/company/company-analysis-chart.tsx
@@ -1,0 +1,427 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import type {
+  CompanyDashboardModel,
+  DashboardFormatType,
+  DashboardSelectedIndicator,
+} from "@/lib/company-dashboard";
+
+type CompanyAnalysisChartProps = {
+  chartSeries: CompanyDashboardModel["chartSeries"];
+  selectedIndicators: DashboardSelectedIndicator[];
+};
+
+const CHART_COLORS = [
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+];
+
+type AxisStats = {
+  min: number;
+  max: number;
+};
+
+function formatCompactCurrency(value: number): string {
+  return new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(value);
+}
+
+function formatMetricValue(value: number, formatType: DashboardFormatType): string {
+  if (formatType === "pct") {
+    return `${(value * 100).toFixed(1)}%`;
+  }
+
+  if (formatType === "ratio") {
+    return `${value.toFixed(2)}x`;
+  }
+
+  return formatCompactCurrency(value);
+}
+
+function formatAxisValue(value: number, formatType: DashboardFormatType | "mixed"): string {
+  if (formatType === "pct") {
+    return `${(value * 100).toFixed(0)}%`;
+  }
+
+  if (formatType === "ratio") {
+    return `${value.toFixed(1)}x`;
+  }
+
+  if (formatType === "mixed") {
+    return value.toFixed(1);
+  }
+
+  return formatCompactCurrency(value);
+}
+
+function buildAxisStats(values: number[]): AxisStats {
+  if (values.length === 0) {
+    return { min: 0, max: 1 };
+  }
+
+  const rawMin = Math.min(...values, 0);
+  const rawMax = Math.max(...values, 0);
+
+  if (rawMin === rawMax) {
+    return {
+      min: rawMin === 0 ? 0 : rawMin * 0.9,
+      max: rawMax === 0 ? 1 : rawMax * 1.1,
+    };
+  }
+
+  const padding = (rawMax - rawMin) * 0.08;
+  return {
+    min: rawMin - padding,
+    max: rawMax + padding,
+  };
+}
+
+function buildTicks(stats: AxisStats, count = 5): number[] {
+  return Array.from({ length: count }, (_, index) => {
+    const ratio = index / (count - 1);
+    return stats.min + (stats.max - stats.min) * ratio;
+  });
+}
+
+export function CompanyAnalysisChart({
+  chartSeries,
+  selectedIndicators,
+}: CompanyAnalysisChartProps) {
+  const [hoveredYear, setHoveredYear] = useState<number | null>(null);
+
+  const activeSeries = useMemo(
+    () =>
+      selectedIndicators.flatMap((selection, index) => {
+        const series = chartSeries[selection.id];
+        if (!series || series.points.length === 0) {
+          return [];
+        }
+
+        return [
+          {
+            ...series,
+            chartType: selection.chartType,
+            color: CHART_COLORS[index % CHART_COLORS.length],
+          },
+        ];
+      }),
+    [chartSeries, selectedIndicators],
+  );
+
+  const years = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          activeSeries.flatMap((series) => series.points.map((point) => point.year)),
+        ),
+      ).sort((left, right) => left - right),
+    [activeSeries],
+  );
+
+  if (activeSeries.length === 0 || years.length === 0) {
+    return (
+      <div className="flex h-[320px] items-center justify-center rounded-[1.25rem] border border-dashed border-border/70 bg-muted/16 text-sm text-muted-foreground">
+        Selecione indicadores com historico anual para visualizar o grafico.
+      </div>
+    );
+  }
+
+  const valueSeries = activeSeries.filter((series) => series.formatType === "brl");
+  const relativeSeries = activeSeries.filter((series) => series.formatType !== "brl");
+  const valueStats = buildAxisStats(valueSeries.flatMap((series) => series.points.map((point) => point.value)));
+  const relativeStats = buildAxisStats(
+    relativeSeries.flatMap((series) => series.points.map((point) => point.value)),
+  );
+  const rightAxisMode: DashboardFormatType | "mixed" =
+    relativeSeries.length === 0
+      ? "mixed"
+      : relativeSeries.every((series) => series.formatType === "pct")
+        ? "pct"
+        : relativeSeries.every((series) => series.formatType === "ratio")
+          ? "ratio"
+          : "mixed";
+
+  const W = 760;
+  const H = 320;
+  const PAD = { top: 28, right: 72, bottom: 44, left: 82 };
+  const innerW = W - PAD.left - PAD.right;
+  const innerH = H - PAD.top - PAD.bottom;
+  const slot = innerW / Math.max(years.length, 1);
+  const barSeriesCount = activeSeries.filter((series) => series.chartType === "bar").length;
+  const barWidth = barSeriesCount > 0 ? Math.min((slot * 0.62) / barSeriesCount, 34) : 24;
+
+  function getAxisForFormat(formatType: DashboardFormatType): AxisStats {
+    return formatType === "brl" ? valueStats : relativeStats;
+  }
+
+  function toX(index: number): number {
+    return PAD.left + index * slot + slot / 2;
+  }
+
+  function toY(value: number, formatType: DashboardFormatType): number {
+    const axis = getAxisForFormat(formatType);
+    return PAD.top + innerH - ((value - axis.min) / (axis.max - axis.min || 1)) * innerH;
+  }
+
+  function getBaseline(formatType: DashboardFormatType): number {
+    return toY(0, formatType);
+  }
+
+  function buildLinePath(
+    points: Array<{ year: number; value: number }>,
+    formatType: DashboardFormatType,
+  ): string {
+    return points
+      .map((point, index) => {
+        const yearIndex = years.indexOf(point.year);
+        const x = toX(yearIndex);
+        const y = toY(point.value, formatType);
+        return `${index === 0 ? "M" : "L"}${x},${y}`;
+      })
+      .join(" ");
+  }
+
+  function buildAreaPath(
+    points: Array<{ year: number; value: number }>,
+    formatType: DashboardFormatType,
+  ): string {
+    const linePath = buildLinePath(points, formatType);
+    const firstYearIndex = years.indexOf(points[0]!.year);
+    const lastYearIndex = years.indexOf(points.at(-1)!.year);
+    const baseline = getBaseline(formatType);
+    return `${linePath} L${toX(lastYearIndex)},${baseline} L${toX(firstYearIndex)},${baseline} Z`;
+  }
+
+  const hoveredEntries =
+    hoveredYear === null
+      ? []
+      : activeSeries.flatMap((series) => {
+          const point = series.points.find((item) => item.year === hoveredYear);
+          if (!point) {
+            return [];
+          }
+
+          return [
+            {
+              color: series.color,
+              label: series.label,
+              formatType: series.formatType,
+              value: point.value,
+            },
+          ];
+        });
+
+  return (
+    <div className="space-y-4">
+      <div className="overflow-x-auto rounded-[1.35rem] border border-border/60 bg-background/72 px-4 py-5">
+        <svg viewBox={`0 0 ${W} ${H}`} className="min-w-[680px] w-full" style={{ height: H }}>
+          {buildTicks(valueStats).map((tick) => (
+            <line
+              key={`value-grid-${tick}`}
+              x1={PAD.left}
+              x2={W - PAD.right}
+              y1={toY(tick, "brl")}
+              y2={toY(tick, "brl")}
+              stroke="var(--border)"
+              strokeOpacity="0.45"
+              strokeDasharray={Math.abs(tick) < 0.00001 ? "0" : "4 4"}
+            />
+          ))}
+
+          {valueSeries.length > 0
+            ? buildTicks(valueStats).map((tick) => (
+                <text
+                  key={`value-tick-${tick}`}
+                  x={PAD.left - 10}
+                  y={toY(tick, "brl")}
+                  textAnchor="end"
+                  dominantBaseline="middle"
+                  fontSize={10}
+                  fill="var(--muted-foreground)"
+                >
+                  {formatAxisValue(tick, "brl")}
+                </text>
+              ))
+            : null}
+
+          {relativeSeries.length > 0
+            ? buildTicks(relativeStats).map((tick) => (
+                <text
+                  key={`relative-tick-${tick}`}
+                  x={W - PAD.right + 10}
+                  y={toY(tick, relativeSeries[0]?.formatType ?? "pct")}
+                  textAnchor="start"
+                  dominantBaseline="middle"
+                  fontSize={10}
+                  fill="var(--muted-foreground)"
+                >
+                  {formatAxisValue(tick, rightAxisMode)}
+                </text>
+              ))
+            : null}
+
+          {years.map((year, index) => (
+            <g key={year}>
+              <line
+                x1={toX(index)}
+                x2={toX(index)}
+                y1={PAD.top}
+                y2={H - PAD.bottom}
+                stroke="var(--border)"
+                strokeOpacity={hoveredYear === year ? 0.5 : 0}
+              />
+              <rect
+                x={toX(index) - slot / 2}
+                y={PAD.top}
+                width={slot}
+                height={innerH}
+                fill="transparent"
+                onMouseEnter={() => setHoveredYear(year)}
+                onMouseLeave={() => setHoveredYear(null)}
+              />
+              <text
+                x={toX(index)}
+                y={H - 12}
+                textAnchor="middle"
+                fontSize={11}
+                fill="var(--muted-foreground)"
+              >
+                {year}
+              </text>
+            </g>
+          ))}
+
+          {activeSeries.map((series, seriesIndex) => {
+            if (series.chartType === "bar") {
+              const barIndex = activeSeries
+                .filter((item) => item.chartType === "bar")
+                .findIndex((item) => item.id === series.id);
+
+              return (
+                <g key={series.id}>
+                  {series.points.map((point) => {
+                    const yearIndex = years.indexOf(point.year);
+                    const xCenter = toX(yearIndex);
+                    const baseline = getBaseline(series.formatType);
+                    const y = toY(point.value, series.formatType);
+                    const height = Math.abs(baseline - y);
+                    const x =
+                      xCenter -
+                      (barSeriesCount * barWidth) / 2 +
+                      barWidth / 2 +
+                      barIndex * barWidth;
+
+                    return (
+                      <rect
+                        key={`${series.id}-${point.year}`}
+                        x={x}
+                        y={Math.min(y, baseline)}
+                        width={barWidth}
+                        height={Math.max(height, 1)}
+                        rx={5}
+                        fill={series.color}
+                        fillOpacity={hoveredYear === point.year ? 1 : 0.78}
+                      />
+                    );
+                  })}
+                </g>
+              );
+            }
+
+            const path = buildLinePath(series.points, series.formatType);
+            const areaPath =
+              series.chartType === "area"
+                ? buildAreaPath(series.points, series.formatType)
+                : null;
+
+            return (
+              <g key={series.id}>
+                {areaPath ? (
+                  <path d={areaPath} fill={series.color} fillOpacity={0.14} />
+                ) : null}
+                <path
+                  d={path}
+                  fill="none"
+                  stroke={series.color}
+                  strokeWidth={2.4}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                {series.points.map((point) => {
+                  const yearIndex = years.indexOf(point.year);
+                  return (
+                    <circle
+                      key={`${series.id}-${point.year}`}
+                      cx={toX(yearIndex)}
+                      cy={toY(point.value, series.formatType)}
+                      r={hoveredYear === point.year ? 5 : 3}
+                      fill={series.color}
+                      stroke="var(--background)"
+                      strokeWidth={2}
+                    />
+                  );
+                })}
+              </g>
+            );
+          })}
+        </svg>
+      </div>
+
+      <div className="flex flex-wrap items-start gap-3">
+        {activeSeries.map((series) => (
+          <div
+            key={series.id}
+            className="flex items-center gap-2 rounded-full border border-border/60 bg-muted/18 px-3 py-1.5 text-xs"
+          >
+            <span
+              className="size-2.5 rounded-full"
+              style={{ backgroundColor: series.color }}
+            />
+            <span className="font-medium text-foreground">{series.label}</span>
+          </div>
+        ))}
+      </div>
+
+      {hoveredYear !== null && hoveredEntries.length > 0 ? (
+        <div className="rounded-[1.25rem] border border-border/60 bg-muted/18 px-4 py-3">
+          <p className="text-[0.72rem] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+            Ano em foco
+          </p>
+          <div className="mt-2 flex flex-wrap items-start gap-3">
+            <p className="font-heading text-2xl tracking-[-0.03em] text-foreground">
+              {hoveredYear}
+            </p>
+            <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+              {hoveredEntries.map((entry) => (
+                <div
+                  key={entry.label}
+                  className="min-w-[11rem] rounded-[1rem] border border-border/50 bg-background/75 px-3 py-2"
+                >
+                  <div className="flex items-center gap-2">
+                    <span
+                      className="size-2 rounded-full"
+                      style={{ backgroundColor: entry.color }}
+                    />
+                    <p className="text-sm font-medium text-foreground">{entry.label}</p>
+                  </div>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    {formatMetricValue(entry.value, entry.formatType)}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/components/company/company-analysis-panel-lazy.tsx
+++ b/apps/web/components/company/company-analysis-panel-lazy.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+import type { CompanyDashboardModel } from "@/lib/company-dashboard";
+
+const CompanyAnalysisPanel = dynamic(
+  () =>
+    import("@/components/company/company-analysis-panel").then(
+      (module) => module.CompanyAnalysisPanel,
+    ),
+  {
+    loading: () => (
+      <div className="space-y-4 rounded-[1.75rem] border border-border/60 bg-background/82 p-6">
+        <div className="space-y-2">
+          <div className="h-3 w-28 animate-pulse rounded-full bg-muted/70" />
+          <div className="h-8 w-72 animate-pulse rounded-full bg-muted/60" />
+          <div className="h-4 w-full max-w-2xl animate-pulse rounded-full bg-muted/50" />
+        </div>
+        <div className="h-[320px] animate-pulse rounded-[1.25rem] border border-border/60 bg-muted/28" />
+        <div className="h-52 animate-pulse rounded-[1.25rem] border border-border/60 bg-muted/20" />
+      </div>
+    ),
+  },
+);
+
+type CompanyAnalysisPanelLazyProps = {
+  model: CompanyDashboardModel;
+};
+
+export function CompanyAnalysisPanelLazy({
+  model,
+}: CompanyAnalysisPanelLazyProps) {
+  return <CompanyAnalysisPanel model={model} />;
+}

--- a/apps/web/components/company/company-analysis-panel.tsx
+++ b/apps/web/components/company/company-analysis-panel.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  AreaChartIcon,
+  BarChart3Icon,
+  LineChartIcon,
+  SearchIcon,
+} from "lucide-react";
+
+import { IndicatorSelector } from "@/components/analysis/indicator-selector";
+import { CompanyAnalysisChart } from "@/components/company/company-analysis-chart";
+import { SurfaceCard } from "@/components/shared/design-system-recipes";
+import { Input } from "@/components/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type {
+  CompanyDashboardModel,
+  DashboardSelectedIndicator,
+} from "@/lib/company-dashboard";
+import { formatKpiDelta, formatKpiValue } from "@/lib/formatters";
+
+type CompanyAnalysisPanelProps = {
+  model: CompanyDashboardModel;
+};
+
+function getChartIcon(chartType: DashboardSelectedIndicator["chartType"]) {
+  switch (chartType) {
+    case "line":
+      return LineChartIcon;
+    case "area":
+      return AreaChartIcon;
+    default:
+      return BarChart3Icon;
+  }
+}
+
+export function CompanyAnalysisPanel({ model }: CompanyAnalysisPanelProps) {
+  const [selectedIndicators, setSelectedIndicators] = useState<DashboardSelectedIndicator[]>(
+    model.defaultSelectedIndicators,
+  );
+  const [search, setSearch] = useState("");
+
+  useEffect(() => {
+    const validIds = new Set(model.indicatorOptions.map((indicator) => indicator.id));
+    const nextSelection = selectedIndicators.filter((indicator) =>
+      validIds.has(indicator.id),
+    );
+
+    if (nextSelection.length > 0) {
+      if (nextSelection.length !== selectedIndicators.length) {
+        setSelectedIndicators(nextSelection);
+      }
+      return;
+    }
+
+    setSelectedIndicators(model.defaultSelectedIndicators);
+  }, [model.defaultSelectedIndicators, model.indicatorOptions, selectedIndicators]);
+
+  const selectedIds = useMemo(
+    () => new Set(selectedIndicators.map((indicator) => indicator.id)),
+    [selectedIndicators],
+  );
+
+  const filteredRows = useMemo(() => {
+    const query = search.trim().toLowerCase();
+
+    return [...model.tableRows]
+      .filter((row) => {
+        if (!query) {
+          return true;
+        }
+
+        return (
+          row.label.toLowerCase().includes(query) ||
+          row.category.toLowerCase().includes(query)
+        );
+      })
+      .sort((left, right) => {
+        const leftSelected = selectedIds.has(left.id) ? 0 : 1;
+        const rightSelected = selectedIds.has(right.id) ? 0 : 1;
+        if (leftSelected !== rightSelected) {
+          return leftSelected - rightSelected;
+        }
+
+        return left.label.localeCompare(right.label);
+      });
+  }, [model.tableRows, search, selectedIds]);
+
+  return (
+    <SurfaceCard tone="default" padding="lg" className="space-y-6" data-testid="company-analysis-panel">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="space-y-2">
+          <p className="text-[0.72rem] font-medium uppercase tracking-[0.2em] text-muted-foreground">
+            Analise de indicadores
+          </p>
+          <h2 className="font-heading text-[1.5rem] tracking-[-0.03em] text-foreground">
+            Visao anual em um unico painel
+          </h2>
+          <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
+            Escolha os indicadores que entram no grafico e compare o mesmo recorte
+            anual aplicado a esta pagina.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <IndicatorSelector
+            indicators={model.indicatorOptions}
+            selected={selectedIndicators}
+            onSelectionChange={setSelectedIndicators}
+            maxSelections={5}
+            className="min-w-[220px]"
+          />
+          <div className="rounded-full border border-border/60 bg-muted/18 px-3 py-2 text-xs text-muted-foreground">
+            Periodo atual: <span className="font-medium text-foreground">{model.yearsLabel}</span>
+          </div>
+        </div>
+      </div>
+
+      {selectedIndicators.length > 0 ? (
+        <div className="flex flex-wrap items-center gap-2">
+          {selectedIndicators.map((indicator) => {
+            const option = model.indicatorOptions.find((item) => item.id === indicator.id);
+            if (!option) {
+              return null;
+            }
+
+            const ChartIcon = getChartIcon(indicator.chartType);
+            return (
+              <div
+                key={indicator.id}
+                className="flex items-center gap-1.5 rounded-full border border-border/60 bg-muted/18 px-3 py-1.5 text-xs"
+              >
+                <span className="font-medium text-foreground">{option.label}</span>
+                <ChartIcon className="size-3.5 text-muted-foreground" />
+              </div>
+            );
+          })}
+        </div>
+      ) : null}
+
+      <CompanyAnalysisChart
+        chartSeries={model.chartSeries}
+        selectedIndicators={selectedIndicators}
+      />
+
+      <div className="space-y-4 rounded-[1.35rem] border border-border/60 bg-muted/16 p-4">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <p className="text-[0.72rem] font-medium uppercase tracking-[0.2em] text-muted-foreground">
+              Tabela anual
+            </p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Indicadores visiveis neste recorte. Os selecionados no grafico sobem
+              para o topo.
+            </p>
+          </div>
+          <div className="relative w-full max-w-sm">
+            <SearchIcon className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              type="search"
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Filtrar indicador ou categoria..."
+              className="h-10 rounded-full border-border/60 bg-background pl-9"
+            />
+          </div>
+        </div>
+
+        <div className="overflow-x-auto rounded-[1.15rem] border border-border/60 bg-background/82">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Indicador</TableHead>
+                <TableHead>Categoria</TableHead>
+                {model.years.map((year) => (
+                  <TableHead key={year} className="text-right">
+                    {year}
+                  </TableHead>
+                ))}
+                <TableHead className="text-right">Delta YoY</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {filteredRows.map((row) => (
+                <TableRow key={row.id} data-selected={selectedIds.has(row.id) || undefined}>
+                  <TableCell className="min-w-[14rem] font-medium text-foreground">
+                    {row.label}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">{row.category}</TableCell>
+                  {model.years.map((year) => (
+                    <TableCell key={`${row.id}-${year}`} className="text-right font-mono">
+                      {formatKpiValue(row.valuesByYear[year], row.formatType)}
+                    </TableCell>
+                  ))}
+                  <TableCell className="text-right font-mono text-muted-foreground">
+                    {formatKpiDelta(row.delta, row.formatType)}
+                  </TableCell>
+                </TableRow>
+              ))}
+              {filteredRows.length === 0 ? (
+                <TableRow>
+                  <TableCell
+                    colSpan={model.years.length + 3}
+                    className="py-10 text-center text-sm text-muted-foreground"
+                  >
+                    Nenhum indicador apareceu com esse filtro.
+                  </TableCell>
+                </TableRow>
+              ) : null}
+            </TableBody>
+          </Table>
+        </div>
+      </div>
+    </SurfaceCard>
+  );
+}

--- a/apps/web/components/company/company-analysis-panel.tsx
+++ b/apps/web/components/company/company-analysis-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import {
   AreaChartIcon,
   BarChart3Icon,
@@ -46,26 +46,22 @@ export function CompanyAnalysisPanel({ model }: CompanyAnalysisPanelProps) {
     model.defaultSelectedIndicators,
   );
   const [search, setSearch] = useState("");
-
-  useEffect(() => {
+  const effectiveSelectedIndicators = useMemo(() => {
     const validIds = new Set(model.indicatorOptions.map((indicator) => indicator.id));
-    const nextSelection = selectedIndicators.filter((indicator) =>
+    const filteredSelection = selectedIndicators.filter((indicator) =>
       validIds.has(indicator.id),
     );
 
-    if (nextSelection.length > 0) {
-      if (nextSelection.length !== selectedIndicators.length) {
-        setSelectedIndicators(nextSelection);
-      }
-      return;
+    if (filteredSelection.length > 0) {
+      return filteredSelection;
     }
 
-    setSelectedIndicators(model.defaultSelectedIndicators);
+    return model.defaultSelectedIndicators;
   }, [model.defaultSelectedIndicators, model.indicatorOptions, selectedIndicators]);
 
   const selectedIds = useMemo(
-    () => new Set(selectedIndicators.map((indicator) => indicator.id)),
-    [selectedIndicators],
+    () => new Set(effectiveSelectedIndicators.map((indicator) => indicator.id)),
+    [effectiveSelectedIndicators],
   );
 
   const filteredRows = useMemo(() => {
@@ -111,7 +107,7 @@ export function CompanyAnalysisPanel({ model }: CompanyAnalysisPanelProps) {
         <div className="flex flex-wrap items-center gap-2">
           <IndicatorSelector
             indicators={model.indicatorOptions}
-            selected={selectedIndicators}
+            selected={effectiveSelectedIndicators}
             onSelectionChange={setSelectedIndicators}
             maxSelections={5}
             className="min-w-[220px]"
@@ -122,9 +118,9 @@ export function CompanyAnalysisPanel({ model }: CompanyAnalysisPanelProps) {
         </div>
       </div>
 
-      {selectedIndicators.length > 0 ? (
+      {effectiveSelectedIndicators.length > 0 ? (
         <div className="flex flex-wrap items-center gap-2">
-          {selectedIndicators.map((indicator) => {
+          {effectiveSelectedIndicators.map((indicator) => {
             const option = model.indicatorOptions.find((item) => item.id === indicator.id);
             if (!option) {
               return null;
@@ -146,7 +142,7 @@ export function CompanyAnalysisPanel({ model }: CompanyAnalysisPanelProps) {
 
       <CompanyAnalysisChart
         chartSeries={model.chartSeries}
-        selectedIndicators={selectedIndicators}
+        selectedIndicators={effectiveSelectedIndicators}
       />
 
       <div className="space-y-4 rounded-[1.35rem] border border-border/60 bg-muted/16 p-4">

--- a/apps/web/components/company/company-context-card.tsx
+++ b/apps/web/components/company/company-context-card.tsx
@@ -1,0 +1,77 @@
+import Link from "next/link";
+
+import { SurfaceCard } from "@/components/shared/design-system-recipes";
+import { buttonVariants } from "@/components/ui/button";
+import type { CompanyInfo } from "@/lib/api";
+import { buildCompanyHeroModel } from "@/lib/company-dashboard";
+import { formatYearsLabel } from "@/lib/formatters";
+import { cn } from "@/lib/utils";
+
+type CompanyContextCardProps = {
+  company: CompanyInfo;
+  selectedYears: number[];
+  availableYears: number[];
+};
+
+export function CompanyContextCard({
+  company,
+  selectedYears,
+  availableYears,
+}: CompanyContextCardProps) {
+  const hero = buildCompanyHeroModel(company, selectedYears);
+
+  return (
+    <SurfaceCard tone="subtle" padding="md" className="space-y-4">
+      <div className="space-y-2">
+        <p className="text-[0.72rem] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+          Contexto de navegação
+        </p>
+        <h3 className="font-heading text-xl tracking-[-0.02em] text-foreground">
+          Continue a leitura
+        </h3>
+        <p className="text-sm leading-6 text-muted-foreground">
+          Use o mesmo recorte anual para cruzar esta empresa com seu setor ou com
+          outras companhias prontas.
+        </p>
+      </div>
+
+      <dl className="grid gap-2.5 text-sm">
+        <div className="flex items-baseline justify-between gap-3">
+          <dt className="text-muted-foreground">Recorte atual</dt>
+          <dd className="text-right text-foreground">
+            {selectedYears.length > 0 ? formatYearsLabel(selectedYears) : "Sem recorte ativo"}
+          </dd>
+        </div>
+        <div className="flex items-baseline justify-between gap-3">
+          <dt className="text-muted-foreground">Historico na pagina</dt>
+          <dd className="text-right text-foreground">
+            {availableYears.length > 0 ? formatYearsLabel(availableYears) : "Sem anos locais"}
+          </dd>
+        </div>
+        <div className="flex items-baseline justify-between gap-3">
+          <dt className="text-muted-foreground">Setor</dt>
+          <dd className="text-right text-foreground">
+            {company.sector_name || "Nao informado"}
+          </dd>
+        </div>
+      </dl>
+
+      <div className="flex flex-wrap gap-2">
+        <Link
+          href={hero.compareHref}
+          className={cn(buttonVariants({ variant: "outline", size: "sm" }), "rounded-full px-4")}
+        >
+          Comparar
+        </Link>
+        {hero.sectorHref ? (
+          <Link
+            href={hero.sectorHref}
+            className={cn(buttonVariants({ variant: "ghost", size: "sm" }), "rounded-full px-4")}
+          >
+            Ver setor
+          </Link>
+        ) : null}
+      </div>
+    </SurfaceCard>
+  );
+}

--- a/apps/web/components/company/company-header.tsx
+++ b/apps/web/components/company/company-header.tsx
@@ -5,6 +5,7 @@ import { InfoChip } from "@/components/shared/design-system-recipes";
 import { ExcelDownloadButton } from "@/components/shared/excel-download-button";
 import { Button, buttonVariants } from "@/components/ui/button";
 import type { CompanyInfo } from "@/lib/api";
+import { buildCompanyHeroModel } from "@/lib/company-dashboard";
 import { getSectorColor } from "@/lib/constants";
 import { cn } from "@/lib/utils";
 
@@ -13,32 +14,9 @@ type CompanyHeaderProps = {
   selectedYears: number[];
 };
 
-function getInitials(name: string): string {
-  return name
-    .split(/\s+/)
-    .filter(Boolean)
-    .slice(0, 2)
-    .map((word) => word[0]!.toUpperCase())
-    .join("");
-}
-
 export function CompanyHeader({ company, selectedYears }: CompanyHeaderProps) {
   const sectorColor = getSectorColor(company.sector_name);
-  const initials = getInitials(company.company_name);
-
-  const compareParams = new URLSearchParams({ ids: String(company.cd_cvm) });
-  if (selectedYears.length > 0) {
-    compareParams.set("anos", selectedYears.join(","));
-  }
-  const compareHref = `/comparar?${compareParams.toString()}`;
-
-  const latestSelectedYear = selectedYears[selectedYears.length - 1] ?? null;
-  const sectorHref =
-    company.sector_slug && latestSelectedYear
-      ? `/setores/${company.sector_slug}?ano=${latestSelectedYear}`
-      : company.sector_slug
-        ? `/setores/${company.sector_slug}`
-        : null;
+  const hero = buildCompanyHeroModel(company, selectedYears);
 
   return (
     <div className="space-y-4">
@@ -78,7 +56,7 @@ export function CompanyHeader({ company, selectedYears }: CompanyHeaderProps) {
                 className="font-heading text-[1.6rem] font-bold leading-none"
                 style={{ color: sectorColor }}
               >
-                {initials}
+                {hero.initials}
               </span>
             </div>
 
@@ -110,9 +88,9 @@ export function CompanyHeader({ company, selectedYears }: CompanyHeaderProps) {
               }}
               className="rounded-full px-4"
             />
-            {sectorHref ? (
+            {hero.sectorHref ? (
               <Link
-                href={sectorHref}
+                href={hero.sectorHref}
                 className={cn(
                   buttonVariants({ variant: "outline", size: "sm" }),
                   "rounded-full px-4",
@@ -126,7 +104,7 @@ export function CompanyHeader({ company, selectedYears }: CompanyHeaderProps) {
               </Button>
             )}
             <Link
-              href={compareHref}
+              href={hero.compareHref}
               className={cn(
                 buttonVariants({ variant: "outline", size: "sm" }),
                 "rounded-full px-4",

--- a/apps/web/components/company/company-kpi-row.tsx
+++ b/apps/web/components/company/company-kpi-row.tsx
@@ -1,51 +1,34 @@
-import type { KPIBundle, TabularDataRow } from "@/lib/api";
+import type { DashboardKpiCard } from "@/lib/company-dashboard";
 import { formatKpiDelta, formatKpiValue } from "@/lib/formatters";
 import { cn } from "@/lib/utils";
 
-const KPI_CARDS = [
-  { id: "MG_BRUTA", label: "Margem Bruta", formatType: "pct" },
-  { id: "MG_EBITDA", label: "Margem EBITDA", formatType: "pct" },
-  { id: "ROE", label: "ROE", formatType: "pct" },
-  { id: "MG_LIQ", label: "Margem Líquida", formatType: "pct" },
-] as const;
-
 type CompanyKpiRowProps = {
-  bundle: KPIBundle;
+  cards: DashboardKpiCard[];
 };
 
-export function CompanyKpiRow({ bundle }: CompanyKpiRowProps) {
-  const annualRows = bundle.annual.rows as TabularDataRow[];
-  const yearColumns = bundle.annual.columns
-    .filter((c) => /^\d{4}$/.test(c))
-    .sort((a, b) => Number(a) - Number(b));
-  const lastYear = yearColumns.at(-1);
-  const kpiMap = new Map(annualRows.map((row) => [String(row.KPI_ID), row]));
+export function CompanyKpiRow({ cards }: CompanyKpiRowProps) {
+  if (cards.length === 0) {
+    return null;
+  }
 
   return (
     <div className="grid grid-cols-2 gap-3 xl:grid-cols-4">
-      {KPI_CARDS.map((kpi) => {
-        const row = kpiMap.get(kpi.id);
-        const currentValue =
-          row && lastYear ? Number(row[lastYear] ?? NaN) : null;
-        const deltaValue =
-          row?.DELTA_YOY === null || row?.DELTA_YOY === undefined
-            ? null
-            : Number(row.DELTA_YOY);
-        const isPositive = deltaValue !== null && deltaValue >= 0;
+      {cards.map((card) => {
+        const isPositive = card.delta !== null && card.delta >= 0;
 
         return (
           <div
-            key={kpi.id}
+            key={card.id}
             className="rounded-[1.25rem] border border-border/60 bg-card px-5 py-4"
           >
             <p className="text-[0.72rem] font-medium uppercase tracking-[0.18em] text-muted-foreground">
-              {kpi.label}
+              {card.label}
             </p>
             <p className="mt-2 font-heading text-[1.75rem] font-medium tracking-[-0.04em] text-foreground leading-none">
-              {formatKpiValue(currentValue, kpi.formatType)}
+              {formatKpiValue(card.value, card.formatType)}
             </p>
             <div className="mt-2 flex items-center justify-between">
-              {deltaValue !== null ? (
+              {card.delta !== null ? (
                 <span
                   className={cn(
                     "inline-flex items-center rounded-full px-2 py-0.5 text-[0.72rem] font-medium",
@@ -55,13 +38,13 @@ export function CompanyKpiRow({ bundle }: CompanyKpiRowProps) {
                   )}
                 >
                   {isPositive ? "+" : ""}
-                  {formatKpiDelta(deltaValue, kpi.formatType)}
+                  {formatKpiDelta(card.delta, card.formatType)}
                 </span>
               ) : (
                 <span className="text-[0.72rem] text-muted-foreground/40">sem delta</span>
               )}
               <span className="text-[0.68rem] tabular-nums text-muted-foreground/50">
-                {lastYear ?? "—"}
+                {card.year ?? "â€”"}
               </span>
             </div>
           </div>

--- a/apps/web/components/company/company-no-data.tsx
+++ b/apps/web/components/company/company-no-data.tsx
@@ -1,13 +1,13 @@
 import Link from "next/link";
-import { ChevronRightIcon } from "lucide-react";
 
+import { CompanyContextCard } from "@/components/company/company-context-card";
+import { CompanyFreshnessCard } from "@/components/company/company-freshness-card";
+import { CompanyHeader } from "@/components/company/company-header";
 import {
-  InfoChip,
   PageShell,
   SectionHeading,
   SurfaceCard,
 } from "@/components/shared/design-system-recipes";
-import { CompanyRequestRefreshLazy } from "@/components/company/company-request-refresh-lazy";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { buttonVariants } from "@/components/ui/button";
 import {
@@ -22,26 +22,10 @@ type CompanyNoDataPageProps = {
   company: CompanyInfo;
 };
 
-type CompanyMetaCardProps = {
-  label: string;
-  value: string;
-};
-
 type ExpectationCardProps = {
   title: string;
   description: string;
 };
-
-function CompanyMetaCard({ label, value }: CompanyMetaCardProps) {
-  return (
-    <SurfaceCard tone="inset" padding="md" className="flex flex-col gap-1.5">
-      <p className="text-xs uppercase tracking-[0.24em] text-muted-foreground">
-        {label}
-      </p>
-      <p className="text-sm font-medium text-foreground">{value}</p>
-    </SurfaceCard>
-  );
-}
 
 function ExpectationCard({ title, description }: ExpectationCardProps) {
   return (
@@ -53,8 +37,6 @@ function ExpectationCard({ title, description }: ExpectationCardProps) {
 }
 
 export async function CompanyNoDataPage({ company }: CompanyNoDataPageProps) {
-  const sectorLabel =
-    company.sector_name || company.setor_analitico || company.setor_cvm || "Setor nao informado";
   let initialFreshness: RefreshStatusItem | null = null;
 
   try {
@@ -69,98 +51,68 @@ export async function CompanyNoDataPage({ company }: CompanyNoDataPageProps) {
   const lastOutcomeMessage = freshnessCopy?.latestResultDescription ?? null;
 
   return (
-    <PageShell density="relaxed" className="max-w-5xl">
-      <div className="space-y-5">
-        <nav aria-label="breadcrumb">
-          <ol className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-            <li>
-              <Link href="/" className="hover:text-foreground">
-                Home
-              </Link>
-            </li>
-            <li className="flex items-center gap-2">
-              <ChevronRightIcon className="size-4" />
-              <Link href="/empresas" className="hover:text-foreground">
-                Empresas
-              </Link>
-            </li>
-            <li className="flex items-center gap-2 text-foreground">
-              <ChevronRightIcon className="size-4 text-muted-foreground" />
-              <span>{company.company_name}</span>
-            </li>
-          </ol>
-        </nav>
+    <PageShell density="default">
+      <CompanyHeader company={company} selectedYears={[]} />
 
-        <SurfaceCard tone="hero" padding="hero" className="space-y-8">
-          <div className="flex flex-wrap items-center gap-3">
-            <InfoChip tone="brand">Primeira leitura da companhia</InfoChip>
-            <InfoChip>CVM {company.cd_cvm}</InfoChip>
-            {company.ticker_b3 ? <InfoChip tone="muted">{company.ticker_b3}</InfoChip> : null}
-          </div>
-
-          <SectionHeading
-            eyebrow="Historico anual ainda nao liberado"
-            title={company.company_name}
-            titleAs="h1"
-            description="O cadastro desta companhia esta disponivel, mas a leitura detalhada ainda depende de uma carga anual processada. Quando houver historico materializavel, esta pagina passa a liberar KPIs, demonstracoes e Excel."
-            descriptionClassName="max-w-3xl"
-          />
-
-          <div className="grid gap-4 md:grid-cols-3">
-            <CompanyMetaCard label="Setor" value={sectorLabel} />
-            <CompanyMetaCard label="CNPJ" value={company.cnpj ?? "Nao informado"} />
-            <CompanyMetaCard
-              label="Ticker B3"
-              value={company.ticker_b3 ?? "Sem ticker"}
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-12 lg:gap-8">
+        <div className="flex flex-col gap-6 lg:col-span-8">
+          <SurfaceCard tone="default" padding="lg" className="space-y-6">
+            <SectionHeading
+              eyebrow="Historico anual ainda nao liberado"
+              title="Esta empresa ainda depende da primeira materializacao"
+              titleAs="h2"
+              description="O cadastro da companhia ja esta disponivel, mas esta pagina ainda nao encontrou uma serie anual local utilizavel. Quando a leitura on-demand conseguir materializar o historico, este mesmo shell libera os KPIs, o grafico, a tabela anual e as demonstracoes."
+              descriptionClassName="max-w-3xl text-sm leading-7"
             />
-          </div>
 
-          <Alert className="rounded-[1.75rem] border border-border/70 bg-muted/28 px-5 py-5">
-            <AlertTitle>O que destrava esta pagina</AlertTitle>
-            <AlertDescription>
-              A solicitacao on-demand busca uma serie anual utilizavel na CVM e, quando encontra material suficiente, libera esta mesma aba para leitura. Se a CVM nao tiver historico anual processavel, o resultado aparece aqui de forma clara em vez de falhar em silencio.
-              {freshnessCopy?.retryHint ? ` ${freshnessCopy.retryHint}` : ""}
-            </AlertDescription>
-          </Alert>
-
-          {lastOutcomeMessage ? (
-            <Alert className="rounded-[1.75rem] border border-border/70 bg-background/85 px-5 py-5">
-              <AlertTitle>Ultimo resultado conhecido</AlertTitle>
-              <AlertDescription>{lastOutcomeMessage}</AlertDescription>
+            <Alert className="rounded-[1.5rem] border border-border/70 bg-muted/24 px-5 py-5">
+              <AlertTitle>O que destrava esta pagina</AlertTitle>
+              <AlertDescription>
+                A solicitacao on-demand busca uma serie anual processavel na CVM e
+                atualiza o painel lateral com o status real da tentativa. Quando o
+                processamento encontra historico suficiente, esta mesma rota passa a
+                abrir a visao geral completa e as demonstracoes.
+                {freshnessCopy?.retryHint ? ` ${freshnessCopy.retryHint}` : ""}
+              </AlertDescription>
             </Alert>
-          ) : null}
 
-          <div className="grid gap-4 lg:grid-cols-3">
-            <ExpectationCard
-              title="1. O que acontece agora"
-              description="A companhia entra na fila interna, o worker tenta montar a serie anual e o status abaixo acompanha esse processo sem tirar voce da pagina."
-            />
-            <ExpectationCard
-              title="2. O que muda quando funciona"
-              description="Assim que a leitura ficar materializada, esta mesma rota passa a abrir os KPIs, as demonstracoes financeiras e o download em Excel."
-            />
-            <ExpectationCard
-              title="3. Quando nao houver historico"
-              description="Se nao existir serie anual suficiente para a janela padrao, a pagina informa isso claramente e voce pode tentar novamente mais tarde."
-            />
-          </div>
+            {lastOutcomeMessage ? (
+              <Alert className="rounded-[1.5rem] border border-border/70 bg-background/82 px-5 py-5">
+                <AlertTitle>Ultimo resultado conhecido</AlertTitle>
+                <AlertDescription>{lastOutcomeMessage}</AlertDescription>
+              </Alert>
+            ) : null}
 
-          <div className="flex flex-wrap items-start gap-3">
-            <CompanyRequestRefreshLazy
-              cdCvm={company.cd_cvm}
-              initialStatus={initialFreshness}
-            />
-            <Link
-              href="/empresas"
-              className={cn(
-                buttonVariants({ variant: "ghost", size: "lg" }),
-                "rounded-full px-5",
-              )}
-            >
-              Voltar para o diretorio
-            </Link>
-          </div>
-        </SurfaceCard>
+            <div className="grid gap-4 lg:grid-cols-3">
+              <ExpectationCard
+                title="1. Acompanhe pelo painel lateral"
+                description="O card de freshness continua visivel neste mesmo layout e concentra status, progresso, retry e mudanca de estado quando a leitura for concluida."
+              />
+              <ExpectationCard
+                title="2. Quando a leitura funcionar"
+                description="A rota troca para o dashboard real da companhia sem mudar de pagina, preservando o mesmo header, a mesma identidade visual e os mesmos links de contexto."
+              />
+              <ExpectationCard
+                title="3. Quando nao houver historico suficiente"
+                description="A pagina continua explicitando o resultado terminal de forma calma e reutilizavel, em vez de cair num estado generico ou contraditorio."
+              />
+            </div>
+
+            <div className="flex flex-wrap gap-3">
+              <Link
+                href="/empresas"
+                className={cn(buttonVariants({ variant: "ghost", size: "lg" }), "rounded-full px-5")}
+              >
+                Voltar para o diretorio
+              </Link>
+            </div>
+          </SurfaceCard>
+        </div>
+
+        <div className="flex flex-col gap-4 lg:col-span-4">
+          <CompanyFreshnessCard cdCvm={company.cd_cvm} />
+          <CompanyContextCard company={company} selectedYears={[]} availableYears={[]} />
+        </div>
       </div>
     </PageShell>
   );

--- a/apps/web/components/company/company-overview.tsx
+++ b/apps/web/components/company/company-overview.tsx
@@ -1,188 +1,52 @@
+import { CompanyAnalysisPanel } from "@/components/company/company-analysis-panel";
+import { CompanyContextCard } from "@/components/company/company-context-card";
 import { CompanyFreshnessCard } from "@/components/company/company-freshness-card";
-import { CompanyHeroChartLazy } from "@/components/company/company-hero-chart-lazy";
 import { CompanyKpiRow } from "@/components/company/company-kpi-row";
-import { CompanySectorRanking } from "@/components/company/company-sector-ranking";
 import { SparklineChip } from "@/components/shared/sparkline-chip";
-import { SectionHeading } from "@/components/shared/design-system-recipes";
-import type { KPIBundle, TabularDataRow } from "@/lib/api";
-import { formatKpiDelta, formatKpiValue } from "@/lib/formatters";
-import { cn } from "@/lib/utils";
-
-const CHART_KPIS = [
-  { id: "RECEITA_LIQ", label: "Receita" },
-  { id: "EBITDA", label: "EBITDA" },
-  { id: "LUCRO_LIQ", label: "Lucro" },
-] as const;
-
-const SPARKLINE_KPIS = [
-  { id: "RECEITA_LIQ", label: "Receita Líquida", formatType: "brl" },
-  { id: "EBITDA", label: "EBITDA", formatType: "brl" },
-  { id: "MG_EBITDA", label: "Margem EBITDA", formatType: "pct" },
-] as const;
-
-const KPI_GROUPS = [
-  {
-    label: "Rentabilidade",
-    kpis: [
-      { id: "MG_BRUTA", label: "Mg. Bruta", formatType: "pct" },
-      { id: "MG_EBITDA", label: "Mg. EBITDA", formatType: "pct" },
-      { id: "MG_EBIT", label: "Mg. EBIT", formatType: "pct" },
-      { id: "MG_LIQ", label: "Mg. Líquida", formatType: "pct" },
-      { id: "ROE", label: "ROE", formatType: "pct" },
-      { id: "ROA", label: "ROA", formatType: "pct" },
-    ],
-  },
-  {
-    label: "Endividamento",
-    kpis: [
-      { id: "DIV_LIQ_EBITDA", label: "Dív/EBITDA", formatType: "ratio" },
-      { id: "DIV_LIQ_PL", label: "Dív Líq/PL", formatType: "ratio" },
-      { id: "LIQ_CORR", label: "Liq. Corrente", formatType: "ratio" },
-      { id: "COBERT_JUR", label: "Cob. Juros", formatType: "ratio" },
-    ],
-  },
-  {
-    label: "Eficiência",
-    kpis: [
-      { id: "FCO_REC", label: "FCO/Receita", formatType: "pct" },
-      { id: "CAPEX_RECEITA", label: "Capex/Rec", formatType: "pct" },
-      { id: "GIRO_ATIVO", label: "Giro Ativo", formatType: "ratio" },
-    ],
-  },
-] as const;
-
-function isYearColumn(value: string): boolean {
-  return /^\d{4}$/.test(value);
-}
+import type { CompanyInfo, KPIBundle } from "@/lib/api";
+import { buildCompanyDashboardModel } from "@/lib/company-dashboard";
+import { formatKpiValue } from "@/lib/formatters";
 
 type CompanyOverviewProps = {
+  company: CompanyInfo;
   bundle: KPIBundle;
   cdCvm: number;
+  selectedYears: number[];
 };
 
-export function CompanyOverview({ bundle, cdCvm }: CompanyOverviewProps) {
-  const annualRows = bundle.annual.rows as TabularDataRow[];
-  const yearColumns = bundle.annual.columns
-    .filter(isYearColumn)
-    .sort((a, b) => Number(a) - Number(b));
-  const lastYear = yearColumns.at(-1);
-  const kpiMap = new Map(annualRows.map((row) => [String(row.KPI_ID), row]));
-
-  const chartSeries = CHART_KPIS.flatMap((kpi) => {
-    const row = kpiMap.get(kpi.id);
-    if (!row) return [];
-    const points = yearColumns.flatMap((year) => {
-      const val = row[year];
-      if (val === null || val === undefined) return [];
-      const num = Number(val);
-      if (isNaN(num)) return [];
-      return [{ year: Number(year), value: num }];
-    });
-    if (points.length < 2) return [];
-    return [{ label: kpi.label, points }];
-  });
+export function CompanyOverview({
+  company,
+  bundle,
+  cdCvm,
+  selectedYears,
+}: CompanyOverviewProps) {
+  const model = buildCompanyDashboardModel(bundle);
 
   return (
     <div className="grid grid-cols-1 gap-6 lg:grid-cols-12 lg:gap-8">
-      {/* Main column */}
       <div className="flex flex-col gap-6 lg:col-span-8">
-        <CompanyKpiRow bundle={bundle} />
-
-        {chartSeries.length > 0 ? <CompanyHeroChartLazy series={chartSeries} /> : null}
-
-        {/* 3-group KPI tiles */}
-        <section className="space-y-5">
-          <SectionHeading
-            eyebrow="Indicadores"
-            title="Por categoria"
-            titleAs="h3"
-          />
-          <div className="space-y-5">
-            {KPI_GROUPS.map((group) => {
-              const visibleKpis = group.kpis.filter((kpi) => kpiMap.has(kpi.id));
-              if (visibleKpis.length === 0) return null;
-
-              return (
-                <div key={group.label}>
-                  <p className="mb-3 text-[0.72rem] font-medium uppercase tracking-[0.18em] text-muted-foreground">
-                    {group.label}
-                  </p>
-                  <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-                    {visibleKpis.map((kpi) => {
-                      const row = kpiMap.get(kpi.id);
-                      const value =
-                        row && lastYear ? Number(row[lastYear] ?? NaN) : null;
-                      const delta =
-                        row?.DELTA_YOY === null || row?.DELTA_YOY === undefined
-                          ? null
-                          : Number(row.DELTA_YOY);
-                      const isPos = delta !== null && delta >= 0;
-
-                      return (
-                        <div
-                          key={kpi.id}
-                          className="rounded-[1rem] border border-border/60 bg-card px-4 py-3"
-                        >
-                          <p className="text-[0.68rem] uppercase tracking-[0.14em] text-muted-foreground">
-                            {kpi.label}
-                          </p>
-                          <p className="mt-1 font-heading text-[1.25rem] font-medium tracking-[-0.03em] text-foreground leading-none">
-                            {formatKpiValue(value, kpi.formatType)}
-                          </p>
-                          {delta !== null && (
-                            <p
-                              className={cn(
-                                "mt-1 text-[0.7rem] font-medium",
-                                isPos
-                                  ? "text-emerald-600 dark:text-emerald-400"
-                                  : "text-destructive",
-                              )}
-                            >
-                              {isPos ? "+" : ""}
-                              {formatKpiDelta(delta, kpi.formatType)}
-                            </p>
-                          )}
-                        </div>
-                      );
-                    })}
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        </section>
+        <CompanyKpiRow cards={model.summaryCards} />
+        <CompanyAnalysisPanel model={model} />
       </div>
 
-      {/* Right rail */}
       <div className="flex flex-col gap-4 lg:col-span-4">
-        {SPARKLINE_KPIS.map((kpi) => {
-          const row = kpiMap.get(kpi.id);
-          const values = yearColumns.flatMap((year) => {
-            const val = row?.[year];
-            if (val === null || val === undefined) return [];
-            const num = Number(val);
-            return isNaN(num) ? [] : [num];
-          });
-          const currentValue = row && lastYear ? Number(row[lastYear] ?? NaN) : null;
-          const deltaValue =
-            row?.DELTA_YOY === null || row?.DELTA_YOY === undefined
-              ? null
-              : Number(row.DELTA_YOY);
-
-          return (
-            <SparklineChip
-              key={kpi.id}
-              label={kpi.label}
-              value={formatKpiValue(currentValue, kpi.formatType)}
-              delta={deltaValue}
-              formatType={kpi.formatType}
-              values={values}
-            />
-          );
-        })}
+        {model.spotlightMetrics.map((metric) => (
+          <SparklineChip
+            key={metric.id}
+            label={metric.label}
+            value={formatKpiValue(metric.value, metric.formatType)}
+            delta={metric.delta}
+            formatType={metric.formatType}
+            values={metric.values}
+          />
+        ))}
 
         <CompanyFreshnessCard cdCvm={cdCvm} />
-        <CompanySectorRanking />
+        <CompanyContextCard
+          company={company}
+          selectedYears={selectedYears}
+          availableYears={model.years}
+        />
       </div>
     </div>
   );

--- a/apps/web/components/company/company-overview.tsx
+++ b/apps/web/components/company/company-overview.tsx
@@ -1,4 +1,4 @@
-import { CompanyAnalysisPanel } from "@/components/company/company-analysis-panel";
+import { CompanyAnalysisPanelLazy } from "@/components/company/company-analysis-panel-lazy";
 import { CompanyContextCard } from "@/components/company/company-context-card";
 import { CompanyFreshnessCard } from "@/components/company/company-freshness-card";
 import { CompanyKpiRow } from "@/components/company/company-kpi-row";
@@ -26,7 +26,7 @@ export function CompanyOverview({
     <div className="grid grid-cols-1 gap-6 lg:grid-cols-12 lg:gap-8">
       <div className="flex flex-col gap-6 lg:col-span-8">
         <CompanyKpiRow cards={model.summaryCards} />
-        <CompanyAnalysisPanel model={model} />
+        <CompanyAnalysisPanelLazy model={model} />
       </div>
 
       <div className="flex flex-col gap-4 lg:col-span-4">

--- a/apps/web/components/home/bento-features.tsx
+++ b/apps/web/components/home/bento-features.tsx
@@ -4,24 +4,34 @@ import {
   BarChart3Icon,
   FileTextIcon,
   GitCompareArrowsIcon,
+  type LucideIcon,
   LayersIcon,
   SearchIcon,
   TrendingUpIcon,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
-const FEATURES = [
+type FeatureCard = {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+  gridClass: string;
+  accent: string;
+  featured?: boolean;
+};
+
+const FEATURES: FeatureCard[] = [
   {
     icon: SearchIcon,
     title: "Busca inteligente",
-    description: "Encontre qualquer empresa por nome, ticker ou codigo CVM em milissegundos.",
+    description: "Busque por nome, ticker ou codigo CVM e caia direto na leitura pronta ou no caminho on-demand.",
     gridClass: "sm:col-span-2 lg:col-span-1",
     accent: "primary",
   },
   {
     icon: FileTextIcon,
-    title: "DRE e Balanco",
-    description: "Demonstrativos completos com 10+ anos de historico direto da CVM.",
+    title: "DRE, BPA, BPP e DFC",
+    description: "Demonstracoes anuais e tabelas navegaveis organizadas a partir dos arquivos publicos da CVM.",
     gridClass: "lg:col-span-2",
     accent: "chart-1",
   },
@@ -43,18 +53,18 @@ const FEATURES = [
   {
     icon: LayersIcon,
     title: "Setores organizados",
-    description: "Navegue por setores da economia e descubra oportunidades.",
+    description: "Navegue por hubs setoriais reais e conecte empresa, contexto e comparacao no mesmo fluxo.",
     gridClass: "",
     accent: "chart-4",
   },
   {
     icon: TrendingUpIcon,
-    title: "Dados atualizados",
-    description: "Informacoes sincronizadas com os arquivos publicos da CVM.",
+    title: "On-demand quando falta historico",
+    description: "Quando a empresa ainda nao tem leitura local, o produto acompanha a solicitacao e explica o resultado sem esconder o estado real.",
     gridClass: "",
     accent: "chart-5",
   },
-] as const;
+];
 
 function getAccentVar(accent: string) {
   return `var(--${accent})`;
@@ -69,7 +79,7 @@ export function BentoFeatures() {
           Tudo que voce precisa para analisar
         </h2>
         <p className="mx-auto mt-3 max-w-xl text-[0.95rem] leading-relaxed text-muted-foreground">
-          Uma plataforma completa para descoberta e analise de empresas listadas na bolsa brasileira.
+          Estrutura publica orientada a descoberta, leitura detalhada e comparacao das companhias abertas brasileiras.
         </p>
       </div>
 

--- a/apps/web/components/shared/site-header.tsx
+++ b/apps/web/components/shared/site-header.tsx
@@ -75,9 +75,17 @@ const DROPDOWN_ITEMS = {
   ],
 } as const;
 
+type DropdownItem = {
+  icon: typeof BarChart3Icon;
+  label: string;
+  description: string;
+  href: string | null;
+  soon: boolean;
+};
+
 type DropdownMenuProps = {
   label: string;
-  items: (typeof DROPDOWN_ITEMS)["analise"];
+  items: readonly DropdownItem[];
 };
 
 function NavDropdown({ label, items }: DropdownMenuProps) {

--- a/apps/web/lib/company-dashboard.ts
+++ b/apps/web/lib/company-dashboard.ts
@@ -1,0 +1,409 @@
+import type { CompanyInfo, KPIBundle, TabularDataRow } from "./api.ts";
+import { formatYearsLabel, getInitials } from "./formatters.ts";
+
+export type DashboardChartType = "bar" | "line" | "area";
+export type DashboardFormatType = "brl" | "pct" | "ratio";
+
+export type DashboardIndicatorOption = {
+  id: string;
+  label: string;
+  category: string;
+  formatType: DashboardFormatType;
+  defaultChartType: DashboardChartType;
+};
+
+export type DashboardSelectedIndicator = {
+  id: string;
+  chartType: DashboardChartType;
+};
+
+export type DashboardKpiCard = {
+  id: string;
+  label: string;
+  formatType: DashboardFormatType;
+  value: number | null;
+  delta: number | null;
+  year: number | null;
+};
+
+export type DashboardSpotlightMetric = DashboardKpiCard & {
+  values: number[];
+};
+
+export type DashboardChartSeriesPoint = {
+  year: number;
+  value: number;
+};
+
+export type DashboardTableRow = {
+  id: string;
+  label: string;
+  category: string;
+  formatType: DashboardFormatType;
+  delta: number | null;
+  valuesByYear: Record<number, number | null>;
+};
+
+export type CompanyDashboardModel = {
+  years: number[];
+  yearsLabel: string;
+  indicatorOptions: DashboardIndicatorOption[];
+  defaultSelectedIndicators: DashboardSelectedIndicator[];
+  summaryCards: DashboardKpiCard[];
+  spotlightMetrics: DashboardSpotlightMetric[];
+  chartSeries: Record<string, DashboardKpiCard & { points: DashboardChartSeriesPoint[] }>;
+  tableRows: DashboardTableRow[];
+};
+
+export type CompanyHeroModel = {
+  initials: string;
+  compareHref: string;
+  sectorHref: string | null;
+};
+
+type DashboardCatalogEntry = DashboardIndicatorOption & {
+  summary?: boolean;
+  spotlight?: boolean;
+  defaultSelected?: boolean;
+};
+
+const KPI_CATALOG: DashboardCatalogEntry[] = [
+  {
+    id: "RECEITA_LIQ",
+    label: "Receita Liquida",
+    category: "Escala",
+    formatType: "brl",
+    defaultChartType: "bar",
+    spotlight: true,
+    defaultSelected: true,
+  },
+  {
+    id: "EBITDA",
+    label: "EBITDA",
+    category: "Escala",
+    formatType: "brl",
+    defaultChartType: "line",
+    spotlight: true,
+    defaultSelected: true,
+  },
+  {
+    id: "LUCRO_LIQ",
+    label: "Lucro Liquido",
+    category: "Escala",
+    formatType: "brl",
+    defaultChartType: "area",
+    spotlight: true,
+    defaultSelected: true,
+  },
+  {
+    id: "MG_BRUTA",
+    label: "Margem Bruta",
+    category: "Rentabilidade",
+    formatType: "pct",
+    defaultChartType: "line",
+    summary: true,
+  },
+  {
+    id: "MG_EBITDA",
+    label: "Margem EBITDA",
+    category: "Rentabilidade",
+    formatType: "pct",
+    defaultChartType: "line",
+    summary: true,
+    spotlight: true,
+  },
+  {
+    id: "MG_EBIT",
+    label: "Margem EBIT",
+    category: "Rentabilidade",
+    formatType: "pct",
+    defaultChartType: "line",
+  },
+  {
+    id: "MG_LIQ",
+    label: "Margem Liquida",
+    category: "Rentabilidade",
+    formatType: "pct",
+    defaultChartType: "line",
+    summary: true,
+  },
+  {
+    id: "ROE",
+    label: "ROE",
+    category: "Rentabilidade",
+    formatType: "pct",
+    defaultChartType: "line",
+    summary: true,
+  },
+  {
+    id: "ROA",
+    label: "ROA",
+    category: "Rentabilidade",
+    formatType: "pct",
+    defaultChartType: "line",
+  },
+  {
+    id: "DIV_LIQ_EBITDA",
+    label: "Divida Liquida / EBITDA",
+    category: "Endividamento",
+    formatType: "ratio",
+    defaultChartType: "line",
+  },
+  {
+    id: "DIV_LIQ_PL",
+    label: "Divida Liquida / PL",
+    category: "Endividamento",
+    formatType: "ratio",
+    defaultChartType: "line",
+  },
+  {
+    id: "LIQ_CORR",
+    label: "Liquidez Corrente",
+    category: "Endividamento",
+    formatType: "ratio",
+    defaultChartType: "line",
+  },
+  {
+    id: "COBERT_JUR",
+    label: "Cobertura de Juros",
+    category: "Endividamento",
+    formatType: "ratio",
+    defaultChartType: "line",
+  },
+  {
+    id: "FCO_REC",
+    label: "FCO / Receita",
+    category: "Eficiência",
+    formatType: "pct",
+    defaultChartType: "line",
+  },
+  {
+    id: "CAPEX_RECEITA",
+    label: "Capex / Receita",
+    category: "Eficiência",
+    formatType: "pct",
+    defaultChartType: "line",
+  },
+  {
+    id: "GIRO_ATIVO",
+    label: "Giro do Ativo",
+    category: "Eficiência",
+    formatType: "ratio",
+    defaultChartType: "line",
+  },
+];
+
+function isYearColumn(value: string): boolean {
+  return /^\d{4}$/.test(value);
+}
+
+function toRowMap(bundle: KPIBundle): Map<string, TabularDataRow> {
+  return new Map(
+    (bundle.annual.rows as TabularDataRow[]).map((row) => [String(row.KPI_ID ?? ""), row]),
+  );
+}
+
+function getYearColumns(bundle: KPIBundle): number[] {
+  const explicitYears = bundle.annual.columns
+    .filter(isYearColumn)
+    .map((value) => Number(value))
+    .filter((value) => Number.isInteger(value));
+
+  if (explicitYears.length > 0) {
+    return explicitYears.sort((left, right) => left - right);
+  }
+
+  return Array.from(
+    new Set(bundle.years.filter((year) => Number.isInteger(year))),
+  ).sort((left, right) => left - right);
+}
+
+function getNumericValue(
+  row: TabularDataRow | undefined,
+  year: number,
+): number | null {
+  if (!row) {
+    return null;
+  }
+
+  const raw = row[String(year)];
+  if (raw === null || raw === undefined || raw === "") {
+    return null;
+  }
+
+  const numeric = Number(raw);
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
+function getDeltaValue(row: TabularDataRow | undefined): number | null {
+  if (!row) {
+    return null;
+  }
+
+  const numeric = Number(row.DELTA_YOY);
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
+function hasAnyValues(row: TabularDataRow | undefined, years: number[]): boolean {
+  return years.some((year) => getNumericValue(row, year) !== null);
+}
+
+function buildChartSeries(
+  entry: DashboardCatalogEntry,
+  row: TabularDataRow,
+  years: number[],
+): DashboardKpiCard & { points: DashboardChartSeriesPoint[] } {
+  const points = years.flatMap((year) => {
+    const value = getNumericValue(row, year);
+    if (value === null) {
+      return [];
+    }
+
+    return [{ year, value }];
+  });
+
+  const latestYear = points.at(-1)?.year ?? null;
+  const latestValue = latestYear === null ? null : getNumericValue(row, latestYear);
+
+  return {
+    id: entry.id,
+    label: entry.label,
+    formatType: entry.formatType,
+    value: latestValue,
+    delta: getDeltaValue(row),
+    year: latestYear,
+    points,
+  };
+}
+
+export function buildCompanyDashboardModel(bundle: KPIBundle): CompanyDashboardModel {
+  const years = getYearColumns(bundle);
+  const rowMap = toRowMap(bundle);
+
+  const availableEntries = KPI_CATALOG.filter((entry) =>
+    hasAnyValues(rowMap.get(entry.id), years),
+  );
+
+  const indicatorOptions = availableEntries.map(
+    ({ id, label, category, formatType, defaultChartType }) => ({
+      id,
+      label,
+      category,
+      formatType,
+      defaultChartType,
+    }),
+  );
+
+  const defaultSelectedIndicators = availableEntries
+    .filter((entry) => entry.defaultSelected)
+    .slice(0, 5)
+    .map((entry) => ({ id: entry.id, chartType: entry.defaultChartType }));
+
+  const fallbackSelections = availableEntries
+    .slice(0, 3)
+    .map((entry) => ({ id: entry.id, chartType: entry.defaultChartType }));
+
+  const selectedDefaults =
+    defaultSelectedIndicators.length > 0
+      ? defaultSelectedIndicators
+      : fallbackSelections;
+
+  const summaryCards = availableEntries.flatMap((entry) => {
+    if (!entry.summary) {
+      return [];
+    }
+
+    const row = rowMap.get(entry.id);
+    if (!row) {
+      return [];
+    }
+
+    const series = buildChartSeries(entry, row, years);
+    return [series];
+  });
+
+  const spotlightMetrics = availableEntries.flatMap((entry) => {
+    if (!entry.spotlight) {
+      return [];
+    }
+
+    const row = rowMap.get(entry.id);
+    if (!row) {
+      return [];
+    }
+
+    const series = buildChartSeries(entry, row, years);
+    return [
+      {
+        ...series,
+        values: series.points.map((point) => point.value),
+      },
+    ];
+  });
+
+  const chartSeries = Object.fromEntries(
+    availableEntries.flatMap((entry) => {
+      const row = rowMap.get(entry.id);
+      if (!row) {
+        return [];
+      }
+
+      const series = buildChartSeries(entry, row, years);
+      if (series.points.length === 0) {
+        return [];
+      }
+
+      return [[entry.id, series]];
+    }),
+  );
+
+  const tableRows = availableEntries.map((entry) => {
+    const row = rowMap.get(entry.id)!;
+
+    return {
+      id: entry.id,
+      label: entry.label,
+      category: entry.category,
+      formatType: entry.formatType,
+      delta: getDeltaValue(row),
+      valuesByYear: Object.fromEntries(
+        years.map((year) => [year, getNumericValue(row, year)]),
+      ),
+    };
+  });
+
+  return {
+    years,
+    yearsLabel: formatYearsLabel(years),
+    indicatorOptions,
+    defaultSelectedIndicators: selectedDefaults,
+    summaryCards,
+    spotlightMetrics,
+    chartSeries,
+    tableRows,
+  };
+}
+
+export function buildCompanyHeroModel(
+  company: CompanyInfo,
+  selectedYears: number[],
+): CompanyHeroModel {
+  const compareParams = new URLSearchParams({ ids: String(company.cd_cvm) });
+  if (selectedYears.length > 0) {
+    compareParams.set("anos", selectedYears.join(","));
+  }
+
+  const latestSelectedYear = selectedYears[selectedYears.length - 1] ?? null;
+  const sectorHref =
+    company.sector_slug && latestSelectedYear
+      ? `/setores/${company.sector_slug}?ano=${latestSelectedYear}`
+      : company.sector_slug
+        ? `/setores/${company.sector_slug}`
+        : null;
+
+  return {
+    initials: getInitials(company.company_name),
+    compareHref: `/comparar?${compareParams.toString()}`,
+    sectorHref,
+  };
+}

--- a/apps/web/lib/formatters.ts
+++ b/apps/web/lib/formatters.ts
@@ -27,6 +27,19 @@ export function formatStatementValue(value: number | null | undefined): string {
   }).format(value);
 }
 
+export function formatCompactCurrency(value: number | null | undefined): string {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return "-";
+  }
+
+  return new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(value);
+}
+
 export function formatKpiValue(
   value: number | null | undefined,
   formatType: string,
@@ -37,6 +50,10 @@ export function formatKpiValue(
 
   if (formatType === "pct") {
     return `${(value * 100).toFixed(1)}%`;
+  }
+
+  if (formatType === "brl") {
+    return formatCompactCurrency(value);
   }
 
   return `${value.toFixed(2)}x`;
@@ -53,6 +70,10 @@ export function formatKpiDelta(
   const sign = value >= 0 ? "+" : "";
   if (formatType === "pct") {
     return `${sign}${(value * 100).toFixed(1)} pp`;
+  }
+
+  if (formatType === "brl") {
+    return `${sign}${(value * 100).toFixed(1)}%`;
   }
 
   return `${sign}${value.toFixed(2)}x`;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "eslint",
     "typecheck": "tsc --noEmit",
-    "test:unit": "node --experimental-strip-types --experimental-specifier-resolution=node --test tests/api-client.test.ts tests/companies-page-data.test.ts tests/company-detail-handoff.test.ts tests/company-discovery.test.ts tests/company-period-range.test.ts tests/company-refresh-state.test.ts tests/compare-utils.test.ts tests/compare-page-data.test.ts tests/sectors-page-data.test.ts",
+    "test:unit": "node --experimental-strip-types --experimental-specifier-resolution=node --test tests/api-client.test.ts tests/companies-page-data.test.ts tests/company-dashboard.test.ts tests/company-detail-handoff.test.ts tests/company-discovery.test.ts tests/company-period-range.test.ts tests/company-refresh-state.test.ts tests/compare-utils.test.ts tests/compare-page-data.test.ts tests/sectors-page-data.test.ts",
     "test:e2e": "playwright test"
   },
   "dependencies": {

--- a/apps/web/tests/company-dashboard.test.ts
+++ b/apps/web/tests/company-dashboard.test.ts
@@ -1,0 +1,159 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { CompanyInfo, KPIBundle } from "../lib/api.ts";
+import {
+  buildCompanyDashboardModel,
+  buildCompanyHeroModel,
+} from "../lib/company-dashboard.ts";
+
+function buildCompanyInfo(overrides: Partial<CompanyInfo> = {}): CompanyInfo {
+  return {
+    cd_cvm: 9512,
+    company_name: "PETROLEO BRASILEIRO S.A. - PETROBRAS",
+    nome_comercial: "Petrobras",
+    cnpj: "33.000.167/0001-01",
+    setor_cvm: "Energia",
+    setor_analitico: "Energia",
+    sector_name: "Energia",
+    sector_slug: "energia",
+    company_type: "comercial",
+    ticker_b3: "PETR4",
+    read_model_updated_at: null,
+    has_readable_current_data: true,
+    readable_years_count: 3,
+    latest_readable_year: 2024,
+    read_availability_code: "readable_history_available",
+    read_availability_message: "Leitura anual disponivel ate 2024.",
+    ...overrides,
+  };
+}
+
+function buildBundle(): KPIBundle {
+  return {
+    cd_cvm: 9512,
+    years: [2022, 2023, 2024],
+    annual: {
+      columns: [
+        "KPI_ID",
+        "KPI_NOME",
+        "FORMAT_TYPE",
+        "DELTA_YOY",
+        "2022",
+        "2023",
+        "2024",
+      ],
+      rows: [
+        {
+          KPI_ID: "RECEITA_LIQ",
+          KPI_NOME: "Receita Liquida",
+          FORMAT_TYPE: "brl",
+          DELTA_YOY: 0.08,
+          2022: 1000,
+          2023: 1100,
+          2024: 1188,
+        },
+        {
+          KPI_ID: "EBITDA",
+          KPI_NOME: "EBITDA",
+          FORMAT_TYPE: "brl",
+          DELTA_YOY: 0.06,
+          2022: 300,
+          2023: 320,
+          2024: 339,
+        },
+        {
+          KPI_ID: "LUCRO_LIQ",
+          KPI_NOME: "Lucro Liquido",
+          FORMAT_TYPE: "brl",
+          DELTA_YOY: 0.05,
+          2022: 120,
+          2023: 125,
+          2024: 131,
+        },
+        {
+          KPI_ID: "MG_BRUTA",
+          KPI_NOME: "Margem Bruta",
+          FORMAT_TYPE: "pct",
+          DELTA_YOY: 0.01,
+          2022: 0.42,
+          2023: 0.43,
+          2024: 0.44,
+        },
+        {
+          KPI_ID: "MG_EBITDA",
+          KPI_NOME: "Margem EBITDA",
+          FORMAT_TYPE: "pct",
+          DELTA_YOY: 0.015,
+          2022: 0.28,
+          2023: 0.295,
+          2024: 0.31,
+        },
+        {
+          KPI_ID: "MG_LIQ",
+          KPI_NOME: "Margem Liquida",
+          FORMAT_TYPE: "pct",
+          DELTA_YOY: 0.01,
+          2022: 0.12,
+          2023: 0.125,
+          2024: 0.135,
+        },
+        {
+          KPI_ID: "ROE",
+          KPI_NOME: "ROE",
+          FORMAT_TYPE: "pct",
+          DELTA_YOY: 0.02,
+          2022: 0.17,
+          2023: 0.18,
+          2024: 0.2,
+        },
+        {
+          KPI_ID: "DIV_LIQ_EBITDA",
+          KPI_NOME: "Divida Liquida / EBITDA",
+          FORMAT_TYPE: "ratio",
+          DELTA_YOY: -0.1,
+          2022: 1.4,
+          2023: 1.3,
+          2024: 1.2,
+        },
+      ],
+    },
+    quarterly: {
+      columns: [],
+      rows: [],
+    },
+  };
+}
+
+test("buildCompanyDashboardModel returns chart, cards and table models from annual KPIs", () => {
+  const model = buildCompanyDashboardModel(buildBundle());
+
+  assert.deepEqual(model.years, [2022, 2023, 2024]);
+  assert.equal(model.yearsLabel, "2022, 2023, 2024");
+  assert.ok(model.indicatorOptions.some((indicator) => indicator.id === "RECEITA_LIQ"));
+  assert.deepEqual(
+    model.defaultSelectedIndicators.map((indicator) => indicator.id),
+    ["RECEITA_LIQ", "EBITDA", "LUCRO_LIQ"],
+  );
+  assert.deepEqual(
+    model.summaryCards.map((card) => card.id),
+    ["MG_BRUTA", "MG_EBITDA", "MG_LIQ", "ROE"],
+  );
+  assert.deepEqual(
+    model.spotlightMetrics.map((metric) => metric.id),
+    ["RECEITA_LIQ", "EBITDA", "LUCRO_LIQ", "MG_EBITDA"],
+  );
+  assert.equal(model.chartSeries.RECEITA_LIQ.points.at(-1)?.value, 1188);
+  assert.equal(
+    model.tableRows.find((row) => row.id === "DIV_LIQ_EBITDA")?.valuesByYear[2024],
+    1.2,
+  );
+});
+
+test("buildCompanyHeroModel keeps compare and sector links aligned with selected years", () => {
+  const hero = buildCompanyHeroModel(buildCompanyInfo(), [2023, 2024]);
+
+  assert.equal(hero.initials, "PB");
+  assert.match(hero.compareHref, /\/comparar\?ids=9512&anos=2023%2C2024/);
+  assert.equal(hero.sectorHref, "/setores/energia?ano=2024");
+});

--- a/apps/web/tests/smoke.spec.ts
+++ b/apps/web/tests/smoke.spec.ts
@@ -8,6 +8,8 @@ test("fluxo inicial de descoberta por empresa", async ({ page }) => {
       name: /analise financeira/i,
     }),
   ).toBeVisible();
+  await expect(page.getByText(/companhias abertas/i).first()).toBeVisible();
+  await expect(page.getByText(/ao vivo|verificando|sem sinal/i).first()).toBeVisible();
 
   const searchBox = page.getByLabel(/buscar empresa/i);
   await searchBox.fill("petrobras");
@@ -29,6 +31,17 @@ test("fluxo inicial de descoberta por empresa", async ({ page }) => {
   await expect(page.locator("h1").first()).toContainText(/PETROBRAS/i);
 });
 
+test("detalhe com historico renderiza o dashboard de analise na visao geral", async ({
+  page,
+}) => {
+  await page.goto("/empresas/4170");
+
+  await expect(page.locator("h1").first()).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByTestId("company-analysis-panel")).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByText(/visao anual em um unico painel/i)).toBeVisible();
+  await expect(page.getByText(/tabela anual/i)).toBeVisible();
+});
+
 test("home suggestions usam a rota same-origin", async ({ page }) => {
   await page.goto("/");
 
@@ -44,14 +57,14 @@ test("home suggestions usam a rota same-origin", async ({ page }) => {
 });
 
 test("detalhe sem historico vira experiencia guiada de pre-refresh", async ({ page }) => {
-  await page.goto("/empresas/9512");
+  await page.goto("/empresas/25640");
 
-  await expect(page.locator("h1").first()).toContainText(/PETROBRAS/i, {
+  await expect(page.locator("h1").first()).toContainText(/AUREN/i, {
     timeout: 30_000,
   });
 
   await expect(
-    page.getByText(/historico anual ainda nao liberado/i),
+    page.getByText(/esta empresa ainda depende da primeira materializacao/i),
   ).toBeVisible();
   await expect(
     page.getByText(/o que destrava esta pagina/i),


### PR DESCRIPTION
## Summary
- productionize the `#189` dashboard patterns inside the real company detail route
- unify readable and no-data company states under the same company shell with persistent freshness/on-demand rail
- formalize the `#190` home by restoring live trust/health signals and tightening capability copy
- quarantine `/demo-analysis` as an internal noindex reference route

## What changed
- added a company dashboard adapter layer for hero metadata, KPI cards, chart series, and annual table rows
- replaced the old `Visao Geral` composition with a richer analysis panel on `/empresas/[cd_cvm]`
- refactored the no-data company page to reuse the real company shell and right rail
- restored home trust/health visibility and updated feature copy to match live routes/capabilities
- added unit coverage for the dashboard adapter and expanded smoke coverage for home and company detail

## Validation
- `npm run typecheck`
- `npm run test:unit`
- `npx playwright test tests/smoke.spec.ts`
- `npm run test:e2e` *(fails in existing compare/sectors specs outside this task's write-set; smoke coverage for the new home/company flows passes)*

## Issue
Closes #191
