### PR TITLE
feat(backend): add populares/em-destaque endpoints + company_views analytics table

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -15,6 +15,7 @@ from sentry_sdk.integrations.starlette import StarletteIntegration
 
 from apps.api.app.dependencies import ApiError, ServiceUnavailableError, serialize_error
 from apps.api.app.presenters import ErrorResponsePayload
+from apps.api.app.routes.analytics import router as analytics_router
 from apps.api.app.routes.companies import router as companies_router
 from apps.api.app.routes.health import router as health_router
 from apps.api.app.routes.sectors import router as sectors_router
@@ -135,6 +136,7 @@ def create_app(
     app.include_router(companies_router)
     app.include_router(sectors_router)
     app.include_router(status_router)
+    app.include_router(analytics_router)
     return app
 
 

--- a/apps/api/app/routes/analytics.py
+++ b/apps/api/app/routes/analytics.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import Response
+from pydantic import BaseModel, Field
+
+from apps.api.app.dependencies import ensure_api_ready, get_read_service, get_settings
+from src.read_service import CVMReadService
+
+router = APIRouter(tags=["analytics"])
+
+
+class CompanyViewRequest(BaseModel):
+    cd_cvm: int = Field(..., description="Codigo CVM da empresa visualizada.")
+
+
+@router.post(
+    "/analytics/company-view",
+    status_code=204,
+    summary="Registra uma visualizacao de empresa para o ranking de destaques.",
+    response_class=Response,
+)
+def record_company_view(
+    request: Request,
+    body: CompanyViewRequest,
+    service: CVMReadService = Depends(get_read_service),
+) -> None:
+    ensure_api_ready(get_settings(request))
+    service.record_company_view(body.cd_cvm)

--- a/apps/api/app/routes/companies.py
+++ b/apps/api/app/routes/companies.py
@@ -117,6 +117,43 @@ def get_company_suggestions(
     return present_company_suggestions(items)
 
 
+COMPANY_POPULARES_CACHE_CONTROL = "public, max-age=3600, stale-while-revalidate=86400"
+COMPANY_DESTAQUE_CACHE_CONTROL = "public, max-age=120, stale-while-revalidate=600"
+
+
+@router.get(
+    "/companies/populares",
+    response_model=CompanyDirectoryPagePayload,
+    summary="Retorna as 10 maiores empresas da B3 por market cap (ranking estatico).",
+)
+def list_populares_companies(
+    response: Response,
+    request: Request,
+    service: CVMReadService = Depends(get_read_service),
+) -> CompanyDirectoryPagePayload:
+    ensure_api_ready(get_settings(request))
+    _apply_cache_headers(response, COMPANY_POPULARES_CACHE_CONTROL)
+    page_dto = service.get_populares_companies()
+    return present_company_directory_page(page_dto)
+
+
+@router.get(
+    "/companies/em-destaque",
+    response_model=CompanyDirectoryPagePayload,
+    summary="Retorna as empresas mais visitadas globalmente.",
+)
+def list_em_destaque_companies(
+    response: Response,
+    request: Request,
+    limit: int = Query(default=10, ge=1, le=20, description="Numero maximo de empresas retornadas."),
+    service: CVMReadService = Depends(get_read_service),
+) -> CompanyDirectoryPagePayload:
+    ensure_api_ready(get_settings(request))
+    _apply_cache_headers(response, COMPANY_DESTAQUE_CACHE_CONTROL)
+    page_dto = service.get_em_destaque_companies(limit=limit)
+    return present_company_directory_page(page_dto)
+
+
 @router.get(
     "/companies/export/excel-batch",
     summary="Retorna um arquivo ZIP com um workbook Excel por empresa selecionada.",

--- a/src/database.py
+++ b/src/database.py
@@ -80,9 +80,17 @@ def init_db_tables(engine: Engine) -> None:
                 updated_at      TEXT NOT NULL
             )
         """))
+        conn.execute(text("""
+            CREATE TABLE IF NOT EXISTS company_views (
+                cd_cvm         INTEGER PRIMARY KEY REFERENCES companies(cd_cvm) ON DELETE CASCADE,
+                view_count     INTEGER NOT NULL DEFAULT 0,
+                last_viewed_at TEXT NOT NULL
+            )
+        """))
         ensure_refresh_runtime_tables_for_connection(conn)
 
     _index_ddl = [
+        'CREATE INDEX {c}IF NOT EXISTS idx_company_views_count ON company_views(view_count DESC)',
         'CREATE INDEX {c}IF NOT EXISTS idx_fr_cd_cvm ON financial_reports("CD_CVM")',
         'CREATE INDEX {c}IF NOT EXISTS idx_fr_cd_cvm_stmt_year ON financial_reports("CD_CVM", "STATEMENT_TYPE", "REPORT_YEAR")',
         'CREATE INDEX {c}IF NOT EXISTS idx_fr_cd_conta ON financial_reports("CD_CONTA")',

--- a/src/query_layer.py
+++ b/src/query_layer.py
@@ -470,6 +470,74 @@ class CVMQueryLayer:
             years_map.setdefault(int(row["CD_CVM"]), []).append(int(row["REPORT_YEAR"]))
         return {cd_cvm: tuple(years) for cd_cvm, years in years_map.items()}
 
+    @slow_query_warn(threshold_ms=200)
+    def get_companies_by_cvm_ids(self, cvm_ids: list[int]) -> pd.DataFrame:
+        """Returns directory rows for a specific ordered set of cd_cvm values.
+
+        Result rows are returned in database order; callers are responsible for
+        re-applying the desired ordering (e.g. static market-cap rank).
+        Returns an empty DataFrame when cvm_ids is empty.
+        """
+        if not cvm_ids:
+            return pd.DataFrame()
+        unique_ids = [int(cd) for cd in cvm_ids]
+        placeholders = ", ".join(f":id_{i}" for i in range(len(unique_ids)))
+        params: dict[str, object] = {f"id_{i}": cd for i, cd in enumerate(unique_ids)}
+        sql = text(
+            f"""
+            SELECT
+                c.cd_cvm,
+                c.company_name,
+                COALESCE(c.ticker_b3, '') AS ticker_b3,
+                c.setor_analitico,
+                c.setor_cvm,
+                {_CANONICAL_SECTOR_SQL} AS sector_name,
+                COALESCE(COUNT(fr."CD_CVM"), 0) AS total_rows,
+                CASE WHEN COUNT(fr."CD_CVM") > 0 THEN 1 ELSE 0 END AS has_financial_data,
+                c.coverage_rank
+            FROM companies c
+            LEFT JOIN financial_reports fr ON fr."CD_CVM" = c.cd_cvm
+            WHERE c.cd_cvm IN ({placeholders})
+            GROUP BY c.cd_cvm, c.company_name, c.ticker_b3,
+                     c.setor_analitico, c.setor_cvm, c.coverage_rank
+            """
+        )
+        return pd.read_sql(sql, self.engine, params=params).reset_index(drop=True)
+
+    @slow_query_warn(threshold_ms=200)
+    def get_top_viewed_companies(self, limit: int = 10) -> pd.DataFrame:
+        """Returns top-N companies ordered by view_count DESC.
+
+        Falls back to coverage_rank ASC when view_count values are equal (or when
+        the company_views table is empty), matching the existing smart default.
+        """
+        sql = text(
+            f"""
+            SELECT
+                c.cd_cvm,
+                c.company_name,
+                COALESCE(c.ticker_b3, '') AS ticker_b3,
+                c.setor_analitico,
+                c.setor_cvm,
+                {_CANONICAL_SECTOR_SQL} AS sector_name,
+                COALESCE(COUNT(fr."CD_CVM"), 0) AS total_rows,
+                CASE WHEN COUNT(fr."CD_CVM") > 0 THEN 1 ELSE 0 END AS has_financial_data,
+                c.coverage_rank,
+                COALESCE(cv.view_count, 0) AS view_count
+            FROM companies c
+            LEFT JOIN financial_reports fr ON fr."CD_CVM" = c.cd_cvm
+            LEFT JOIN company_views cv ON cv.cd_cvm = c.cd_cvm
+            GROUP BY c.cd_cvm, c.company_name, c.ticker_b3,
+                     c.setor_analitico, c.setor_cvm, c.coverage_rank, cv.view_count
+            ORDER BY
+                COALESCE(cv.view_count, 0) DESC,
+                CASE WHEN c.coverage_rank IS NULL THEN 1 ELSE 0 END ASC,
+                c.coverage_rank ASC
+            LIMIT :limit
+            """
+        )
+        return pd.read_sql(sql, self.engine, params={"limit": int(limit)}).reset_index(drop=True)
+
     def _company_directory_filters(
         self,
         *,

--- a/src/read_service.py
+++ b/src/read_service.py
@@ -61,6 +61,22 @@ from src.settings import AppSettings, get_settings
 
 EXPORT_STATEMENT_TYPES = ("DRE", "BPA", "BPP", "DFC", "DVA", "DMPL")
 
+# Top-10 B3 companies by approximate market cap, ordered largest-first.
+# cd_cvm values sourced from src/ticker_map.py.
+# Update this list when B3 composition changes significantly (roughly annual).
+POPULARES_CVM_IDS: tuple[int, ...] = (
+    9512,   # PETR4  – PETROBRAS
+    4170,   # VALE3  – VALE
+    19348,  # ITUB4  – ITAÚ UNIBANCO
+    906,    # BBDC4  – BANCO BRADESCO
+    1023,   # BBAS3  – BANCO DO BRASIL
+    22616,  # BPAC11 – BTG PACTUAL
+    23264,  # ABEV3  – AMBEV
+    5410,   # WEGE3  – WEG
+    24813,  # RENT3  – LOCALIZA
+    21610,  # B3SA3  – B3
+)
+
 
 class RefreshAlreadyActiveError(RuntimeError):
     """Raised when an internal on-demand refresh is already active."""
@@ -336,6 +352,79 @@ class CVMReadService:
                 sector=sector_slug,
             ),
         )
+
+    def get_populares_companies(self) -> CompanyDirectoryPage:
+        """Returns top-10 B3 companies by market cap in static rank order.
+
+        The ranking is maintained in POPULARES_CVM_IDS. Companies missing from
+        the local DB (e.g. during seeding) are silently omitted.
+        """
+        ids = list(POPULARES_CVM_IDS)
+        rows_df = self.query_layer.get_companies_by_cvm_ids(ids)
+        if not rows_df.empty:
+            order_map = {cd: i for i, cd in enumerate(ids)}
+            rows_df = rows_df.copy()
+            rows_df["_order"] = rows_df["cd_cvm"].map(lambda x: order_map.get(int(x), 999))
+            rows_df = rows_df.sort_values("_order").drop(columns=["_order"]).reset_index(drop=True)
+            years_map = self.query_layer.get_company_years_map(rows_df["cd_cvm"].tolist())
+            rows_df["anos_disponiveis"] = rows_df["cd_cvm"].map(lambda cd: years_map.get(int(cd), ()))
+        n = len(rows_df)
+        return CompanyDirectoryPage(
+            items=tuple(self._build_company_results(rows_df)),
+            pagination=CompanyDirectoryPagination(
+                page=1, page_size=n, total_items=n,
+                total_pages=1, has_next=False, has_previous=False,
+            ),
+            applied_filters=CompanyDirectoryAppliedFilters(search="", sector=None),
+        )
+
+    def get_em_destaque_companies(self, limit: int = 10) -> CompanyDirectoryPage:
+        """Returns companies most visited globally, ordered by view_count DESC.
+
+        Falls back gracefully to coverage_rank ordering when the company_views
+        table is empty (e.g. immediately after deployment).
+        """
+        rows_df = self.query_layer.get_top_viewed_companies(limit=limit)
+        if not rows_df.empty:
+            rows_df = rows_df.copy()
+            years_map = self.query_layer.get_company_years_map(rows_df["cd_cvm"].tolist())
+            rows_df["anos_disponiveis"] = rows_df["cd_cvm"].map(lambda cd: years_map.get(int(cd), ()))
+        n = len(rows_df)
+        return CompanyDirectoryPage(
+            items=tuple(self._build_company_results(rows_df)),
+            pagination=CompanyDirectoryPagination(
+                page=1, page_size=n, total_items=n,
+                total_pages=1, has_next=False, has_previous=False,
+            ),
+            applied_filters=CompanyDirectoryAppliedFilters(search="", sector=None),
+        )
+
+    def record_company_view(self, cd_cvm: int) -> None:
+        """Increments the global view counter for a company.
+
+        Uses an upsert so the call is idempotent and safe under concurrent
+        writes. Silently ignores unknown cd_cvm values (FK constraint skips
+        the insert rather than raising).
+        """
+        now_iso = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+        try:
+            with self.engine.begin() as conn:
+                conn.execute(
+                    text("""
+                        INSERT INTO company_views (cd_cvm, view_count, last_viewed_at)
+                        VALUES (:cd, 1, :now)
+                        ON CONFLICT(cd_cvm) DO UPDATE SET
+                            view_count     = company_views.view_count + 1,
+                            last_viewed_at = :now
+                    """),
+                    {"cd": int(cd_cvm), "now": now_iso},
+                )
+        except Exception:
+            # Analytics must never break the API — log and continue
+            import logging
+            logging.getLogger(__name__).warning(
+                "record_company_view failed for cd_cvm=%s", cd_cvm, exc_info=True
+            )
 
     def get_company_filters(self) -> CompanyFiltersDTO:
         df = self.query_layer.get_available_company_sectors()


### PR DESCRIPTION
## Summary

- Adds `company_views` table (additive DDL) to track global company page view counts
- Adds `POPULARES_CVM_IDS` static ranking of top-10 B3 companies by market cap
- New FastAPI endpoints: `GET /companies/populares`, `GET /companies/em-destaque`, `POST /analytics/company-view`
- New `CVMQueryLayer` methods: `get_companies_by_cvm_ids()`, `get_top_viewed_companies()`
- New `CVMReadService` methods: `get_populares_companies()`, `get_em_destaque_companies()`, `record_company_view()`

## Risk
`risk:contract-sensitive` — touches `apps/api/app/routes/` (critical-contract) and `src/database.py`, `src/read_service.py`, `src/query_layer.py`, `apps/api/app/main.py` (critical-runtime).

## Compatibilidade
All changes are **additive-only**. No existing endpoint, response schema, or DB column is modified:
- `GET /companies` — unchanged
- `GET /companies/filters` — unchanged
- `GET /companies/{cd_cvm}` — unchanged (new routes registered before this path, correct FastAPI ordering)
- `company_views` is a new table; no FK from existing tables (only CASCADE DELETE toward companies)
- `analytics.py` is a new router; `main.py` gains one `include_router` call only
- No existing `CVMQueryLayer` or `CVMReadService` method signature changed

## Verification
- [x] Imports compile, routes appear in FastAPI router
- [x] `init_db_tables` creates `company_views` table idempotently
- [x] `get_populares_companies()` returns companies in POPULARES_CVM_IDS order
- [x] `record_company_view()` upserts correctly (PETR4 first after 2 views)
- [x] `get_em_destaque_companies()` falls back to `coverage_rank` when no views recorded

## Test plan
- [ ] Deploy to Railway staging
- [ ] `GET /companies/populares` → 200, 10 items in PETR4→B3 order
- [ ] `GET /companies/em-destaque` → 200, items ordered by view_count
- [ ] `POST /analytics/company-view` `{"cd_cvm": 9512}` → 204

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)