### PR TITLE
feat(frontend): replace home feature grid with Remotion box

### DIFF
--- a/apps/web/components/home/analysis-remotion-player.tsx
+++ b/apps/web/components/home/analysis-remotion-player.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { Player } from "@remotion/player";
+import {
+  AbsoluteFill,
+  interpolate,
+  spring,
+  useCurrentFrame,
+  useVideoConfig,
+} from "remotion";
+
+function AnalysisRemotionVideo() {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const intro = spring({ frame, fps, config: { damping: 18, stiffness: 80 } });
+  const loop = (frame % 120) / 120;
+  const scanX = interpolate(loop, [0, 1], [-18, 118]);
+
+  const cards = [
+    { label: "Dados CVM", value: "100%" },
+    { label: "KPIs", value: "60+" },
+    { label: "Comparar", value: "4x" },
+  ];
+
+  return (
+    <AbsoluteFill className="overflow-hidden rounded-[1.35rem] bg-[oklch(0.16_0.025_160)] text-white">
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_18%_16%,rgba(72,187,120,0.32),transparent_28%),radial-gradient(circle_at_82%_12%,rgba(245,158,11,0.25),transparent_26%),linear-gradient(135deg,rgba(255,255,255,0.08),transparent_48%)]" />
+      <div
+        className="absolute bottom-0 top-0 w-16 bg-white/12 blur-xl"
+        style={{ left: `${scanX}%` }}
+      />
+      <div className="absolute inset-5 rounded-[1rem] border border-white/12 bg-white/[0.06] shadow-[inset_0_1px_0_rgba(255,255,255,0.12)]" />
+
+      <div
+        className="relative z-10 flex h-full flex-col justify-between p-6"
+        style={{
+          opacity: interpolate(intro, [0, 1], [0, 1]),
+          transform: `translateY(${interpolate(intro, [0, 1], [18, 0])}px)`,
+        }}
+      >
+        <div>
+          <div className="mb-4 inline-flex rounded-full border border-white/15 bg-white/10 px-3 py-1 text-[0.66rem] font-semibold uppercase tracking-[0.24em] text-white/72">
+            Analise guiada
+          </div>
+          <h3 className="max-w-[15rem] font-heading text-[1.85rem] font-semibold leading-[0.96] tracking-[-0.06em] text-white">
+            Tudo que você precisa saber para analisar
+          </h3>
+        </div>
+
+        <div className="grid grid-cols-3 gap-2">
+          {cards.map((card, index) => {
+            const itemIn = spring({
+              frame: frame - 10 - index * 8,
+              fps,
+              config: { damping: 16, stiffness: 90 },
+            });
+
+            return (
+              <div
+                key={card.label}
+                className="rounded-2xl border border-white/12 bg-white/10 p-3 backdrop-blur"
+                style={{
+                  opacity: interpolate(itemIn, [0, 1], [0.35, 1]),
+                  transform: `translateY(${interpolate(itemIn, [0, 1], [10, 0])}px)`,
+                }}
+              >
+                <div className="font-heading text-xl font-semibold tracking-tight">
+                  {card.value}
+                </div>
+                <div className="mt-1 text-[0.62rem] uppercase tracking-[0.14em] text-white/58">
+                  {card.label}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </AbsoluteFill>
+  );
+}
+
+export function AnalysisRemotionPlayer() {
+  return (
+    <Player
+      component={AnalysisRemotionVideo}
+      compositionHeight={520}
+      compositionWidth={520}
+      durationInFrames={180}
+      fps={30}
+      loop
+      autoPlay
+      controls={false}
+      acknowledgeRemotionLicense
+      style={{ width: "100%", height: "100%" }}
+    />
+  );
+}

--- a/apps/web/components/home/bento-features.tsx
+++ b/apps/web/components/home/bento-features.tsx
@@ -1,13 +1,6 @@
 "use client";
 
-import { Player } from "@remotion/player";
-import {
-  AbsoluteFill,
-  interpolate,
-  spring,
-  useCurrentFrame,
-  useVideoConfig,
-} from "remotion";
+import dynamic from "next/dynamic";
 import {
   BarChart3Icon,
   FileTextIcon,
@@ -65,78 +58,21 @@ const FEATURES: FeatureCard[] = [
   },
 ];
 
+const AnalysisRemotionPlayer = dynamic(
+  () =>
+    import("@/components/home/analysis-remotion-player").then(
+      (mod) => mod.AnalysisRemotionPlayer,
+    ),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-full min-h-[20rem] rounded-[1.35rem] bg-[oklch(0.16_0.025_160)]" />
+    ),
+  },
+);
+
 function getAccentVar(accent: string) {
   return `var(--${accent})`;
-}
-
-function AnalysisRemotionVideo() {
-  const frame = useCurrentFrame();
-  const { fps } = useVideoConfig();
-  const intro = spring({ frame, fps, config: { damping: 18, stiffness: 80 } });
-  const loop = (frame % 120) / 120;
-  const scanX = interpolate(loop, [0, 1], [-18, 118]);
-
-  const cards = [
-    { label: "Dados CVM", value: "100%" },
-    { label: "KPIs", value: "60+" },
-    { label: "Comparar", value: "4x" },
-  ];
-
-  return (
-    <AbsoluteFill className="overflow-hidden rounded-[1.35rem] bg-[oklch(0.16_0.025_160)] text-white">
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_18%_16%,rgba(72,187,120,0.32),transparent_28%),radial-gradient(circle_at_82%_12%,rgba(245,158,11,0.25),transparent_26%),linear-gradient(135deg,rgba(255,255,255,0.08),transparent_48%)]" />
-      <div
-        className="absolute bottom-0 top-0 w-16 bg-white/12 blur-xl"
-        style={{ left: `${scanX}%` }}
-      />
-      <div className="absolute inset-5 rounded-[1rem] border border-white/12 bg-white/[0.06] shadow-[inset_0_1px_0_rgba(255,255,255,0.12)]" />
-
-      <div
-        className="relative z-10 flex h-full flex-col justify-between p-6"
-        style={{
-          opacity: interpolate(intro, [0, 1], [0, 1]),
-          transform: `translateY(${interpolate(intro, [0, 1], [18, 0])}px)`,
-        }}
-      >
-        <div>
-          <div className="mb-4 inline-flex rounded-full border border-white/15 bg-white/10 px-3 py-1 text-[0.66rem] font-semibold uppercase tracking-[0.24em] text-white/72">
-            Analise guiada
-          </div>
-          <h3 className="max-w-[15rem] font-heading text-[1.85rem] font-semibold leading-[0.96] tracking-[-0.06em] text-white">
-            Tudo que você precisa saber para analisar
-          </h3>
-        </div>
-
-        <div className="grid grid-cols-3 gap-2">
-          {cards.map((card, index) => {
-            const itemIn = spring({
-              frame: frame - 10 - index * 8,
-              fps,
-              config: { damping: 16, stiffness: 90 },
-            });
-
-            return (
-              <div
-                key={card.label}
-                className="rounded-2xl border border-white/12 bg-white/10 p-3 backdrop-blur"
-                style={{
-                  opacity: interpolate(itemIn, [0, 1], [0.35, 1]),
-                  transform: `translateY(${interpolate(itemIn, [0, 1], [10, 0])}px)`,
-                }}
-              >
-                <div className="font-heading text-xl font-semibold tracking-tight">
-                  {card.value}
-                </div>
-                <div className="mt-1 text-[0.62rem] uppercase tracking-[0.14em] text-white/58">
-                  {card.label}
-                </div>
-              </div>
-            );
-          })}
-        </div>
-      </div>
-    </AbsoluteFill>
-  );
 }
 
 export function BentoFeatures() {
@@ -155,18 +91,7 @@ export function BentoFeatures() {
       <div className="overflow-hidden rounded-[1.75rem] border border-border/70 bg-card shadow-[0_28px_90px_-42px_rgba(16,30,24,0.32)]">
         <div className="grid gap-0 lg:grid-cols-[0.95fr_1.25fr]">
           <div className="relative min-h-[22rem] bg-muted/30 p-3 sm:min-h-[25rem]">
-            <Player
-              component={AnalysisRemotionVideo}
-              compositionHeight={520}
-              compositionWidth={520}
-              durationInFrames={180}
-              fps={30}
-              loop
-              autoPlay
-              controls={false}
-              acknowledgeRemotionLicense
-              style={{ width: "100%", height: "100%" }}
-            />
+            <AnalysisRemotionPlayer />
           </div>
 
           <div className="grid content-center gap-3 p-4 sm:p-6 lg:grid-cols-2">

--- a/apps/web/components/home/bento-features.tsx
+++ b/apps/web/components/home/bento-features.tsx
@@ -1,5 +1,13 @@
 "use client";
 
+import { Player } from "@remotion/player";
+import {
+  AbsoluteFill,
+  interpolate,
+  spring,
+  useCurrentFrame,
+  useVideoConfig,
+} from "remotion";
 import {
   BarChart3Icon,
   FileTextIcon,
@@ -15,53 +23,44 @@ type FeatureCard = {
   icon: LucideIcon;
   title: string;
   description: string;
-  gridClass: string;
   accent: string;
-  featured?: boolean;
 };
 
 const FEATURES: FeatureCard[] = [
   {
     icon: SearchIcon,
     title: "Busca inteligente",
-    description: "Busque por nome, ticker ou codigo CVM e caia direto na leitura pronta ou no caminho on-demand.",
-    gridClass: "sm:col-span-2 lg:col-span-1",
+    description: "Nome, ticker ou codigo CVM com caminho direto para leitura ou on-demand.",
     accent: "primary",
   },
   {
     icon: FileTextIcon,
     title: "DRE, BPA, BPP e DFC",
-    description: "Demonstracoes anuais e tabelas navegaveis organizadas a partir dos arquivos publicos da CVM.",
-    gridClass: "lg:col-span-2",
+    description: "Demonstracoes anuais e tabelas navegaveis a partir dos arquivos publicos da CVM.",
     accent: "chart-1",
   },
   {
     icon: BarChart3Icon,
     title: "60+ KPIs",
-    description: "Indicadores calculados automaticamente: margem, ROE, liquidez e mais.",
-    gridClass: "lg:row-span-2",
+    description: "Margem, ROE, liquidez e indicadores calculados automaticamente.",
     accent: "chart-2",
-    featured: true,
   },
   {
     icon: GitCompareArrowsIcon,
     title: "Comparacao side-by-side",
-    description: "Compare ate 4 empresas simultaneamente com periodos sincronizados.",
-    gridClass: "sm:col-span-2 lg:col-span-1",
+    description: "Ate 4 empresas com periodos sincronizados no mesmo fluxo.",
     accent: "chart-3",
   },
   {
     icon: LayersIcon,
     title: "Setores organizados",
-    description: "Navegue por hubs setoriais reais e conecte empresa, contexto e comparacao no mesmo fluxo.",
-    gridClass: "",
+    description: "Hubs setoriais reais para conectar empresa, contexto e comparacao.",
     accent: "chart-4",
   },
   {
     icon: TrendingUpIcon,
-    title: "On-demand quando falta historico",
-    description: "Quando a empresa ainda nao tem leitura local, o produto acompanha a solicitacao e explica o resultado sem esconder o estado real.",
-    gridClass: "",
+    title: "On-demand guiado",
+    description: "Quando falta historico local, o produto acompanha a solicitacao sem esconder estado.",
     accent: "chart-5",
   },
 ];
@@ -70,71 +69,146 @@ function getAccentVar(accent: string) {
   return `var(--${accent})`;
 }
 
+function AnalysisRemotionVideo() {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const intro = spring({ frame, fps, config: { damping: 18, stiffness: 80 } });
+  const loop = (frame % 120) / 120;
+  const scanX = interpolate(loop, [0, 1], [-18, 118]);
+
+  const cards = [
+    { label: "Dados CVM", value: "100%" },
+    { label: "KPIs", value: "60+" },
+    { label: "Comparar", value: "4x" },
+  ];
+
+  return (
+    <AbsoluteFill className="overflow-hidden rounded-[1.35rem] bg-[oklch(0.16_0.025_160)] text-white">
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_18%_16%,rgba(72,187,120,0.32),transparent_28%),radial-gradient(circle_at_82%_12%,rgba(245,158,11,0.25),transparent_26%),linear-gradient(135deg,rgba(255,255,255,0.08),transparent_48%)]" />
+      <div
+        className="absolute bottom-0 top-0 w-16 bg-white/12 blur-xl"
+        style={{ left: `${scanX}%` }}
+      />
+      <div className="absolute inset-5 rounded-[1rem] border border-white/12 bg-white/[0.06] shadow-[inset_0_1px_0_rgba(255,255,255,0.12)]" />
+
+      <div
+        className="relative z-10 flex h-full flex-col justify-between p-6"
+        style={{
+          opacity: interpolate(intro, [0, 1], [0, 1]),
+          transform: `translateY(${interpolate(intro, [0, 1], [18, 0])}px)`,
+        }}
+      >
+        <div>
+          <div className="mb-4 inline-flex rounded-full border border-white/15 bg-white/10 px-3 py-1 text-[0.66rem] font-semibold uppercase tracking-[0.24em] text-white/72">
+            Analise guiada
+          </div>
+          <h3 className="max-w-[15rem] font-heading text-[1.85rem] font-semibold leading-[0.96] tracking-[-0.06em] text-white">
+            Tudo que você precisa saber para analisar
+          </h3>
+        </div>
+
+        <div className="grid grid-cols-3 gap-2">
+          {cards.map((card, index) => {
+            const itemIn = spring({
+              frame: frame - 10 - index * 8,
+              fps,
+              config: { damping: 16, stiffness: 90 },
+            });
+
+            return (
+              <div
+                key={card.label}
+                className="rounded-2xl border border-white/12 bg-white/10 p-3 backdrop-blur"
+                style={{
+                  opacity: interpolate(itemIn, [0, 1], [0.35, 1]),
+                  transform: `translateY(${interpolate(itemIn, [0, 1], [10, 0])}px)`,
+                }}
+              >
+                <div className="font-heading text-xl font-semibold tracking-tight">
+                  {card.value}
+                </div>
+                <div className="mt-1 text-[0.62rem] uppercase tracking-[0.14em] text-white/58">
+                  {card.label}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </AbsoluteFill>
+  );
+}
+
 export function BentoFeatures() {
   return (
-    <section className="w-full max-w-5xl mx-auto">
+    <section className="mx-auto w-full max-w-5xl">
       <div className="mb-8 text-center">
         <p className="eyebrow mb-3">Recursos</p>
         <h2 className="font-heading text-[clamp(1.75rem,4vw,2.5rem)] font-medium tracking-[-0.035em] text-foreground">
-          Tudo que voce precisa para analisar
+          Tudo que você precisa para analisar
         </h2>
         <p className="mx-auto mt-3 max-w-xl text-[0.95rem] leading-relaxed text-muted-foreground">
-          Estrutura publica orientada a descoberta, leitura detalhada e comparacao das companhias abertas brasileiras.
+          Uma leitura unica para descobrir, comparar e aprofundar companhias abertas brasileiras.
         </p>
       </div>
 
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        {FEATURES.map((feature) => {
-          const accentColor = getAccentVar(feature.accent);
-          return (
-            <div
-              key={feature.title}
-              className={cn(
-                "group relative overflow-hidden rounded-[1.25rem] border border-border/60 bg-card p-6 transition-all duration-300",
-                "hover:-translate-y-0.5 hover:border-primary/20 hover:shadow-[0_20px_50px_-20px_rgba(16,30,24,0.18)]",
-                feature.gridClass,
-                feature.featured && "flex flex-col justify-between"
-              )}
-            >
-              {/* Gradient background on hover */}
-              <div
-                className="pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100"
-                style={{
-                  background: `radial-gradient(ellipse at top left, color-mix(in oklch, ${accentColor} 8%, transparent), transparent 60%)`,
-                }}
-              />
+      <div className="overflow-hidden rounded-[1.75rem] border border-border/70 bg-card shadow-[0_28px_90px_-42px_rgba(16,30,24,0.32)]">
+        <div className="grid gap-0 lg:grid-cols-[0.95fr_1.25fr]">
+          <div className="relative min-h-[22rem] bg-muted/30 p-3 sm:min-h-[25rem]">
+            <Player
+              component={AnalysisRemotionVideo}
+              compositionHeight={520}
+              compositionWidth={520}
+              durationInFrames={180}
+              fps={30}
+              loop
+              autoPlay
+              controls={false}
+              acknowledgeRemotionLicense
+              style={{ width: "100%", height: "100%" }}
+            />
+          </div>
 
-              <div className="relative">
+          <div className="grid content-center gap-3 p-4 sm:p-6 lg:grid-cols-2">
+            {FEATURES.map((feature) => {
+              const accentColor = getAccentVar(feature.accent);
+              return (
                 <div
-                  className="mb-4 flex size-11 items-center justify-center rounded-[12px] transition-transform duration-300 group-hover:scale-105"
-                  style={{
-                    background: `color-mix(in oklch, ${accentColor} 12%, transparent)`,
-                    border: `1px solid color-mix(in oklch, ${accentColor} 20%, transparent)`,
-                    color: accentColor,
-                  }}
+                  key={feature.title}
+                  className={cn(
+                    "group relative overflow-hidden rounded-[1.15rem] border border-border/60 bg-background/72 p-5",
+                    "transition-all duration-300 hover:-translate-y-0.5 hover:border-primary/25 hover:bg-background"
+                  )}
                 >
-                  <feature.icon className="size-5" strokeWidth={1.75} />
-                </div>
-                <h3 className="mb-2 font-heading text-lg font-semibold tracking-tight text-foreground">
-                  {feature.title}
-                </h3>
-                <p className="text-[0.88rem] leading-relaxed text-muted-foreground">
-                  {feature.description}
-                </p>
-              </div>
-
-              {feature.featured && (
-                <div className="relative mt-6 flex items-center gap-2 text-[0.8rem] font-medium text-muted-foreground">
-                  <span
-                    className="size-1.5 rounded-full animate-pulse"
-                    style={{ backgroundColor: accentColor }}
+                  <div
+                    className="pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+                    style={{
+                      background: `radial-gradient(ellipse at top left, color-mix(in oklch, ${accentColor} 10%, transparent), transparent 62%)`,
+                    }}
                   />
-                  <span>Calculo automatico</span>
+                  <div className="relative">
+                    <div
+                      className="mb-4 flex size-10 items-center justify-center rounded-[12px] transition-transform duration-300 group-hover:scale-105"
+                      style={{
+                        background: `color-mix(in oklch, ${accentColor} 12%, transparent)`,
+                        border: `1px solid color-mix(in oklch, ${accentColor} 22%, transparent)`,
+                        color: accentColor,
+                      }}
+                    >
+                      <feature.icon className="size-4.5" strokeWidth={1.8} />
+                    </div>
+                    <h3 className="mb-2 font-heading text-base font-semibold tracking-tight text-foreground">
+                      {feature.title}
+                    </h3>
+                    <p className="text-[0.84rem] leading-relaxed text-muted-foreground">
+                      {feature.description}
+                    </p>
+                  </div>
                 </div>
-              )}
-            </div>
-          );
-        })}
+              );
+            })}
+          </div>
+        </div>
       </div>
     </section>
   );

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -17,6 +17,7 @@
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tooltip": "^1.2.8",
+        "@remotion/player": "^4.0.451",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
@@ -28,6 +29,7 @@
         "react-countup": "^6.5.3",
         "react-day-picker": "^9.14.0",
         "react-dom": "19.2.4",
+        "remotion": "^4.0.451",
         "shadcn": "^4.2.0",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0"
@@ -3026,6 +3028,19 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
+    },
+    "node_modules/@remotion/player": {
+      "version": "4.0.451",
+      "resolved": "https://registry.npmjs.org/@remotion/player/-/player-4.0.451.tgz",
+      "integrity": "sha512-mJSaWHsMQuDXVVVh6UVBySBzzzqeSI+MHUuS+6hk/CrqZwBz1CQnsrtFZcjcnBpY40ao+ZqMA6uTEgs9n34YlQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "remotion": "4.0.451"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -9371,6 +9386,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/remotion": {
+      "version": "4.0.451",
+      "resolved": "https://registry.npmjs.org/remotion/-/remotion-4.0.451.tgz",
+      "integrity": "sha512-uTku1RmytCk50ZtPEoTdmB/4Erb+nH85vT3jkCLWQCaG9qWXxp2XAJ+eL7EfsCUyast2umZm4vdrdKXVxbeDMQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/require-directory": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,6 +21,7 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@remotion/player": "^4.0.451",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
@@ -32,6 +33,7 @@
     "react-countup": "^6.5.3",
     "react-day-picker": "^9.14.0",
     "react-dom": "19.2.4",
+    "remotion": "^4.0.451",
     "shadcn": "^4.2.0",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0"


### PR DESCRIPTION
﻿## Summary

Replaces the homepage Recursos bento grid with one cohesive feature box:

- removes the uneven bottom-left empty space from the old grid layout
- embeds an inline Remotion Player animation with "Tudo que você precisa saber para analisar"
- keeps the six feature explanations in compact cards beside the video
- adds the minimal Remotion runtime dependencies for the web app

## Validation

- npm run typecheck
- npm run lint (passes with existing warnings in demo-analysis/date-range/company-analysis-chart)
- npm run build
- npm run test:unit (80 passed)
- git diff --check origin/main...HEAD
- visual Playwright screenshot on localhost:3001 confirmed the section renders as a single box and the Remotion animation appears in viewport

Closes #200
