### PR TITLE
feat(desktop): add refresh-status and request-refresh bridge stubs

### DIFF
--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -326,6 +326,8 @@ import {
   bridgeFetchSectorDetail,
   bridgeFetchHealth,
   bridgeTrackCompanyView,
+  bridgeFetchRefreshStatus,
+  bridgeRequestRefresh,
 } from "./desktop-bridge.ts";
 
 export type ApiErrorCode =
@@ -1205,6 +1207,7 @@ export async function fetchCompanyStatement(
 export async function fetchRequestRefresh(
   cdCvm: number,
 ): Promise<RefreshDispatchResponse> {
+  if (isDesktopMode()) return bridgeRequestRefresh(cdCvm);
   return (await routeFetch<RefreshDispatchResponse>(
     `/api/request-refresh/${cdCvm}`,
     {
@@ -1221,6 +1224,7 @@ export async function fetchRequestRefresh(
 export async function fetchRefreshStatus(
   cdCvm: number,
 ): Promise<RefreshStatusItem[]> {
+  if (isDesktopMode()) return bridgeFetchRefreshStatus(cdCvm);
   const items = (await routeFetch<RawRefreshStatusItem[]>(
     `/api/refresh-status/${cdCvm}`,
     undefined,

--- a/apps/web/lib/desktop-bridge.ts
+++ b/apps/web/lib/desktop-bridge.ts
@@ -21,7 +21,9 @@ import type {
   SectorDirectory,
   SectorDetail,
   HealthResponse,
-} from "./api";
+  RefreshDispatchResponse,
+  RefreshStatusItem,
+} from "./api.ts";
 
 // ---------------------------------------------------------------------------
 // Declaração global do pywebview
@@ -50,6 +52,8 @@ interface PywebviewApi {
   get_sectors(params?: Record<string, unknown>): Promise<unknown>;
   get_sector_detail(params: Record<string, unknown>): Promise<unknown>;
   get_health(params?: Record<string, unknown>): Promise<unknown>;
+  get_refresh_status(params?: Record<string, unknown>): Promise<unknown>;
+  request_refresh(params: Record<string, unknown>): Promise<unknown>;
 }
 
 // ---------------------------------------------------------------------------
@@ -205,4 +209,22 @@ export function bridgeTrackCompanyView(cdCvm: number): void {
   if (!isDesktopMode()) return;
   const api = typeof window !== "undefined" ? window.pywebview?.api : undefined;
   api?.track_company_view({ cd_cvm: cdCvm }).catch(() => undefined);
+}
+
+export async function bridgeFetchRefreshStatus(
+  cdCvm: number,
+): Promise<RefreshStatusItem[]> {
+  const result = await callBridge<{ items: RefreshStatusItem[] }>(
+    "get_refresh_status",
+    { cd_cvm: cdCvm },
+  );
+  return result.items ?? [];
+}
+
+export async function bridgeRequestRefresh(
+  cdCvm: number,
+): Promise<RefreshDispatchResponse> {
+  return callBridge<RefreshDispatchResponse>("request_refresh", {
+    cd_cvm: cdCvm,
+  });
 }

--- a/apps/web/tests/desktop-bridge.test.ts
+++ b/apps/web/tests/desktop-bridge.test.ts
@@ -10,6 +10,8 @@ import {
   bridgeFetchCompanyYears,
   bridgeFetchHealth,
   bridgeTrackCompanyView,
+  bridgeFetchRefreshStatus,
+  bridgeRequestRefresh,
 } from "../lib/desktop-bridge.ts";
 
 // ---------------------------------------------------------------------------
@@ -206,4 +208,48 @@ test("bridgeFetchHealth returns ok status", async () => {
 
 test("bridgeTrackCompanyView is a no-op when not in desktop mode", () => {
   assert.doesNotThrow(() => bridgeTrackCompanyView(9512));
+});
+
+// ---------------------------------------------------------------------------
+// bridgeFetchRefreshStatus — retorna lista vazia no desktop
+// ---------------------------------------------------------------------------
+
+test("bridgeFetchRefreshStatus returns empty array in desktop mode", async () => {
+  const restore = withPywebview({
+    get_refresh_status: async () => ({ items: [] }),
+  } as unknown as PyApi);
+
+  try {
+    const items = await bridgeFetchRefreshStatus(9512);
+    assert.deepEqual(items, []);
+  } finally {
+    restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// bridgeRequestRefresh — retorna already_current, não inicia polling
+// ---------------------------------------------------------------------------
+
+test("bridgeRequestRefresh returns already_current status", async () => {
+  const restore = withPywebview({
+    request_refresh: async () => ({
+      status: "already_current",
+      cd_cvm: 9512,
+      job_id: null,
+      accepted_at: "",
+      message: "Atualizacao nao disponivel no modo desktop.",
+      status_reason_code: "desktop_viewer",
+      status_reason_message: null,
+      is_retry_allowed: false,
+    }),
+  } as unknown as PyApi);
+
+  try {
+    const result = await bridgeRequestRefresh(9512);
+    assert.equal(result.status, "already_current");
+    assert.equal(result.is_retry_allowed, false);
+  } finally {
+    restore();
+  }
 });

--- a/desktop/bridge.py
+++ b/desktop/bridge.py
@@ -173,6 +173,32 @@ class CVMBridge:
             return {"error": str(exc)}
 
     # ------------------------------------------------------------------
+    # Refresh (stub — desktop não tem scraper ativo)
+    # ------------------------------------------------------------------
+
+    def get_refresh_status(self, params=None) -> dict:
+        # Desktop viewer tem dados estáticos; nenhum job de refresh ativo.
+        return {"items": []}
+
+    def request_refresh(self, params=None) -> dict:
+        p = params or {}
+        cd_cvm = int(p.get("cd_cvm", 0))
+        # "already_current" evita que a UI entre em loop de polling.
+        return {
+            "status": "already_current",
+            "cd_cvm": cd_cvm,
+            "job_id": None,
+            "accepted_at": "",
+            "message": (
+                "Atualizacao de dados nao disponivel no modo desktop. "
+                "Use o app de atualizacao (cvm_pyqt_app.py)."
+            ),
+            "status_reason_code": "desktop_viewer",
+            "status_reason_message": None,
+            "is_retry_allowed": False,
+        }
+
+    # ------------------------------------------------------------------
     # Health / diagnóstico
     # ------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- `desktop/bridge.py`: `get_refresh_status` (returns `{"items": []}`) and `request_refresh` (returns `{"status": "already_current", ...}`) — desktop viewer has no active scraper, stubs prevent 404s and polling loops
- `apps/web/lib/desktop-bridge.ts`: two new typed functions `bridgeFetchRefreshStatus` + `bridgeRequestRefresh`
- `apps/web/lib/api.ts`: `if (isDesktopMode())` guards on `fetchRefreshStatus` and `fetchRequestRefresh`
- `apps/web/tests/desktop-bridge.test.ts`: 2 new tests, 93 total passing

## Test plan

- [x] `npm run test:unit` — 93/93 passing
- [x] `fetchRefreshStatus` in desktop mode returns `[]` (no polling loop)
- [x] `fetchRequestRefresh` in desktop mode returns `already_current` (no 404)

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)