### PR TITLE
fix(web): reorganize company period controls

### DIFF
--- a/apps/web/app/empresas/[cd_cvm]/page.tsx
+++ b/apps/web/app/empresas/[cd_cvm]/page.tsx
@@ -195,12 +195,6 @@ export default async function EmpresaDetailPage({
 
       <CompanyHeader company={company} selectedYears={selectedYears} />
 
-      <CompanyPeriodPreset
-        pathname={pathname}
-        availableYears={readableYears}
-        selectedYears={selectedYears}
-      />
-
       <CompanyUrlTabs
         pathname={pathname}
         currentValue={currentTab}
@@ -214,6 +208,8 @@ export default async function EmpresaDetailPage({
             company={company}
             bundle={bundle}
             cdCvm={cdCvm}
+            pathname={pathname}
+            availableYears={readableYears}
             selectedYears={selectedYears}
           />
         ) : (
@@ -243,6 +239,12 @@ export default async function EmpresaDetailPage({
               eventName="company_statement_changed"
             />
           </div>
+          <CompanyPeriodPreset
+            pathname={pathname}
+            availableYears={readableYears}
+            selectedYears={selectedYears}
+            variant="custom-only"
+          />
           {statement ? (
             <CompanyStatementsLazy matrix={statement} />
           ) : (

--- a/apps/web/components/company/company-analysis-panel-lazy.tsx
+++ b/apps/web/components/company/company-analysis-panel-lazy.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
+import type { ReactNode } from "react";
 
 import type { CompanyDashboardModel } from "@/lib/company-dashboard";
 
@@ -26,10 +27,12 @@ const CompanyAnalysisPanel = dynamic(
 
 type CompanyAnalysisPanelLazyProps = {
   model: CompanyDashboardModel;
+  periodControl?: ReactNode;
 };
 
 export function CompanyAnalysisPanelLazy({
   model,
+  periodControl,
 }: CompanyAnalysisPanelLazyProps) {
-  return <CompanyAnalysisPanel model={model} />;
+  return <CompanyAnalysisPanel model={model} periodControl={periodControl} />;
 }

--- a/apps/web/components/company/company-analysis-panel.tsx
+++ b/apps/web/components/company/company-analysis-panel.tsx
@@ -1,12 +1,7 @@
 "use client";
 
-import { useMemo, useState } from "react";
-import {
-  AreaChartIcon,
-  BarChart3Icon,
-  LineChartIcon,
-  SearchIcon,
-} from "lucide-react";
+import { useMemo, useState, type ReactNode } from "react";
+import { SearchIcon } from "lucide-react";
 
 import { IndicatorSelector } from "@/components/analysis/indicator-selector";
 import { CompanyAnalysisChart } from "@/components/company/company-analysis-chart";
@@ -28,20 +23,13 @@ import { formatKpiDelta, formatKpiValue } from "@/lib/formatters";
 
 type CompanyAnalysisPanelProps = {
   model: CompanyDashboardModel;
+  periodControl?: ReactNode;
 };
 
-function getChartIcon(chartType: DashboardSelectedIndicator["chartType"]) {
-  switch (chartType) {
-    case "line":
-      return LineChartIcon;
-    case "area":
-      return AreaChartIcon;
-    default:
-      return BarChart3Icon;
-  }
-}
-
-export function CompanyAnalysisPanel({ model }: CompanyAnalysisPanelProps) {
+export function CompanyAnalysisPanel({
+  model,
+  periodControl,
+}: CompanyAnalysisPanelProps) {
   const [selectedIndicators, setSelectedIndicators] = useState<DashboardSelectedIndicator[]>(
     model.defaultSelectedIndicators,
   );
@@ -112,33 +100,9 @@ export function CompanyAnalysisPanel({ model }: CompanyAnalysisPanelProps) {
             maxSelections={5}
             className="min-w-[220px]"
           />
-          <div className="rounded-full border border-border/60 bg-muted/18 px-3 py-2 text-xs text-muted-foreground">
-            Periodo atual: <span className="font-medium text-foreground">{model.yearsLabel}</span>
-          </div>
+          {periodControl}
         </div>
       </div>
-
-      {effectiveSelectedIndicators.length > 0 ? (
-        <div className="flex flex-wrap items-center gap-2">
-          {effectiveSelectedIndicators.map((indicator) => {
-            const option = model.indicatorOptions.find((item) => item.id === indicator.id);
-            if (!option) {
-              return null;
-            }
-
-            const ChartIcon = getChartIcon(indicator.chartType);
-            return (
-              <div
-                key={indicator.id}
-                className="flex items-center gap-1.5 rounded-full border border-border/60 bg-muted/18 px-3 py-1.5 text-xs"
-              >
-                <span className="font-medium text-foreground">{option.label}</span>
-                <ChartIcon className="size-3.5 text-muted-foreground" />
-              </div>
-            );
-          })}
-        </div>
-      ) : null}
 
       <CompanyAnalysisChart
         chartSeries={model.chartSeries}

--- a/apps/web/components/company/company-overview.tsx
+++ b/apps/web/components/company/company-overview.tsx
@@ -1,7 +1,7 @@
 import { CompanyAnalysisPanelLazy } from "@/components/company/company-analysis-panel-lazy";
 import { CompanyContextCard } from "@/components/company/company-context-card";
 import { CompanyFreshnessCard } from "@/components/company/company-freshness-card";
-import { CompanyKpiRow } from "@/components/company/company-kpi-row";
+import { CompanyPeriodPreset } from "@/components/company/company-period-preset";
 import { SparklineChip } from "@/components/shared/sparkline-chip";
 import type { CompanyInfo, KPIBundle } from "@/lib/api";
 import { buildCompanyDashboardModel } from "@/lib/company-dashboard";
@@ -11,6 +11,8 @@ type CompanyOverviewProps = {
   company: CompanyInfo;
   bundle: KPIBundle;
   cdCvm: number;
+  pathname: string;
+  availableYears: number[];
   selectedYears: number[];
 };
 
@@ -18,6 +20,8 @@ export function CompanyOverview({
   company,
   bundle,
   cdCvm,
+  pathname,
+  availableYears,
   selectedYears,
 }: CompanyOverviewProps) {
   const model = buildCompanyDashboardModel(bundle);
@@ -25,8 +29,17 @@ export function CompanyOverview({
   return (
     <div className="grid grid-cols-1 gap-6 lg:grid-cols-12 lg:gap-8">
       <div className="flex flex-col gap-6 lg:col-span-8">
-        <CompanyKpiRow cards={model.summaryCards} />
-        <CompanyAnalysisPanelLazy model={model} />
+        <CompanyAnalysisPanelLazy
+          model={model}
+          periodControl={
+            <CompanyPeriodPreset
+              pathname={pathname}
+              availableYears={availableYears}
+              selectedYears={selectedYears}
+              variant="custom-only"
+            />
+          }
+        />
       </div>
 
       <div className="flex flex-col gap-4 lg:col-span-4">

--- a/apps/web/components/company/company-period-preset.tsx
+++ b/apps/web/components/company/company-period-preset.tsx
@@ -15,6 +15,7 @@ type CompanyPeriodPresetProps = {
   pathname: string;
   availableYears: number[];
   selectedYears: number[];
+  variant?: "full" | "custom-only";
 };
 
 const PRESET_OPTIONS: Array<{
@@ -200,6 +201,7 @@ export function CompanyPeriodPreset({
   pathname,
   availableYears,
   selectedYears,
+  variant = "full",
 }: CompanyPeriodPresetProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -232,6 +234,39 @@ export function CompanyPeriodPreset({
     startTransition(() => {
       router.push(`${pathname}?${query}`);
     });
+  }
+
+  if (variant === "custom-only") {
+    return (
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="rounded-full border border-border/60 bg-muted/18 px-3 py-2 text-xs text-muted-foreground">
+            Periodo atual:{" "}
+            <span className="font-medium text-foreground">
+              {selectedYears.join(", ")}
+            </span>
+          </div>
+          <Button
+            type="button"
+            variant={customLocked ? "secondary" : "outline"}
+            size="sm"
+            className="rounded-full px-4"
+            onClick={() => setCustomLocked((current) => !current)}
+          >
+            Personalizado
+          </Button>
+        </div>
+
+        {customLocked ? (
+          <CustomCompanyPeriodRange
+            key={selectedYears.join(",")}
+            pathname={pathname}
+            availableYears={availableYears}
+            selectedYears={selectedYears}
+          />
+        ) : null}
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
Closes #221

## Summary
- moves the company period control into the analysis/statement cards instead of the global top area
- keeps only the compact Periodo atual + Personalizado control in the company detail surface
- removes the large KPI summary rectangles and the redundant selected-indicator chips from the overview

## Validation
- npm run typecheck
- npm run lint (passes; existing warnings outside this task remain)
- npm run build
- npm run test:unit
- Playwright: /empresas/9512?aba=visao-geral with local API, dark-mode screenshot confirms top Periodo controls and old KPI rectangles are gone
