### PR TITLE
fix(web): keep company custom period expanded

### DIFF
--- a/apps/web/components/company/company-period-preset.tsx
+++ b/apps/web/components/company/company-period-preset.tsx
@@ -246,25 +246,14 @@ export function CompanyPeriodPreset({
               {selectedYears.join(", ")}
             </span>
           </div>
-          <Button
-            type="button"
-            variant={customLocked ? "secondary" : "outline"}
-            size="sm"
-            className="rounded-full px-4"
-            onClick={() => setCustomLocked((current) => !current)}
-          >
-            Personalizado
-          </Button>
         </div>
 
-        {customLocked ? (
-          <CustomCompanyPeriodRange
-            key={selectedYears.join(",")}
-            pathname={pathname}
-            availableYears={availableYears}
-            selectedYears={selectedYears}
-          />
-        ) : null}
+        <CustomCompanyPeriodRange
+          key={selectedYears.join(",")}
+          pathname={pathname}
+          availableYears={availableYears}
+          selectedYears={selectedYears}
+        />
       </div>
     );
   }

--- a/apps/web/components/company/company-url-tabs.tsx
+++ b/apps/web/components/company/company-url-tabs.tsx
@@ -46,7 +46,7 @@ export function CompanyUrlTabs({
     >
       <TabsList
         variant="underline"
-        className="w-fit rounded-full border border-border/70 bg-background/88 p-1"
+        className="w-fit rounded-full border border-border/70 bg-background/88 p-1 [&_[data-slot=tab-indicator]]:hidden"
       >
         {options.map((option) => (
           <TabsTrigger


### PR DESCRIPTION
Closes #223

## Summary
- keeps the compact company period range editor expanded by default
- removes the Personalizado button from the company detail compact period control
- hides the green underline indicator under the company detail tabs

## Validation
- npm run typecheck
- npm run lint (passes; existing warnings outside this task remain)
- npm run build
- npm run test:unit
- Playwright: /empresas/9512?aba=visao-geral confirms the range inputs are visible immediately and the tab indicator is hidden
