### PR TITLE
fix(web): clean company page helper copy

### DIFF
--- a/apps/web/components/company/company-analysis-panel.tsx
+++ b/apps/web/components/company/company-analysis-panel.tsx
@@ -5,6 +5,7 @@ import { SearchIcon } from "lucide-react";
 
 import { IndicatorSelector } from "@/components/analysis/indicator-selector";
 import { CompanyAnalysisChart } from "@/components/company/company-analysis-chart";
+import { CompanyHelpTip } from "@/components/company/company-help-tip";
 import { SurfaceCard } from "@/components/shared/design-system-recipes";
 import { Input } from "@/components/ui/input";
 import {
@@ -79,20 +80,21 @@ export function CompanyAnalysisPanel({
 
   return (
     <SurfaceCard tone="default" padding="lg" className="space-y-6" data-testid="company-analysis-panel">
-      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+      <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
         <div className="space-y-2">
-          <p className="text-[0.72rem] font-medium uppercase tracking-[0.2em] text-muted-foreground">
-            Analise de indicadores
-          </p>
+          <div className="flex items-center gap-2">
+            <p className="text-[0.72rem] font-medium uppercase tracking-[0.2em] text-muted-foreground">
+              Analise de indicadores
+            </p>
+            <CompanyHelpTip>
+              Escolha ate 5 indicadores para o grafico. O recorte anual usado aqui tambem vale para a pagina.
+            </CompanyHelpTip>
+          </div>
           <h2 className="font-heading text-[1.5rem] tracking-[-0.03em] text-foreground">
-            Visao anual em um unico painel
+            Visao anual
           </h2>
-          <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
-            Escolha os indicadores que entram no grafico e compare o mesmo recorte
-            anual aplicado a esta pagina.
-          </p>
         </div>
-        <div className="flex flex-wrap items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2 xl:justify-end">
           <IndicatorSelector
             indicators={model.indicatorOptions}
             selected={effectiveSelectedIndicators}
@@ -111,14 +113,13 @@ export function CompanyAnalysisPanel({
 
       <div className="space-y-4 rounded-[1.35rem] border border-border/60 bg-muted/16 p-4">
         <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-          <div>
+          <div className="flex items-center gap-2">
             <p className="text-[0.72rem] font-medium uppercase tracking-[0.2em] text-muted-foreground">
               Tabela anual
             </p>
-            <p className="mt-1 text-sm text-muted-foreground">
-              Indicadores visiveis neste recorte. Os selecionados no grafico sobem
-              para o topo.
-            </p>
+            <CompanyHelpTip>
+              Indicadores selecionados sobem para o topo. Use o filtro para achar indicador ou categoria.
+            </CompanyHelpTip>
           </div>
           <div className="relative w-full max-w-sm">
             <SearchIcon className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />

--- a/apps/web/components/company/company-context-card.tsx
+++ b/apps/web/components/company/company-context-card.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 
+import { CompanyHelpTip } from "@/components/company/company-help-tip";
 import { SurfaceCard } from "@/components/shared/design-system-recipes";
 import { buttonVariants } from "@/components/ui/button";
 import type { CompanyInfo } from "@/lib/api";
@@ -23,16 +24,17 @@ export function CompanyContextCard({
   return (
     <SurfaceCard tone="subtle" padding="md" className="space-y-4">
       <div className="space-y-2">
-        <p className="text-[0.72rem] font-medium uppercase tracking-[0.18em] text-muted-foreground">
-          Contexto de navegação
-        </p>
+        <div className="flex items-center gap-2">
+          <p className="text-[0.72rem] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+            Contexto
+          </p>
+          <CompanyHelpTip>
+            Use o mesmo recorte anual para comparar esta empresa com o setor ou outras companhias.
+          </CompanyHelpTip>
+        </div>
         <h3 className="font-heading text-xl tracking-[-0.02em] text-foreground">
           Continue a leitura
         </h3>
-        <p className="text-sm leading-6 text-muted-foreground">
-          Use o mesmo recorte anual para cruzar esta empresa com seu setor ou com
-          outras companhias prontas.
-        </p>
       </div>
 
       <dl className="grid gap-2.5 text-sm">

--- a/apps/web/components/company/company-freshness-card.tsx
+++ b/apps/web/components/company/company-freshness-card.tsx
@@ -1,4 +1,5 @@
 import { CompanyRequestRefreshLazy } from "@/components/company/company-request-refresh-lazy";
+import { CompanyHelpTip } from "@/components/company/company-help-tip";
 import { SurfaceCard } from "@/components/shared/design-system-recipes";
 import {
   fetchCompanyFreshness,
@@ -132,15 +133,15 @@ export async function CompanyFreshnessCard({
           </span>
         </div>
         <div className="space-y-2">
-          <p className="text-xs uppercase tracking-[0.22em] text-muted-foreground">
-            Estado da leitura
-          </p>
+          <div className="flex items-center gap-2">
+            <p className="text-xs uppercase tracking-[0.22em] text-muted-foreground">
+              Estado da leitura
+            </p>
+            <CompanyHelpTip>{summary.description}</CompanyHelpTip>
+          </div>
           <h3 className="font-heading text-xl tracking-[-0.02em] text-foreground">
             {summary.title}
           </h3>
-          <p className="text-sm leading-6 text-muted-foreground">
-            {summary.description}
-          </p>
         </div>
       </div>
 

--- a/apps/web/components/company/company-help-tip.tsx
+++ b/apps/web/components/company/company-help-tip.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { CircleHelpIcon } from "lucide-react";
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+type CompanyHelpTipProps = {
+  children: string;
+  label?: string;
+  className?: string;
+};
+
+export function CompanyHelpTip({
+  children,
+  label = "Mais informacoes",
+  className,
+}: CompanyHelpTipProps) {
+  return (
+    <TooltipProvider delayDuration={120}>
+      <Tooltip>
+        <TooltipTrigger
+          type="button"
+          aria-label={label}
+          className={cn(
+            "inline-flex size-5 shrink-0 items-center justify-center rounded-full border border-border/70 bg-muted/30 text-muted-foreground transition-colors hover:border-primary/35 hover:bg-primary/10 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+            className,
+          )}
+        >
+          <CircleHelpIcon className="size-3.5" aria-hidden="true" />
+        </TooltipTrigger>
+        <TooltipContent
+          side="top"
+          align="start"
+          className="max-w-72 text-xs leading-5"
+        >
+          {children}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/apps/web/components/company/company-period-preset.tsx
+++ b/apps/web/components/company/company-period-preset.tsx
@@ -3,6 +3,7 @@
 import { startTransition, useState, type FormEvent } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 
+import { CompanyHelpTip } from "@/components/company/company-help-tip";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { resolveCompanyPeriodRange } from "@/lib/company-period-range";
@@ -180,15 +181,13 @@ function CustomCompanyPeriodRange({
         </Button>
       </div>
 
-      <div className="mt-3 flex flex-col gap-1 text-xs">
-        <p className="text-muted-foreground">
-          Aceita ano e trimestre nos formatos 2022, 2022T3 e 2022 3T.
-        </p>
-        <p className="text-muted-foreground/80">
-          O detalhe continua usando os anos cobertos pelo intervalo informado.
-        </p>
+      <div className="mt-3 flex items-center gap-2 text-xs">
+        <span className="text-muted-foreground">Aceita ano ou trimestre.</span>
+        <CompanyHelpTip>
+          Exemplos: 2022, 2022T3 e 2022 3T. A pagina continua usando os anos cobertos pelo intervalo informado.
+        </CompanyHelpTip>
         {errorMessage ? (
-          <p className="text-destructive" role="alert">
+          <p className="ml-auto text-destructive" role="alert">
             {errorMessage}
           </p>
         ) : null}
@@ -240,11 +239,14 @@ export function CompanyPeriodPreset({
     return (
       <div className="flex flex-col gap-3">
         <div className="flex flex-wrap items-center gap-2">
-          <div className="rounded-full border border-border/60 bg-muted/18 px-3 py-2 text-xs text-muted-foreground">
+          <div className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-muted/18 px-3 py-2 text-xs text-muted-foreground">
             Periodo atual:{" "}
             <span className="font-medium text-foreground">
               {selectedYears.join(", ")}
             </span>
+            <CompanyHelpTip className="size-4 border-border/60">
+              O grafico, tabela e demonstracoes usam este recorte. Periodos com trimestre sao convertidos para os anos cobertos.
+            </CompanyHelpTip>
           </div>
         </div>
 

--- a/apps/web/components/company/company-statements.tsx
+++ b/apps/web/components/company/company-statements.tsx
@@ -4,6 +4,7 @@ import { startTransition, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { SearchIcon } from "lucide-react";
 
+import { CompanyHelpTip } from "@/components/company/company-help-tip";
 import { SurfaceCard } from "@/components/shared/design-system-recipes";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
@@ -223,6 +224,9 @@ export function CompanyStatements({ matrix }: CompanyStatementsProps) {
             onCheckedChange={(checked) => setShowYoY(Boolean(checked))}
           />
           Mostrar variação YoY
+          <CompanyHelpTip>
+            Mostra a variacao percentual contra o periodo anterior disponivel na tabela.
+          </CompanyHelpTip>
         </label>
         <span className="ml-auto text-[0.72rem] text-muted-foreground tabular-nums">
           {filteredRows.length} linhas · R$ milhões
@@ -270,10 +274,12 @@ export function CompanyStatements({ matrix }: CompanyStatementsProps) {
         </table>
       </div>
 
-      <p className="pt-3 text-xs italic text-muted-foreground">
-        Fonte: CVM · DFP/ITR consolidados. Linhas em destaque são totalizadoras. Valores em R$
-        milhões, sem ajuste de inflação.
-      </p>
+      <div className="flex items-center gap-2 pt-3 text-xs text-muted-foreground">
+        <span>Fonte: CVM · R$ milhoes</span>
+        <CompanyHelpTip>
+          DFP/ITR consolidados. Linhas em destaque sao totalizadoras. Valores sem ajuste de inflacao.
+        </CompanyHelpTip>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- reduces visible explanatory copy on the company detail page
- adds reusable contextual ? help tooltips near key titles and labels
- adjusts the analysis panel breakpoint so controls do not cramp the title area

Closes #225

## Validation
- npm run typecheck
- npm run lint (existing warnings only)
- npm run build
- npm run test:unit
- Playwright desktop/mobile checks for /empresas/9512?aba=visao-geral
