### PR TITLE
feat(desktop): pywebview entry point with standalone server subprocess

### DIFF
--- a/COMO_RODAR.md
+++ b/COMO_RODAR.md
@@ -246,18 +246,21 @@ npm run dev
 python -m desktop.app --dev
 ```
 
-### Modo offline (static export)
+### Modo standalone (sem npm run dev)
 
-Gere o build estático uma vez e rode sem servidores auxiliares:
+Gere o build uma vez; o app sobe o servidor Node.js embutido automaticamente:
 
 ```powershell
-# Build do static export (só precisa rodar quando a UI mudar)
-$env:NEXT_DESKTOP_BUILD = "true"
+# Build (só precisa rodar quando a UI mudar)
 npm --prefix apps/web run build
+# → gera .next/standalone/server.js
 
-# Abrir o app
+# Abrir o app (sem npm run dev, sem FastAPI)
 python -m desktop.app
 ```
+
+> O bridge Python responde diretamente no modo standalone; FastAPI não é necessário
+> para leitura de dados.
 
 ### Flags
 
@@ -265,7 +268,7 @@ python -m desktop.app
 |---|---|
 | `--dev` | Carrega `http://localhost:3000` (Next.js dev server) |
 | `--debug` | Abre DevTools no modo ativo |
-| (nenhuma) | Sobe servidor embutido e carrega `apps/web/out/` |
+| (nenhuma) | Inicia `.next/standalone/server.js` e carrega o app |
 
 ### Teste de sanidade (com `--debug`)
 
@@ -286,6 +289,8 @@ await window.pywebview.api.get_companies({page: 1, page_size: 5})
 | O que aconteceu | O que fazer |
 |---|---|
 | `ModuleNotFoundError` ao abrir o desktop | Prefira `python -m desktop.cvm_pyqt_app`; o entrypoint por arquivo tambem deve funcionar no estado atual. |
+| `Standalone server nao encontrado` ao rodar `python -m desktop.app` | Execute `npm --prefix apps/web run build` para gerar `.next/standalone/server.js`. |
+| `Servidor standalone nao respondeu` | Verifique se `node` esta no PATH e se o build foi concluido com sucesso. |
 | `python` nao reconhecido | Instale o Python e coloque no `PATH`. |
 | `runtime_doctor.py` falha com `venv-broken` | Recrie a `.venv` com `python -m venv .venv`. |
 | App desktop abre sem empresas | Rode `setup_db.py`, `setup_companies_table.py` e atualize dados. |

--- a/COMO_RODAR.md
+++ b/COMO_RODAR.md
@@ -225,6 +225,62 @@ python scripts/final_verification.py --xlsx output/reports/PETROBRAS_financials.
 
 ---
 
+## 9. Desktop pywebview (Fase 3)
+
+App nativo com janela pywebview + UI Next.js. O bridge Python responde
+diretamente, sem precisar do servidor FastAPI para leitura.
+
+### Modo dev (recomendado para desenvolvimento)
+
+Requer Next.js dev server e FastAPI rodando:
+
+```powershell
+# Terminal 1 — FastAPI
+uvicorn apps.api.app.main:app --reload
+
+# Terminal 2 — Next.js
+cd apps/web
+npm run dev
+
+# Terminal 3 — janela pywebview
+python -m desktop.app --dev
+```
+
+### Modo offline (static export)
+
+Gere o build estático uma vez e rode sem servidores auxiliares:
+
+```powershell
+# Build do static export (só precisa rodar quando a UI mudar)
+$env:NEXT_DESKTOP_BUILD = "true"
+npm --prefix apps/web run build
+
+# Abrir o app
+python -m desktop.app
+```
+
+### Flags
+
+| Flag | Efeito |
+|---|---|
+| `--dev` | Carrega `http://localhost:3000` (Next.js dev server) |
+| `--debug` | Abre DevTools no modo ativo |
+| (nenhuma) | Sobe servidor embutido e carrega `apps/web/out/` |
+
+### Teste de sanidade (com `--debug`)
+
+Abra o console do DevTools e execute:
+
+```javascript
+await window.pywebview.api.ping()
+// → {pong: true, ts: 1234567890.0}
+
+await window.pywebview.api.get_companies({page: 1, page_size: 5})
+// → {items: [...], pagination: {...}}
+```
+
+---
+
 ## Problemas comuns
 
 | O que aconteceu | O que fazer |

--- a/COMO_RODAR.md
+++ b/COMO_RODAR.md
@@ -225,72 +225,11 @@ python scripts/final_verification.py --xlsx output/reports/PETROBRAS_financials.
 
 ---
 
-## 9. Desktop pywebview (Fase 3)
-
-App nativo com janela pywebview + UI Next.js. O bridge Python responde
-diretamente, sem precisar do servidor FastAPI para leitura.
-
-### Modo dev (recomendado para desenvolvimento)
-
-Requer Next.js dev server e FastAPI rodando:
-
-```powershell
-# Terminal 1 — FastAPI
-uvicorn apps.api.app.main:app --reload
-
-# Terminal 2 — Next.js
-cd apps/web
-npm run dev
-
-# Terminal 3 — janela pywebview
-python -m desktop.app --dev
-```
-
-### Modo standalone (sem npm run dev)
-
-Gere o build uma vez; o app sobe o servidor Node.js embutido automaticamente:
-
-```powershell
-# Build (só precisa rodar quando a UI mudar)
-npm --prefix apps/web run build
-# → gera .next/standalone/server.js
-
-# Abrir o app (sem npm run dev, sem FastAPI)
-python -m desktop.app
-```
-
-> O bridge Python responde diretamente no modo standalone; FastAPI não é necessário
-> para leitura de dados.
-
-### Flags
-
-| Flag | Efeito |
-|---|---|
-| `--dev` | Carrega `http://localhost:3000` (Next.js dev server) |
-| `--debug` | Abre DevTools no modo ativo |
-| (nenhuma) | Inicia `.next/standalone/server.js` e carrega o app |
-
-### Teste de sanidade (com `--debug`)
-
-Abra o console do DevTools e execute:
-
-```javascript
-await window.pywebview.api.ping()
-// → {pong: true, ts: 1234567890.0}
-
-await window.pywebview.api.get_companies({page: 1, page_size: 5})
-// → {items: [...], pagination: {...}}
-```
-
----
-
 ## Problemas comuns
 
 | O que aconteceu | O que fazer |
 |---|---|
 | `ModuleNotFoundError` ao abrir o desktop | Prefira `python -m desktop.cvm_pyqt_app`; o entrypoint por arquivo tambem deve funcionar no estado atual. |
-| `Standalone server nao encontrado` ao rodar `python -m desktop.app` | Execute `npm --prefix apps/web run build` para gerar `.next/standalone/server.js`. |
-| `Servidor standalone nao respondeu` | Verifique se `node` esta no PATH e se o build foi concluido com sucesso. |
 | `python` nao reconhecido | Instale o Python e coloque no `PATH`. |
 | `runtime_doctor.py` falha com `venv-broken` | Recrie a `.venv` com `python -m venv .venv`. |
 | App desktop abre sem empresas | Rode `setup_db.py`, `setup_companies_table.py` e atualize dados. |

--- a/desktop/app.py
+++ b/desktop/app.py
@@ -3,17 +3,16 @@ CVM Analytics — entry point pywebview.
 
 Uso:
   python -m desktop.app --dev    # Next.js dev server em :3000 + FastAPI em :8000
-  python -m desktop.app          # static export em apps/web/out/
+  python -m desktop.app          # standalone server em .next/standalone/server.js
   python -m desktop.app --debug  # abre DevTools no modo que estiver ativo
 """
 
 from __future__ import annotations
 
-import functools
-import http.server
 import socket
+import subprocess
 import sys
-import threading
+import time
 from pathlib import Path
 
 import webview
@@ -21,35 +20,49 @@ import webview
 from desktop.bridge import CVMBridge
 
 _DEV_URL = "http://localhost:3000"
-_OUT_DIR = Path(__file__).parent.parent / "apps" / "web" / "out"
+_STANDALONE = Path(__file__).parent.parent / "apps" / "web" / ".next" / "standalone" / "server.js"
+_STATIC_DIR = Path(__file__).parent.parent / "apps" / "web" / ".next" / "standalone"
 _WIDTH, _HEIGHT = 1280, 820
 _BG = "#0a0a0a"
+_STARTUP_TIMEOUT = 10  # seconds to wait for the standalone server to be ready
 
 
-class _SPAHandler(http.server.SimpleHTTPRequestHandler):
-    """Serve apps/web/out/ com fallback para index.html (SPA client-side routing)."""
-
-    def do_GET(self) -> None:
-        candidate = Path(self.directory) / self.path.lstrip("/")
-        if not candidate.exists() or candidate.is_dir():
-            self.path = "/index.html"
-        super().do_GET()
-
-    def log_message(self, *_args: object) -> None:
-        pass  # silencia logs do servidor embutido
+def _free_port() -> int:
+    """Devolve uma porta TCP livre em 127.0.0.1."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
 
 
-def _start_spa_server(directory: Path) -> int:
-    """Sobe HTTPServer numa porta aleatória e retorna o número da porta."""
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.bind(("127.0.0.1", 0))
-    port: int = sock.getsockname()[1]
-    sock.close()
+def _wait_for_port(port: int, timeout: float = _STARTUP_TIMEOUT) -> bool:
+    """Aguarda até o servidor responder em 127.0.0.1:<port>."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+                return True
+        except OSError:
+            time.sleep(0.2)
+    return False
 
-    handler = functools.partial(_SPAHandler, directory=str(directory))
-    server = http.server.HTTPServer(("127.0.0.1", port), handler)
-    threading.Thread(target=server.serve_forever, daemon=True).start()
-    return port
+
+def _start_standalone_server() -> tuple[subprocess.Popen[bytes], int]:
+    """
+    Inicia .next/standalone/server.js em uma porta aleatória.
+    Retorna (processo, porta).
+    """
+    port = _free_port()
+    proc = subprocess.Popen(
+        ["node", str(_STANDALONE)],
+        env={
+            **__import__("os").environ,
+            "PORT": str(port),
+            "HOSTNAME": "127.0.0.1",
+        },
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return proc, port
 
 
 def main() -> None:
@@ -58,19 +71,25 @@ def main() -> None:
     debug_mode = "--debug" in args
 
     bridge = CVMBridge()
+    server_proc: subprocess.Popen[bytes] | None = None
 
     if dev_mode:
         url = _DEV_URL
     else:
-        index = _OUT_DIR / "index.html"
-        if not index.exists():
+        if not _STANDALONE.exists():
             sys.exit(
-                f"[desktop] Static export não encontrado em {_OUT_DIR}.\n"
+                f"[desktop] Standalone server não encontrado em {_STANDALONE}.\n"
                 "Execute primeiro:\n"
-                "  $env:NEXT_DESKTOP_BUILD = 'true'\n"
-                "  npm --prefix apps/web run build"
+                "  npm --prefix apps/web run build\n"
+                "O build gera .next/standalone/server.js automaticamente."
             )
-        port = _start_spa_server(_OUT_DIR)
+        server_proc, port = _start_standalone_server()
+        if not _wait_for_port(port):
+            server_proc.terminate()
+            sys.exit(
+                f"[desktop] Servidor standalone não respondeu na porta {port} "
+                f"após {_STARTUP_TIMEOUT}s."
+            )
         url = f"http://127.0.0.1:{port}"
 
     webview.create_window(
@@ -83,6 +102,9 @@ def main() -> None:
         min_size=(800, 600),
     )
     webview.start(debug=debug_mode)
+
+    if server_proc is not None:
+        server_proc.terminate()
 
 
 if __name__ == "__main__":

--- a/desktop/app.py
+++ b/desktop/app.py
@@ -1,0 +1,89 @@
+"""
+CVM Analytics — entry point pywebview.
+
+Uso:
+  python -m desktop.app --dev    # Next.js dev server em :3000 + FastAPI em :8000
+  python -m desktop.app          # static export em apps/web/out/
+  python -m desktop.app --debug  # abre DevTools no modo que estiver ativo
+"""
+
+from __future__ import annotations
+
+import functools
+import http.server
+import socket
+import sys
+import threading
+from pathlib import Path
+
+import webview
+
+from desktop.bridge import CVMBridge
+
+_DEV_URL = "http://localhost:3000"
+_OUT_DIR = Path(__file__).parent.parent / "apps" / "web" / "out"
+_WIDTH, _HEIGHT = 1280, 820
+_BG = "#0a0a0a"
+
+
+class _SPAHandler(http.server.SimpleHTTPRequestHandler):
+    """Serve apps/web/out/ com fallback para index.html (SPA client-side routing)."""
+
+    def do_GET(self) -> None:
+        candidate = Path(self.directory) / self.path.lstrip("/")
+        if not candidate.exists() or candidate.is_dir():
+            self.path = "/index.html"
+        super().do_GET()
+
+    def log_message(self, *_args: object) -> None:
+        pass  # silencia logs do servidor embutido
+
+
+def _start_spa_server(directory: Path) -> int:
+    """Sobe HTTPServer numa porta aleatória e retorna o número da porta."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    port: int = sock.getsockname()[1]
+    sock.close()
+
+    handler = functools.partial(_SPAHandler, directory=str(directory))
+    server = http.server.HTTPServer(("127.0.0.1", port), handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return port
+
+
+def main() -> None:
+    args = sys.argv[1:]
+    dev_mode = "--dev" in args
+    debug_mode = "--debug" in args
+
+    bridge = CVMBridge()
+
+    if dev_mode:
+        url = _DEV_URL
+    else:
+        index = _OUT_DIR / "index.html"
+        if not index.exists():
+            sys.exit(
+                f"[desktop] Static export não encontrado em {_OUT_DIR}.\n"
+                "Execute primeiro:\n"
+                "  $env:NEXT_DESKTOP_BUILD = 'true'\n"
+                "  npm --prefix apps/web run build"
+            )
+        port = _start_spa_server(_OUT_DIR)
+        url = f"http://127.0.0.1:{port}"
+
+    webview.create_window(
+        "CVM Analytics",
+        url=url,
+        js_api=bridge,
+        width=_WIDTH,
+        height=_HEIGHT,
+        background_color=_BG,
+        min_size=(800, 600),
+    )
+    webview.start(debug=debug_mode)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ psycopg2-binary>=2.9
 streamlit>=1.32
 xlsxwriter>=3.1
 plotly>=5.0
+pywebview>=4.4


### PR DESCRIPTION
## Summary

- `desktop/app.py`: pywebview entry point with two execution modes
  - `--dev`: opens window pointing to `http://localhost:3000` (Next.js dev server)
  - normal: starts `.next/standalone/server.js` as subprocess on random port, waits up to 10s for readiness, then opens the pywebview window; subprocess is terminated on exit
- `requirements.txt`: added `pywebview>=4.4`

Note: `COMO_RODAR.md` docs update (section 9) was removed from this PR — `shared-governance` group allows only `frontend/backend/ops-quality` lanes. Will be addressed in a separate `ops-quality` task.

## Test plan

- [x] `python -m desktop.app --dev` connects to `localhost:3000` (bridge available via `window.pywebview.api`)
- [x] Error message is clear when `.next/standalone/server.js` is missing
- [ ] `python -m desktop.app` (after `npm run build`) opens the app without `npm run dev`
- [ ] `python -m desktop.app --debug` opens DevTools

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)