### PR TITLE
feat(desktop): PyInstaller bundle — pasta distribuível CVMAnalytics.exe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ logs/
 
 # Browser test artifacts
 .playwright-cli/
+
+# Desktop build artifacts
+desktop/node_portable/
+desktop/__pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,3 @@ logs/
 
 # Browser test artifacts
 .playwright-cli/
-
-# Desktop build artifacts
-desktop/node_portable/
-desktop/__pycache__/

--- a/desktop/.gitignore
+++ b/desktop/.gitignore
@@ -1,0 +1,2 @@
+# node.exe copiado pelo build_desktop.ps1 — nao versionar
+node_portable/

--- a/desktop/app.py
+++ b/desktop/app.py
@@ -5,10 +5,15 @@ Uso:
   python -m desktop.app --dev    # Next.js dev server em :3000 + FastAPI em :8000
   python -m desktop.app          # standalone server em .next/standalone/server.js
   python -m desktop.app --debug  # abre DevTools no modo que estiver ativo
+
+Quando empacotado via PyInstaller (sys.frozen=True):
+  - server.js lido de sys._MEIPASS/web_standalone/server.js
+  - node.exe lido de sys._MEIPASS/node.exe (copiado pelo build_desktop.ps1)
 """
 
 from __future__ import annotations
 
+import os
 import socket
 import subprocess
 import sys
@@ -20,22 +25,45 @@ import webview
 from desktop.bridge import CVMBridge
 
 _DEV_URL = "http://localhost:3000"
-_STANDALONE = Path(__file__).parent.parent / "apps" / "web" / ".next" / "standalone" / "server.js"
-_STATIC_DIR = Path(__file__).parent.parent / "apps" / "web" / ".next" / "standalone"
 _WIDTH, _HEIGHT = 1280, 820
 _BG = "#0a0a0a"
-_STARTUP_TIMEOUT = 10  # seconds to wait for the standalone server to be ready
+_STARTUP_TIMEOUT = 15  # segundos — bundle pode demorar mais no primeiro boot
+
+
+def _bundled() -> bool:
+    return getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS")
+
+
+def _bundle_dir() -> Path:
+    return Path(sys._MEIPASS)  # type: ignore[attr-defined]
+
+
+def _repo_root() -> Path:
+    return Path(__file__).parent.parent
+
+
+def _standalone_path() -> Path:
+    if _bundled():
+        return _bundle_dir() / "web_standalone" / "server.js"
+    return _repo_root() / "apps" / "web" / ".next" / "standalone" / "server.js"
+
+
+def _node_exe() -> str:
+    """Retorna o caminho do node a usar: bundled primeiro, depois PATH."""
+    if _bundled():
+        node = _bundle_dir() / "node.exe"
+        if node.exists():
+            return str(node)
+    return "node"
 
 
 def _free_port() -> int:
-    """Devolve uma porta TCP livre em 127.0.0.1."""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("127.0.0.1", 0))
         return s.getsockname()[1]
 
 
 def _wait_for_port(port: int, timeout: float = _STARTUP_TIMEOUT) -> bool:
-    """Aguarda até o servidor responder em 127.0.0.1:<port>."""
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         try:
@@ -46,19 +74,11 @@ def _wait_for_port(port: int, timeout: float = _STARTUP_TIMEOUT) -> bool:
     return False
 
 
-def _start_standalone_server() -> tuple[subprocess.Popen[bytes], int]:
-    """
-    Inicia .next/standalone/server.js em uma porta aleatória.
-    Retorna (processo, porta).
-    """
+def _start_standalone_server(standalone: Path) -> tuple[subprocess.Popen[bytes], int]:
     port = _free_port()
     proc = subprocess.Popen(
-        ["node", str(_STANDALONE)],
-        env={
-            **__import__("os").environ,
-            "PORT": str(port),
-            "HOSTNAME": "127.0.0.1",
-        },
+        [_node_exe(), str(standalone)],
+        env={**os.environ, "PORT": str(port), "HOSTNAME": "127.0.0.1"},
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
@@ -76,14 +96,15 @@ def main() -> None:
     if dev_mode:
         url = _DEV_URL
     else:
-        if not _STANDALONE.exists():
+        standalone = _standalone_path()
+        if not standalone.exists():
             sys.exit(
-                f"[desktop] Standalone server não encontrado em {_STANDALONE}.\n"
+                f"[desktop] Standalone server não encontrado em {standalone}.\n"
                 "Execute primeiro:\n"
-                "  npm --prefix apps/web run build\n"
-                "O build gera .next/standalone/server.js automaticamente."
+                "  .\\desktop\\build_desktop.ps1\n"
+                "(ou: npm --prefix apps/web run build)"
             )
-        server_proc, port = _start_standalone_server()
+        server_proc, port = _start_standalone_server(standalone)
         if not _wait_for_port(port):
             server_proc.terminate()
             sys.exit(

--- a/desktop/app.spec
+++ b/desktop/app.spec
@@ -1,0 +1,87 @@
+# -*- mode: python ; coding: utf-8 -*-
+# PyInstaller spec para CVM Analytics Desktop (Opção A — pasta distribuível).
+#
+# Pré-requisitos antes de rodar este spec:
+#   1. npm --prefix apps/web run build   (gera .next/standalone/)
+#   2. Copiar public/ e .next/static/ para dentro de standalone/ (feito pelo build_desktop.ps1)
+#   3. Ter desktop/node_portable/node.exe disponível (copiado pelo build_desktop.ps1)
+#
+# Uso: pyinstaller desktop/app.spec --noconfirm
+# Saída: dist/CVMAnalytics/CVMAnalytics.exe
+
+from pathlib import Path
+
+ROOT = Path(SPECPATH).parent  # repo root (spec está em desktop/, ROOT é um nível acima)
+STANDALONE_DIR = ROOT / "apps" / "web" / ".next" / "standalone"
+NODE_EXE = ROOT / "desktop" / "node_portable" / "node.exe"
+
+datas = []
+
+if STANDALONE_DIR.exists():
+    datas.append((str(STANDALONE_DIR), "web_standalone"))
+
+if NODE_EXE.exists():
+    datas.append((str(NODE_EXE), "."))
+
+a = Analysis(
+    [str(ROOT / "desktop" / "app.py")],
+    pathex=[str(ROOT)],
+    binaries=[],
+    datas=datas,
+    hiddenimports=[
+        # pywebview backends (Windows usa EdgeChromium / WinForms)
+        "webview",
+        "webview.platforms.winforms",
+        "webview.platforms.edgechromium",
+        # bridge e deps lazy-importadas
+        "desktop.bridge",
+        "src.read_service",
+        "src.db",
+        # clr/pythonnet necessário para pywebview no Windows
+        "clr_loader",
+        "pythonnet",
+    ],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[
+        # excluir tooling que não vai ao runtime
+        "pytest",
+        "IPython",
+        "matplotlib",
+        "tkinter",
+    ],
+    noarchive=False,
+    optimize=0,
+)
+
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,  # --onedir: binários ficam na pasta, não embutidos no exe
+    name="CVMAnalytics",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=False,  # sem janela de console
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    icon=None,  # TODO: adicionar ícone .ico em Fase 5
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name="CVMAnalytics",
+)

--- a/desktop/build_desktop.ps1
+++ b/desktop/build_desktop.ps1
@@ -1,13 +1,18 @@
 # build_desktop.ps1
-# Spike stub — Fase 1. Pipeline completo vem na Fase 4.
+# Gera a pasta distribuível dist/CVMAnalytics/ com CVMAnalytics.exe.
 #
-# Usage:
+# Uso:
 #   .\desktop\build_desktop.ps1
+#   .\desktop\build_desktop.ps1 -SkipNextBuild   # pula o next build (UI nao mudou)
+#   .\desktop\build_desktop.ps1 -Verbose
 #
-# Phases (Fase 4 will automate all steps):
-#   1. next build (static export)
-#   2. PyInstaller bundle
-#   3. (Fase 4) Inno Setup installer
+# Saída:
+#   dist/CVMAnalytics/CVMAnalytics.exe   — clique para abrir o app
+#
+# Requisitos:
+#   - Python com pyinstaller, pywebview instalados  (pip install -r requirements.txt)
+#   - Node.js instalado (node no PATH)
+#   - npm instalado
 
 param(
     [switch]$SkipNextBuild,
@@ -15,57 +20,121 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
-$Root = Split-Path $PSScriptRoot -Parent
-$WebDir = Join-Path $Root "apps\web"
-$DesktopDir = Join-Path $Root "desktop"
+$Root    = Split-Path $PSScriptRoot -Parent
+$WebDir  = Join-Path $Root "apps\web"
+$DesktopDir = $PSScriptRoot
 
+Write-Host ""
 Write-Host "=== CVM Analytics Desktop Build ===" -ForegroundColor Cyan
+Write-Host "  Root: $Root"
+Write-Host ""
 
-# Step 1 — Next.js static export
+# ---------------------------------------------------------------------------
+# Passo 1 — Next.js standalone build
+# ---------------------------------------------------------------------------
 if (-not $SkipNextBuild) {
-    Write-Host "`n[1/2] Building Next.js static export..." -ForegroundColor Yellow
+    Write-Host "[1/4] next build (output: standalone)..." -ForegroundColor Yellow
     Push-Location $WebDir
     try {
         & node_modules\.bin\next build
-        if ($LASTEXITCODE -ne 0) { throw "next build failed" }
+        if ($LASTEXITCODE -ne 0) { throw "next build falhou (exit $LASTEXITCODE)" }
     } finally {
         Pop-Location
     }
-    Write-Host "  next build OK — output in apps/web/out/" -ForegroundColor Green
+    Write-Host "  OK: .next/standalone/ gerado" -ForegroundColor Green
 } else {
-    Write-Host "`n[1/2] Skipping Next.js build (-SkipNextBuild)" -ForegroundColor Gray
+    Write-Host "[1/4] Pulando next build (-SkipNextBuild)" -ForegroundColor Gray
 }
 
-# Step 2 — PyInstaller bundle
-Write-Host "`n[2/2] Bundling with PyInstaller..." -ForegroundColor Yellow
+# ---------------------------------------------------------------------------
+# Passo 2 — Copiar public/ e .next/static/ para dentro de standalone/
+# (Next.js nao copia esses assets automaticamente no standalone output)
+# ---------------------------------------------------------------------------
+Write-Host "[2/4] Copiando assets estaticos para standalone/..." -ForegroundColor Yellow
+
+$StandaloneDir = Join-Path $WebDir ".next\standalone"
+$PublicSrc     = Join-Path $WebDir "public"
+$StaticSrc     = Join-Path $WebDir ".next\static"
+$PublicDst     = Join-Path $StandaloneDir "public"
+$StaticDst     = Join-Path $StandaloneDir ".next\static"
+
+if (-not (Test-Path $StandaloneDir)) {
+    throw "standalone/ nao encontrado em $StandaloneDir. Execute o next build primeiro."
+}
+if (Test-Path $PublicSrc) {
+    Copy-Item -Recurse -Force $PublicSrc $PublicDst
+    Write-Host "  OK: public/ copiado" -ForegroundColor Green
+} else {
+    Write-Host "  (sem public/ para copiar)" -ForegroundColor Gray
+}
+if (Test-Path $StaticSrc) {
+    if (-not (Test-Path (Split-Path $StaticDst -Parent))) {
+        New-Item -ItemType Directory -Force (Split-Path $StaticDst -Parent) | Out-Null
+    }
+    Copy-Item -Recurse -Force $StaticSrc $StaticDst
+    Write-Host "  OK: .next/static/ copiado" -ForegroundColor Green
+}
+
+# ---------------------------------------------------------------------------
+# Passo 3 — Preparar node.exe portátil
+# Copia o node.exe do sistema para desktop/node_portable/
+# (PyInstaller inclui esse arquivo no bundle via app.spec)
+# ---------------------------------------------------------------------------
+Write-Host "[3/4] Preparando node.exe portátil..." -ForegroundColor Yellow
+
+$NodePortableDir = Join-Path $DesktopDir "node_portable"
+$NodePortableExe = Join-Path $NodePortableDir "node.exe"
+
+if (-not (Test-Path $NodePortableExe)) {
+    $NodeSys = (Get-Command node -ErrorAction SilentlyContinue)
+    if (-not $NodeSys) {
+        throw "node nao encontrado no PATH. Instale o Node.js em https://nodejs.org"
+    }
+    New-Item -ItemType Directory -Force $NodePortableDir | Out-Null
+    Copy-Item $NodeSys.Source $NodePortableExe
+    Write-Host "  OK: node.exe copiado de $($NodeSys.Source)" -ForegroundColor Green
+} else {
+    Write-Host "  OK: node_portable/node.exe ja existe" -ForegroundColor Green
+}
+
+# ---------------------------------------------------------------------------
+# Passo 4 — PyInstaller
+# ---------------------------------------------------------------------------
+Write-Host "[4/4] PyInstaller bundle..." -ForegroundColor Yellow
+
+$SpecFile = Join-Path $DesktopDir "app.spec"
+if (-not (Test-Path $SpecFile)) {
+    throw "app.spec nao encontrado em $SpecFile"
+}
+
 Push-Location $Root
 try {
-    $specFile = Join-Path $DesktopDir "spike_app.spec"
-    if (Test-Path $specFile) {
-        pyinstaller $specFile --noconfirm
-    } else {
-        # Auto-spec for spike (single file, no static assets yet)
-        pyinstaller desktop\spike_app.py `
-            --onefile `
-            --name CVMAnalytics-Spike `
-            --noconsole `
-            --add-data "src;src" `
-            --hidden-import pywebview `
-            --hidden-import clr_loader `
-            --hidden-import pythonnet
-    }
-    if ($LASTEXITCODE -ne 0) { throw "PyInstaller failed" }
+    $pyArgs = @($SpecFile, "--noconfirm")
+    if ($Verbose) { $pyArgs += "--log-level=INFO" }
+    pyinstaller @pyArgs
+    if ($LASTEXITCODE -ne 0) { throw "PyInstaller falhou (exit $LASTEXITCODE)" }
 } finally {
     Pop-Location
 }
 
-$exe = Get-ChildItem (Join-Path $Root "dist") -Filter "CVMAnalytics*" -ErrorAction SilentlyContinue | Select-Object -First 1
-if ($exe) {
-    $sizeMB = [math]::Round($exe.Length / 1MB, 1)
-    Write-Host "  Bundle OK: $($exe.FullName) ($sizeMB MB)" -ForegroundColor Green
+# ---------------------------------------------------------------------------
+# Resultado
+# ---------------------------------------------------------------------------
+$ExePath  = Join-Path $Root "dist\CVMAnalytics\CVMAnalytics.exe"
+$DistDir  = Join-Path $Root "dist\CVMAnalytics"
+
+if (Test-Path $ExePath) {
+    $SizeMB = [math]::Round((Get-ChildItem $DistDir -Recurse | Measure-Object -Property Length -Sum).Sum / 1MB, 0)
     Write-Host ""
-    Write-Host "=== Spike criteria check ===" -ForegroundColor Cyan
-    Write-Host "  Bundle size: $sizeMB MB (target < 100 MB)" -ForegroundColor $(if ($sizeMB -lt 100) { "Green" } else { "Red" })
+    Write-Host "=== Build concluído ===" -ForegroundColor Green
+    Write-Host "  Pasta:  $DistDir"
+    Write-Host "  Exe:    $ExePath"
+    Write-Host "  Tamanho total: ~$SizeMB MB"
+    Write-Host ""
+    Write-Host "Para abrir: clique duas vezes em CVMAnalytics.exe" -ForegroundColor Cyan
+    Write-Host "Ou via terminal: & '$ExePath'"
 } else {
-    Write-Host "  Could not find output .exe" -ForegroundColor Red
+    Write-Host ""
+    Write-Host "ERRO: CVMAnalytics.exe nao encontrado em $ExePath" -ForegroundColor Red
+    exit 1
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ streamlit>=1.32
 xlsxwriter>=3.1
 plotly>=5.0
 pywebview>=4.4
+pyinstaller>=6.0


### PR DESCRIPTION
## Summary

- `desktop/app.py`: detecta `sys._MEIPASS` para resolver caminhos quando empacotado; usa `node.exe` bundled em vez do PATH do sistema
- `desktop/app.spec`: spec PyInstaller `--onedir` com `web_standalone/` (= `.next/standalone/`) e `node.exe` como datas
- `desktop/build_desktop.ps1`: reescrita completa — 4 passos: next build → copia assets estáticos → copia `node.exe` portátil → pyinstaller
- `requirements.txt`: adiciona `pyinstaller>=6.0`
- `.gitignore`: exclui `desktop/node_portable/`

## Como usar após merge

```powershell
# instalar pyinstaller (uma vez)
pip install -r requirements.txt

# gerar o bundle (toda vez que a UI ou Python mudar)
.\desktop\build_desktop.ps1

# abrir o app (apenas clique duplo em dist/CVMAnalytics/CVMAnalytics.exe)
```

## Test plan

- [ ] `.\desktop\build_desktop.ps1` completa os 4 passos sem erro
- [ ] `dist/CVMAnalytics/CVMAnalytics.exe` abre a janela pywebview com a UI
- [ ] Console DevTools: `await window.pywebview.api.ping()` retorna `{pong: true, ...}`
- [ ] `-SkipNextBuild` pula o passo 1 corretamente

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)