### PR TITLE
chore(web): normalize visual consistency tokens

### DIFF
--- a/apps/web/app/comparar/page.tsx
+++ b/apps/web/app/comparar/page.tsx
@@ -136,14 +136,14 @@ export default async function ComparePage({ searchParams }: ComparePageProps) {
       />
 
       {compareData.dataError ? (
-        <Alert className="rounded-[1.75rem] border border-destructive/25 bg-destructive/6 px-5 py-5 text-left">
+        <Alert variant="destructive-soft">
           <AlertTitle>Comparacao indisponivel no estado atual</AlertTitle>
           <AlertDescription>{compareData.dataError}</AlertDescription>
         </Alert>
       ) : null}
 
       {compareData.partialErrors.length > 0 ? (
-        <Alert className="rounded-[1.75rem] border border-border/70 bg-background/85 px-5 py-4 text-left">
+        <Alert className="rounded-3xl border-border/70 bg-background/85 px-5 py-4 text-left">
           <AlertTitle>Alguns dados nao puderam ser carregados</AlertTitle>
           <AlertDescription>{partialErrorDescription}</AlertDescription>
         </Alert>

--- a/apps/web/app/design-system/page.tsx
+++ b/apps/web/app/design-system/page.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 import dynamic from "next/dynamic";
 import type { ReactNode } from "react";
@@ -295,7 +295,7 @@ export default function DesignSystemPage() {
             <nav className="space-y-5">
               {NAV.map((group) => (
                 <div key={group.group}>
-                  <p className="mb-1.5 text-[0.65rem] font-semibold uppercase tracking-[0.16em] text-muted-foreground/70">
+                  <p className="mb-1.5 text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground/70">
                     {group.group}
                   </p>
                   <ul className="space-y-0.5">

--- a/apps/web/app/empresas/[cd_cvm]/loading.tsx
+++ b/apps/web/app/empresas/[cd_cvm]/loading.tsx
@@ -5,7 +5,7 @@ export default function EmpresaDetailLoading() {
     <div className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-4 py-12 sm:px-6 lg:px-10">
       <div className="space-y-4">
         <Skeleton className="h-4 w-64 rounded-full" />
-        <Skeleton className="h-32 rounded-[1.75rem]" />
+        <Skeleton className="h-32 rounded-3xl" />
       </div>
       <Skeleton className="h-28 rounded-[1.5rem]" />
       <Skeleton className="h-10 w-60 rounded-full" />
@@ -15,7 +15,7 @@ export default function EmpresaDetailLoading() {
         <Skeleton className="h-36 rounded-[1.4rem]" />
         <Skeleton className="h-36 rounded-[1.4rem]" />
       </div>
-      <Skeleton className="h-96 rounded-[1.75rem]" />
+      <Skeleton className="h-96 rounded-3xl" />
     </div>
   );
 }

--- a/apps/web/app/empresas/[cd_cvm]/page.tsx
+++ b/apps/web/app/empresas/[cd_cvm]/page.tsx
@@ -63,7 +63,7 @@ function DetailPageError({
           titleAs="h1"
           description="Nao foi possivel carregar os dados desta companhia agora."
         />
-        <Alert className="rounded-[1.75rem] border border-destructive/25 bg-destructive/6 px-5 py-5 text-left">
+        <Alert variant="destructive-soft">
           <AlertTitle>Falha na leitura detalhada</AlertTitle>
           <AlertDescription>{message}</AlertDescription>
         </Alert>
@@ -212,7 +212,7 @@ export default async function EmpresaDetailPage({
             selectedYears={selectedYears}
           />
         ) : (
-          <Alert className="rounded-[1.75rem] border border-destructive/25 bg-destructive/6 px-5 py-5 text-left">
+          <Alert variant="destructive-soft">
             <AlertTitle>Visao geral indisponivel</AlertTitle>
             <AlertDescription>
               {contentError ??
@@ -247,7 +247,7 @@ export default async function EmpresaDetailPage({
           {statement ? (
             <CompanyStatementsLazy matrix={statement} />
           ) : (
-            <Alert className="rounded-[1.75rem] border border-destructive/25 bg-destructive/6 px-5 py-5 text-left">
+            <Alert variant="destructive-soft">
               <AlertTitle>Demonstracao indisponivel</AlertTitle>
               <AlertDescription>
                 {contentError ??

--- a/apps/web/app/empresas/loading.tsx
+++ b/apps/web/app/empresas/loading.tsx
@@ -9,7 +9,7 @@ export default function EmpresasLoading() {
         <Skeleton className="h-6 w-full max-w-3xl" />
       </div>
       <Skeleton className="h-20 rounded-[1.5rem]" />
-      <div className="rounded-[1.75rem] border border-border/60 bg-background/70 p-4">
+      <div className="rounded-xl border border-border/60 bg-background/70 p-4">
         <div className="space-y-4">
           <Skeleton className="h-20 rounded-2xl" />
           <Skeleton className="h-20 rounded-2xl" />

--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -30,7 +30,7 @@ export default function GlobalError({
       <SurfaceCard tone="hero" padding="hero" className="space-y-6">
         <InfoChip tone="muted">Erro de servico</InfoChip>
         <SectionHeading title={copy.title} titleAs="h1" />
-        <Alert className="rounded-[1.75rem] border border-destructive/25 bg-destructive/6 px-5 py-5 text-left">
+        <Alert variant="destructive-soft">
           <AlertTitle>Falha controlada da camada web</AlertTitle>
           <AlertDescription>{copy.message}</AlertDescription>
         </Alert>

--- a/apps/web/app/loading.tsx
+++ b/apps/web/app/loading.tsx
@@ -14,10 +14,10 @@ export default function RootLoading() {
         <Skeleton className="mt-4 h-14 w-full rounded-[1.25rem]" />
       </SurfaceCard>
       <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-        <Skeleton className="h-44 rounded-[1.75rem]" />
-        <Skeleton className="h-44 rounded-[1.75rem]" />
-        <Skeleton className="h-44 rounded-[1.75rem]" />
-        <Skeleton className="h-44 rounded-[1.75rem]" />
+        <Skeleton className="h-44 rounded-3xl" />
+        <Skeleton className="h-44 rounded-3xl" />
+        <Skeleton className="h-44 rounded-3xl" />
+        <Skeleton className="h-44 rounded-3xl" />
       </div>
     </PageShell>
   );

--- a/apps/web/app/portfolio/page.tsx
+++ b/apps/web/app/portfolio/page.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 import { useState } from "react";
 import Link from "next/link";
@@ -10,6 +10,8 @@ import {
   ExternalLink,
 } from "lucide-react";
 
+import { Badge } from "@/components/ui/badge";
+
 // Data
 
 const PROJECTS = [
@@ -18,7 +20,7 @@ const PROJECTS = [
     title: "Brazilian Company Financial Dashboard",
     category: "Financial Dashboard",
     description:
-      "A dashboard for exploring financial data from Brazilian public companies — DRE, balance sheet, KPIs, and market data in one place.",
+      "A dashboard for exploring financial data from Brazilian public companies â€” DRE, balance sheet, KPIs, and market data in one place.",
     financeRelevance:
       "Company analysis, financial statements, indicators, and market data.",
     tools: ["React", "Financial APIs", "AI-assisted coding"],
@@ -57,9 +59,9 @@ const PROJECTS = [
 const RESEARCH = [
   {
     id: "cfa",
-    title: "CFA Research Challenge — Local Brazil",
+    title: "CFA Research Challenge â€” Local Brazil",
     institution: "CFA Institute",
-    date: "Sep. 2024 – Jan. 2025",
+    date: "Sep. 2024 â€“ Jan. 2025",
     company: "Vibra (VBBR3)",
     result: "Vice-Champion",
     resultType: "top" as const,
@@ -70,7 +72,7 @@ const RESEARCH = [
     id: "constellation",
     title: "Constellation Challenge 2024",
     institution: "Constellation Asset Management",
-    date: "Mar. 2024 – Apr. 2024",
+    date: "Mar. 2024 â€“ Apr. 2024",
     company: "Mercado Libre (MELI)",
     result: "Semi-Finalist",
     resultType: "mid" as const,
@@ -81,7 +83,7 @@ const RESEARCH = [
     id: "btg",
     title: "BTG Pactual Experience 2023",
     institution: "BTG Pactual",
-    date: "Oct. 2023 – Dec. 2023",
+    date: "Oct. 2023 â€“ Dec. 2023",
     company: "Mater Dei (MATD3) / Madero",
     result: "Finalist",
     resultType: "mid" as const,
@@ -92,7 +94,7 @@ const RESEARCH = [
     id: "apex",
     title: "Internal Research Challenge",
     institution: "Mentored by Apex Capital",
-    date: "Mar. 2023 – Sep. 2023",
+    date: "Mar. 2023 â€“ Sep. 2023",
     company: "Mater Dei (MATD3)",
     result: null as string | null,
     resultType: null as "top" | "mid" | null,
@@ -104,9 +106,9 @@ const RESEARCH = [
 const EXPERIENCE = [
   {
     id: "gmf",
-    title: "Member — GMF",
+    title: "Member â€” GMF",
     org: "Grupo de Mercado Financeiro da Unicamp",
-    date: "Feb. 2023 – Jan. 2025",
+    date: "Feb. 2023 â€“ Jan. 2025",
     description:
       "Participated in the financial market league at UNICAMP, contributing to education initiatives, accounting classes, financial education projects, research activities, and the 2024 member selection process.",
     placeholder: false,
@@ -115,7 +117,7 @@ const EXPERIENCE = [
     id: "internship",
     title: "Internship Experience",
     org: "To be added",
-    date: "—",
+    date: "â€”",
     description: "Placeholder for recent internship experience.",
     placeholder: true,
   },
@@ -125,9 +127,9 @@ const EDUCATION = [
   {
     id: "unicamp",
     degree: "Bachelor's Degree in Economic Sciences",
-    institution: "Universidade Estadual de Campinas — UNICAMP",
+    institution: "Universidade Estadual de Campinas â€” UNICAMP",
     detail: "Institute of Economics",
-    date: "2022 – 2026",
+    date: "2022 â€“ 2026",
     current: true,
   },
   {
@@ -135,7 +137,7 @@ const EDUCATION = [
     degree: "High School + Technical Education in Business Administration",
     institution: "ETEC Prefeito Braz Paschoalin",
     detail: null as string | null,
-    date: "2019 – 2021",
+    date: "2019 â€“ 2021",
     current: false,
   },
 ];
@@ -180,7 +182,7 @@ const SKILLS = [
   },
 ];
 
-// ─── SUB-COMPONENTS ────────────────────────────────────────────────────────────
+// â”€â”€â”€ SUB-COMPONENTS â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 function StatusBadge({ status }: { status: string }) {
   const cls =
@@ -190,11 +192,9 @@ function StatusBadge({ status }: { status: string }) {
         ? "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-400"
         : "border-border/80 bg-muted text-muted-foreground";
   return (
-    <span
-      className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-[0.62rem] font-semibold uppercase tracking-[0.13em] whitespace-nowrap ${cls}`}
-    >
+    <Badge className={`font-semibold uppercase tracking-[0.13em] ${cls}`}>
       {status}
-    </span>
+    </Badge>
   );
 }
 
@@ -210,21 +210,19 @@ function ResultBadge({
       ? "border-primary/30 bg-primary/10 text-primary/90"
       : "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-400";
   return (
-    <span
-      className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-[0.62rem] font-semibold uppercase tracking-[0.13em] whitespace-nowrap ${cls}`}
-    >
+    <Badge className={`font-semibold uppercase tracking-[0.13em] ${cls}`}>
       {result}
-    </span>
+    </Badge>
   );
 }
 
-// ─── SECTIONS ─────────────────────────────────────────────────────────────────
+// â”€â”€â”€ SECTIONS â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 function Hero() {
   const metrics = [
-    { label: "CFA Challenge", value: "Vice-Champion", sub: "2024–2025" },
+    { label: "CFA Challenge", value: "Vice-Champion", sub: "2024â€“2025" },
     { label: "BTG Experience", value: "Finalist", sub: "2023" },
-    { label: "Research Challenges", value: "4 total", sub: "2023–2025" },
+    { label: "Research Challenges", value: "4 total", sub: "2023â€“2025" },
     { label: "Focus", value: "Equity Research", sub: "& Valuation" },
   ];
 
@@ -233,13 +231,13 @@ function Hero() {
       <div className="mx-auto w-full max-w-4xl px-6">
         {/* Meta row */}
         <div className="mb-8 flex items-center gap-3">
-          <span className="text-[0.68rem] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
-            UNICAMP · Economics · Class of 2026
+          <span className="text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground">
+            UNICAMP Â· Economics Â· Class of 2026
           </span>
           <span className="inline-block h-1 w-1 rounded-full bg-muted-foreground/40" />
-          <span className="inline-flex items-center rounded-full border border-primary/30 bg-primary/10 px-2.5 py-0.5 text-[0.58rem] font-semibold uppercase tracking-[0.13em] text-primary/90">
+          <Badge className="border-primary/30 bg-primary/10 font-semibold uppercase tracking-[0.13em] text-primary/90">
             Open to opportunities
-          </span>
+          </Badge>
         </div>
 
         {/* Headline */}
@@ -252,8 +250,8 @@ function Hero() {
         </h1>
 
         {/* Subline */}
-        <p className="mb-10 max-w-[560px] text-[1.0625rem] leading-relaxed text-muted-foreground">
-          I study economics and build practical tools for financial analysis —
+        <p className="mb-10 max-w-[560px] text-lg leading-relaxed text-muted-foreground">
+          I study economics and build practical tools for financial analysis â€”
           combining market research, valuation, data workflows, and AI-assisted
           development.
         </p>
@@ -287,13 +285,13 @@ function Hero() {
               key={m.label}
               className="rounded-[0.7rem] border border-border/50 bg-card/90 px-4 py-3 backdrop-blur-sm"
             >
-              <div className="mb-1 text-[0.62rem] font-semibold uppercase tracking-[0.13em] text-muted-foreground">
+              <div className="mb-1 text-xs font-semibold uppercase tracking-[0.13em] text-muted-foreground">
                 {m.label}
               </div>
-              <div className="mb-0.5 font-heading text-[0.95rem] font-semibold tracking-[-0.01em] text-foreground">
+              <div className="mb-0.5 font-heading text-base font-semibold tracking-[-0.01em] text-foreground">
                 {m.value}
               </div>
-              <div className="font-mono text-[0.65rem] text-muted-foreground">
+              <div className="font-mono text-xs text-muted-foreground">
                 {m.sub}
               </div>
             </div>
@@ -315,14 +313,14 @@ function Projects() {
       <div className="mx-auto w-full max-w-4xl px-6">
         {/* Header */}
         <div className="mb-10">
-          <span className="mb-3 block text-[0.68rem] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
+          <span className="mb-3 block text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground">
             AI-Assisted Development
           </span>
           <h2 className="mb-3 font-heading text-[clamp(1.75rem,4vw,2.5rem)] font-medium leading-[1.1] tracking-[-0.035em] text-foreground">
             Featured Projects
           </h2>
-          <p className="mb-6 max-w-[540px] text-[0.95rem] leading-relaxed text-muted-foreground">
-            Practical tools and experiments built with AI assistance — focused
+          <p className="mb-6 max-w-[540px] text-base leading-relaxed text-muted-foreground">
+            Practical tools and experiments built with AI assistance â€” focused
             on financial analysis, data workflows, and market research.
           </p>
           {/* Filter pills */}
@@ -331,7 +329,8 @@ function Projects() {
               <button
                 key={s}
                 onClick={() => setFilter(s)}
-                className={`rounded-full border px-3.5 py-1 text-[0.72rem] font-medium transition-all ${
+                aria-label={`Filtrar projetos por ${s}`}
+                className={`rounded-full border px-3.5 py-1 text-xs font-medium transition-all ${
                   filter === s
                     ? "border-primary/45 bg-primary/10 text-primary"
                     : "border-border/70 text-muted-foreground hover:border-border hover:text-foreground"
@@ -352,7 +351,7 @@ function Projects() {
             >
               {/* Header row */}
               <div className="flex items-start justify-between gap-2">
-                <span className="text-[0.64rem] font-semibold uppercase tracking-[0.13em] text-muted-foreground">
+                <span className="text-xs font-semibold uppercase tracking-[0.13em] text-muted-foreground">
                   {project.category}
                 </span>
                 <StatusBadge status={project.status} />
@@ -360,7 +359,7 @@ function Projects() {
 
               {/* Title + desc */}
               <div>
-                <h3 className="mb-2 font-heading text-[0.95rem] font-semibold leading-[1.3] tracking-[-0.01em] text-foreground">
+                <h3 className="mb-2 font-heading text-base font-semibold leading-[1.3] tracking-[-0.01em] text-foreground">
                   {project.title}
                 </h3>
                 <p className="text-sm leading-relaxed text-muted-foreground">
@@ -370,8 +369,8 @@ function Projects() {
 
               {/* Finance relevance */}
               <div className="rounded-[0.7rem] border border-primary/15 bg-primary/5 px-4 py-3 text-xs leading-[1.5] text-primary/80">
-                <span className="text-[0.6rem] font-semibold uppercase tracking-[0.1em] opacity-70">
-                  Finance relevance ·{" "}
+                <span className="text-xs font-semibold uppercase tracking-[0.1em] opacity-70">
+                  Finance relevance Â·{" "}
                 </span>
                 {project.financeRelevance}
               </div>
@@ -381,7 +380,7 @@ function Projects() {
                 {project.tools.map((t) => (
                   <span
                     key={t}
-                    className="rounded-[0.4rem] bg-muted px-2.5 py-1 font-mono text-[0.7rem] font-medium text-muted-foreground"
+                    className="rounded-[0.4rem] bg-muted px-2.5 py-1 font-mono text-xs font-medium text-muted-foreground"
                   >
                     {t}
                   </span>
@@ -392,14 +391,14 @@ function Projects() {
               <div className="mt-auto flex gap-2 border-t border-border/60 pt-3">
                 <a
                   href={project.github}
-                  className="inline-flex items-center gap-1.5 rounded-[0.6rem] border border-border/70 px-3 py-1.5 text-[0.72rem] font-medium text-muted-foreground transition-all hover:border-primary/35 hover:bg-primary/5 hover:text-primary"
+                  className="inline-flex items-center gap-1.5 rounded-[0.6rem] border border-border/70 px-3 py-1.5 text-xs font-medium text-muted-foreground transition-all hover:border-primary/35 hover:bg-primary/5 hover:text-primary"
                 >
                   <Code2Icon className="size-3.5" /> GitHub
                 </a>
                 {project.demo && (
                   <a
                     href={project.demo}
-                    className="inline-flex items-center gap-1.5 rounded-[0.6rem] border border-border/70 px-3 py-1.5 text-[0.72rem] font-medium text-muted-foreground transition-all hover:border-primary/35 hover:bg-primary/5 hover:text-primary"
+                    className="inline-flex items-center gap-1.5 rounded-[0.6rem] border border-border/70 px-3 py-1.5 text-xs font-medium text-muted-foreground transition-all hover:border-primary/35 hover:bg-primary/5 hover:text-primary"
                   >
                     <ExternalLink className="size-3.5" /> Live demo
                   </a>
@@ -418,13 +417,13 @@ function Research() {
     <section className="border-b border-border/60 py-20" id="research">
       <div className="mx-auto w-full max-w-4xl px-6">
         <div className="mb-10">
-          <span className="mb-3 block text-[0.68rem] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
+          <span className="mb-3 block text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground">
             Equity Research
           </span>
           <h2 className="mb-3 font-heading text-[clamp(1.75rem,4vw,2.5rem)] font-medium leading-[1.1] tracking-[-0.035em] text-foreground">
             Research &amp; Finance Experience
           </h2>
-          <p className="max-w-[520px] text-[0.95rem] leading-relaxed text-muted-foreground">
+          <p className="max-w-[520px] text-base leading-relaxed text-muted-foreground">
             Competitive research challenges and structured equity analysis
             programs.
           </p>
@@ -438,7 +437,7 @@ function Research() {
           {RESEARCH.map((item, i) => (
             <div key={item.id} className="flex items-start gap-5">
               {/* Dot */}
-              <div className="relative z-10 flex size-[31px] shrink-0 items-center justify-center rounded-full border-2 border-primary/40 bg-[color-mix(in_oklch,var(--primary)_10%,var(--background))] font-heading text-[0.8rem] font-bold text-primary">
+              <div className="relative z-10 flex size-[31px] shrink-0 items-center justify-center rounded-full border-2 border-primary/40 bg-[color-mix(in_oklch,var(--primary)_10%,var(--background))] font-heading text-sm font-bold text-primary">
                 {["01", "02", "03", "04"][i]}
               </div>
 
@@ -448,7 +447,7 @@ function Research() {
                   {/* Top row */}
                   <div className="mb-4 flex flex-wrap items-start justify-between gap-4">
                     <div>
-                      <div className="mb-1 font-heading text-[0.95rem] font-semibold leading-snug tracking-[-0.01em] text-foreground">
+                      <div className="mb-1 font-heading text-base font-semibold leading-snug tracking-[-0.01em] text-foreground">
                         {item.title}
                       </div>
                       <div className="text-sm text-muted-foreground">
@@ -456,7 +455,7 @@ function Research() {
                       </div>
                     </div>
                     <div className="flex shrink-0 flex-col items-end gap-2">
-                      <span className="font-mono text-[0.68rem] text-muted-foreground">
+                      <span className="font-mono text-xs text-muted-foreground">
                         {item.date}
                       </span>
                       {item.result && item.resultType && (
@@ -471,10 +470,10 @@ function Research() {
                   {/* Company chip */}
                   <div className="mb-4 flex flex-wrap gap-3">
                     <div className="flex items-center gap-2">
-                      <span className="text-[0.6rem] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+                      <span className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
                         Company
                       </span>
-                      <span className="rounded-[5px] border border-primary/20 bg-primary/10 px-2 py-0.5 font-mono text-[0.72rem] font-medium text-primary">
+                      <span className="rounded-[5px] border border-primary/20 bg-primary/10 px-2 py-0.5 font-mono text-xs font-medium text-primary">
                         {item.company}
                       </span>
                     </div>
@@ -498,7 +497,7 @@ function Experience() {
     <section className="border-b border-border/60 py-20" id="experience">
       <div className="mx-auto w-full max-w-4xl px-6">
         <div className="mb-10">
-          <span className="mb-3 block text-[0.68rem] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
+          <span className="mb-3 block text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground">
             Professional
           </span>
           <h2 className="font-heading text-[clamp(1.75rem,4vw,2.5rem)] font-medium leading-[1.1] tracking-[-0.035em] text-foreground">
@@ -518,19 +517,19 @@ function Experience() {
             >
               <div className="mb-3 flex flex-wrap items-start justify-between gap-3">
                 <div>
-                  <div className="mb-1 flex items-center gap-2 font-heading text-[0.95rem] font-semibold leading-snug tracking-[-0.01em] text-foreground">
+                  <div className="mb-1 flex items-center gap-2 font-heading text-base font-semibold leading-snug tracking-[-0.01em] text-foreground">
                     {exp.title}
                     {exp.placeholder && (
-                      <span className="inline-flex items-center rounded-full border border-border/80 bg-muted px-2.5 py-0.5 text-[0.62rem] font-semibold uppercase tracking-[0.13em] text-muted-foreground">
+                      <Badge className="border-border/80 bg-muted font-semibold uppercase tracking-[0.13em] text-muted-foreground">
                         To be added
-                      </span>
+                      </Badge>
                     )}
                   </div>
                   <div className="text-sm font-medium text-muted-foreground">
                     {exp.org}
                   </div>
                 </div>
-                <span className="shrink-0 font-mono text-[0.68rem] text-muted-foreground">
+                <span className="shrink-0 font-mono text-xs text-muted-foreground">
                   {exp.date}
                 </span>
               </div>
@@ -550,7 +549,7 @@ function Education() {
     <section className="border-b border-border/60 py-20" id="education">
       <div className="mx-auto w-full max-w-4xl px-6">
         <div className="mb-10">
-          <span className="mb-3 block text-[0.68rem] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
+          <span className="mb-3 block text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground">
             Academic Background
           </span>
           <h2 className="font-heading text-[clamp(1.75rem,4vw,2.5rem)] font-medium leading-[1.1] tracking-[-0.035em] text-foreground">
@@ -566,17 +565,17 @@ function Education() {
             >
               <div className="mb-4 flex items-start justify-between">
                 {edu.current ? (
-                  <span className="inline-flex items-center rounded-full border border-primary/30 bg-primary/10 px-2.5 py-0.5 text-[0.62rem] font-semibold uppercase tracking-[0.13em] text-primary/90">
+                  <Badge className="border-primary/30 bg-primary/10 font-semibold uppercase tracking-[0.13em] text-primary/90">
                     Current
-                  </span>
+                  </Badge>
                 ) : (
                   <span />
                 )}
-                <span className="font-mono text-[0.68rem] text-muted-foreground">
+                <span className="font-mono text-xs text-muted-foreground">
                   {edu.date}
                 </span>
               </div>
-              <div className="mb-2 font-heading text-[0.95rem] font-semibold leading-[1.35] tracking-[-0.01em] text-foreground">
+              <div className="mb-2 font-heading text-base font-semibold leading-[1.35] tracking-[-0.01em] text-foreground">
                 {edu.degree}
               </div>
               <div className="mb-1 text-sm font-medium text-muted-foreground">
@@ -600,7 +599,7 @@ function Skills() {
     <section className="border-b border-border/60 py-20" id="skills">
       <div className="mx-auto w-full max-w-4xl px-6">
         <div className="mb-10">
-          <span className="mb-3 block text-[0.68rem] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
+          <span className="mb-3 block text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground">
             Competencies
           </span>
           <h2 className="font-heading text-[clamp(1.75rem,4vw,2.5rem)] font-medium leading-[1.1] tracking-[-0.035em] text-foreground">
@@ -641,13 +640,13 @@ function Contact() {
       <div className="mx-auto w-full max-w-4xl px-6">
         <div className="flex flex-col items-center gap-6 rounded-[1.6rem] border border-border/60 bg-card px-10 py-12 text-center">
           <div>
-            <span className="mb-3 block text-[0.68rem] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
+            <span className="mb-3 block text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground">
               Get in touch
             </span>
             <h2 className="mb-4 font-heading text-[clamp(1.75rem,4vw,2.5rem)] font-medium leading-[1.1] tracking-[-0.035em] text-foreground">
               Let&apos;s connect
             </h2>
-            <p className="mx-auto max-w-[420px] text-[0.95rem] leading-relaxed text-muted-foreground">
+            <p className="mx-auto max-w-[420px] text-base leading-relaxed text-muted-foreground">
               I&apos;m open to conversations about equity research, financial
               analysis, data tools, or internship and collaboration
               opportunities.
@@ -684,7 +683,7 @@ function Contact() {
   );
 }
 
-// ─── PAGE ─────────────────────────────────────────────────────────────────────
+// â”€â”€â”€ PAGE â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 export default function PortfolioPage() {
   return (

--- a/apps/web/app/setores/[slug]/page.tsx
+++ b/apps/web/app/setores/[slug]/page.tsx
@@ -48,7 +48,7 @@ function SectorDetailError({
           titleAs="h1"
           description="O detalhe do setor nao conseguiu concluir a leitura agora."
         />
-        <Alert className="rounded-[1.75rem] border border-destructive/25 bg-destructive/6 px-5 py-5 text-left">
+        <Alert variant="destructive-soft">
           <AlertTitle>Falha controlada do detalhe setorial</AlertTitle>
           <AlertDescription>{message}</AlertDescription>
         </Alert>

--- a/apps/web/app/setores/page.tsx
+++ b/apps/web/app/setores/page.tsx
@@ -28,7 +28,7 @@ export default async function SetoresPage() {
 
   if (!directory) {
     return (
-      <PageShell density="relaxed" className="max-w-4xl">
+      <PageShell density="relaxed">
         <SurfaceCard tone="hero" padding="hero" className="space-y-6">
           <SectionHeading
             eyebrow="PG-05 - Hub de setores"
@@ -36,7 +36,7 @@ export default async function SetoresPage() {
             titleAs="h1"
             description="O hub de setores nao respondeu agora. O restante da navegacao publica continua disponivel."
           />
-          <Alert className="rounded-[1.75rem] border border-destructive/25 bg-destructive/6 px-5 py-5 text-left">
+          <Alert variant="destructive-soft">
             <AlertTitle>Falha controlada do hub setorial</AlertTitle>
             <AlertDescription>
               {directoryError ??

--- a/apps/web/components/area-chart-medium.tsx
+++ b/apps/web/components/area-chart-medium.tsx
@@ -1,4 +1,4 @@
-'use client';
+﻿'use client';
 
 import { useState } from 'react';
 import type { JSX } from 'react';
@@ -49,9 +49,9 @@ const TIME_PERIOD_OPTIONS = [
 ] as const;
 
 const SERIES_META = [
-  { key: 'DLP', color: '#5B14C5' },
-  { key: 'Threat Intel', color: '#DAC5F9' },
-  { key: 'SysLog', color: '#B58BF3' },
+  { key: 'DLP', color: 'var(--chart-3)' },
+  { key: 'Threat Intel', color: 'var(--chart-5)' },
+  { key: 'SysLog', color: 'var(--chart-4)' },
 ] as const;
 
 const CHART_DATA_BY_PERIOD = {
@@ -104,7 +104,7 @@ const INCIDENT_STATS: IncidentStat[] = [
 
 function DiamondAlertIcon({
   className,
-  fill = '#E84045',
+  fill = 'var(--destructive)',
 }: {
   className?: string;
   fill?: string;
@@ -120,7 +120,7 @@ function DiamondAlertIcon({
 
 function CircleAlertIcon({
   className,
-  fill = '#E84045',
+  fill = 'var(--destructive)',
 }: {
   className?: string;
   fill?: string;
@@ -136,7 +136,7 @@ function CircleAlertIcon({
 
 function TriangleAlertIcon({
   className,
-  fill = '#40E5D1',
+  fill = 'var(--chart-1)',
 }: {
   className?: string;
   fill?: string;
@@ -144,8 +144,8 @@ function TriangleAlertIcon({
   return (
     <svg className={className} width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden>
       <path d="M10 2.5 18 17H2L10 2.5Z" fill={fill} />
-      <rect x="9.2" y="7" width="1.6" height="5.8" rx="0.8" fill="#05211D" />
-      <circle cx="10" cy="14.8" r="1" fill="#05211D" />
+      <rect x="9.2" y="7" width="1.6" height="5.8" rx="0.8" fill="var(--background)" />
+      <circle cx="10" cy="14.8" r="1" fill="var(--background)" />
     </svg>
   );
 }
@@ -187,7 +187,7 @@ const DETAILED_METRICS: DetailedMetric[] = [
     tooltip: 'Mean Time to Respond',
     value: '6 Hours',
     trend: 'up',
-    trendColor: '#F08083',
+    trendColor: 'var(--destructive)',
     delay: 0,
   },
   {
@@ -197,7 +197,7 @@ const DETAILED_METRICS: DetailedMetric[] = [
     tooltip: 'Incident Response Time',
     value: '4 Hours',
     trend: 'up',
-    trendColor: '#F08083',
+    trendColor: 'var(--destructive)',
     delay: 0.05,
   },
   {
@@ -207,7 +207,7 @@ const DETAILED_METRICS: DetailedMetric[] = [
     tooltip: 'Incident Escalation Rate',
     value: '10%',
     trend: 'down',
-    trendColor: '#40E5D1',
+    trendColor: 'var(--chart-1)',
     delay: 0.1,
   },
 ];
@@ -358,7 +358,7 @@ function IncidentAreaChart({ period }: { period: PeriodKey }) {
             y={height - 8}
             textAnchor="middle"
             fontSize="11"
-            fill="#9A9AAF"
+            fill="var(--muted-foreground)"
           >
             {formatShortDate(point.date)}
           </text>
@@ -380,7 +380,7 @@ const AdvancedIncidentReportCard = () => {
         <select
           value={selectedTimePeriod}
           onChange={(event) => setSelectedTimePeriod(event.target.value as PeriodKey)}
-          className="rounded-md bg-gray-100 p-3 pt-2 pb-2 text-gray-800 outline-none transition-colors duration-300 focus:ring-2 focus:ring-blue-500 dark:bg-[#262631] dark:text-white"
+          className="rounded-md bg-gray-100 p-3 pt-2 pb-2 text-gray-800 outline-none transition-colors duration-300 focus:ring-2 focus:ring-blue-500 dark:bg-[var(--muted)] dark:text-white"
           aria-label="Select time period for incident report"
         >
           {TIME_PERIOD_OPTIONS.map((option) => (
@@ -404,7 +404,7 @@ const AdvancedIncidentReportCard = () => {
 
       <div className="flex w-full flex-col justify-between gap-4 px-8 pt-8 pb-2 sm:flex-row sm:gap-8">
         {INCIDENT_STATS.map((stat) => {
-          const trendColor = stat.trend === 'up' ? '#F08083' : '#40E5D1';
+          const trendColor = stat.trend === 'up' ? 'var(--destructive)' : 'var(--chart-1)';
 
           return (
             <div key={stat.id} className="flex w-full flex-col gap-2 sm:w-1/2">
@@ -437,7 +437,7 @@ const AdvancedIncidentReportCard = () => {
         })}
       </div>
 
-      <div className="mt-4 flex flex-col divide-y divide-gray-200 px-8 font-mono transition-colors duration-300 dark:divide-[#262631]">
+      <div className="mt-4 flex flex-col divide-y divide-gray-200 px-8 font-mono transition-colors duration-300 dark:divide-[var(--muted)]">
         {DETAILED_METRICS.map((metric) => (
           <motion.div
             key={metric.id}
@@ -447,7 +447,7 @@ const AdvancedIncidentReportCard = () => {
             className="flex w-full items-center gap-2 py-4"
           >
             <div className="flex w-1/2 items-center gap-2 text-base text-gray-500 transition-colors duration-300 dark:text-gray-400">
-              <metric.icon fill={metric.trend === 'down' ? '#40E5D1' : '#E84045'} />
+              <metric.icon fill={metric.trend === 'down' ? 'var(--chart-1)' : 'var(--destructive)'} />
               <span className="truncate" title={metric.tooltip}>
                 {metric.label}
               </span>

--- a/apps/web/components/companies/companies-directory-client.tsx
+++ b/apps/web/components/companies/companies-directory-client.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+﻿import Link from "next/link";
 
 import { CompanyDirectoryFilters } from "@/components/companies/company-directory-filters";
 import { CompanyDirectoryList } from "@/components/companies/company-directory-list";
@@ -82,7 +82,7 @@ export function CompaniesDirectoryPageContent({
             titleAs="h1"
             description="A listagem de empresas nao respondeu agora. O fluxo de busca e navegacao pode ser retomado assim que a API voltar a responder."
           />
-          <Alert className="rounded-[1.75rem] border border-destructive/25 bg-destructive/6 px-5 py-5 text-left">
+          <Alert variant="destructive-soft">
             <AlertTitle>Falha controlada da listagem</AlertTitle>
             <AlertDescription>
               {data.directoryError ??
@@ -129,13 +129,13 @@ export function CompaniesDirectoryPageContent({
     <PageShell density="default" className="space-y-8">
       <div className="flex flex-wrap items-end justify-between gap-4">
         <div>
-          <p className="mb-1 text-[0.72rem] font-medium uppercase tracking-[0.26em] text-muted-foreground">
+          <p className="mb-1 text-xs font-medium uppercase tracking-[0.26em] text-muted-foreground">
             Diretorio / CVM
           </p>
           <h1 className="font-heading text-[clamp(1.75rem,4vw,2.5rem)] font-medium leading-tight tracking-[-0.04em] text-foreground">
             Todas as companhias abertas
           </h1>
-          <p className="mt-1.5 text-[0.9rem] text-muted-foreground">
+          <p className="mt-1.5 text-sm text-muted-foreground">
             {formatCompactInteger(directory.pagination.total_items)} empresas
             {currentSearch ? ` / "${currentSearch}"` : ""}
             {currentSector ? ` / ${currentSector}` : ""}
@@ -180,14 +180,14 @@ export function CompaniesDirectoryPageContent({
       </div>
 
       {directoryError ? (
-        <Alert className="rounded-[1.75rem] border border-border/70 bg-background/85 px-5 py-4">
+        <Alert className="rounded-3xl border-border/70 bg-background/85 px-5 py-4">
           <AlertTitle>Atualizacao parcial da listagem</AlertTitle>
           <AlertDescription>{directoryError}</AlertDescription>
         </Alert>
       ) : null}
 
       {filtersError ? (
-        <Alert className="rounded-[1.75rem] border border-border/70 bg-background/85 px-5 py-4">
+        <Alert className="rounded-3xl border-border/70 bg-background/85 px-5 py-4">
           <AlertTitle>Filtro setorial indisponivel</AlertTitle>
           <AlertDescription>
             {filtersError} A busca livre e a paginacao continuam disponiveis.
@@ -203,7 +203,7 @@ export function CompaniesDirectoryPageContent({
           >
             <span
               className={cn(
-                "inline-flex rounded-full border px-2 py-0.5 text-[0.62rem] font-medium uppercase tracking-[0.14em]",
+                "inline-flex rounded-full border px-2 py-0.5 text-xs font-medium uppercase tracking-[0.14em]",
                 item.className,
               )}
             >

--- a/apps/web/components/companies/company-card.tsx
+++ b/apps/web/components/companies/company-card.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+﻿import Link from "next/link";
 
 import type { CompanyDirectoryItem } from "@/lib/api";
 import { getCompanyAvailability } from "@/lib/company-discovery";
@@ -72,7 +72,7 @@ export function CompanyCard({ item }: CompanyCardProps) {
           </div>
           {item.ticker_b3 ? (
             <span
-              className="rounded-[0.35rem] border px-1.5 py-0.5 font-mono text-[0.7rem] font-medium"
+              className="rounded-[0.35rem] border px-1.5 py-0.5 font-mono text-xs font-medium"
               style={{
                 background: `color-mix(in oklch, ${color} 10%, transparent)`,
                 borderColor: `color-mix(in oklch, ${color} 22%, transparent)`,
@@ -85,7 +85,7 @@ export function CompanyCard({ item }: CompanyCardProps) {
         </div>
         <span
           className={cn(
-            "rounded-full border px-2.5 py-1 text-[0.64rem] font-medium uppercase tracking-[0.14em]",
+            "rounded-full border px-2.5 py-1 text-xs font-medium uppercase tracking-[0.14em]",
             getAvailabilityBadgeClassName(availability.kind),
           )}
         >
@@ -110,13 +110,13 @@ export function CompanyCard({ item }: CompanyCardProps) {
       </div>
 
       <div className="min-w-0 flex-1">
-        <p className="line-clamp-2 font-heading text-[0.95rem] font-medium leading-tight text-foreground">
+        <p className="line-clamp-2 font-heading text-base font-medium leading-tight text-foreground">
           {item.company_name}
         </p>
         {item.sector_name ? (
-          <p className="mt-0.5 text-[0.75rem] text-muted-foreground">{item.sector_name}</p>
+          <p className="mt-0.5 text-xs text-muted-foreground">{item.sector_name}</p>
         ) : null}
-        <p className="mt-2 text-[0.78rem] leading-6 text-muted-foreground">
+        <p className="mt-2 text-sm leading-6 text-muted-foreground">
           {availability.detail}
         </p>
       </div>
@@ -133,10 +133,10 @@ export function CompanyCard({ item }: CompanyCardProps) {
           ] as const
         ).map(({ label, value }) => (
           <div key={label} className="px-2 first:pl-0 last:pr-0">
-            <p className="text-[0.62rem] uppercase tracking-[0.12em] text-muted-foreground">
+            <p className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
               {label}
             </p>
-            <p className="mt-0.5 text-[0.78rem] font-medium text-foreground/78">
+            <p className="mt-0.5 text-sm font-medium text-foreground/78">
               {value}
             </p>
           </div>

--- a/apps/web/components/companies/company-directory-filters.tsx
+++ b/apps/web/components/companies/company-directory-filters.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 import { SearchIcon, XIcon } from "lucide-react";
 import { startTransition, useState } from "react";
@@ -107,7 +107,7 @@ export function CompanyDirectoryFilters({
               )}
             >
               <SelectValue
-                placeholder={sectorFilterUnavailable ? "Indisponível" : "Todos os setores"}
+                placeholder={sectorFilterUnavailable ? "IndisponÃ­vel" : "Todos os setores"}
               />
             </SelectTrigger>
             <SelectContent>
@@ -116,7 +116,7 @@ export function CompanyDirectoryFilters({
                 {!sectorFilterUnavailable
                   ? sectors.map((sector) => (
                       <SelectItem key={sector.sector_slug} value={sector.sector_slug}>
-                        {sector.sector_name} · {sector.company_count}
+                        {sector.sector_name} Â· {sector.company_count}
                       </SelectItem>
                     ))
                   : null}
@@ -133,7 +133,7 @@ export function CompanyDirectoryFilters({
       {hasActiveFilters && (
         <div className="flex flex-wrap items-center gap-2">
           {currentSearch && (
-            <span className="flex items-center gap-1.5 rounded-full border border-primary/25 bg-primary/8 px-3 py-1 text-[0.75rem] font-medium text-primary">
+            <span className="flex items-center gap-1.5 rounded-full border border-primary/25 bg-primary/8 px-3 py-1 text-xs font-medium text-primary">
               &ldquo;{currentSearch}&rdquo;
               <button
                 type="button"
@@ -145,7 +145,7 @@ export function CompanyDirectoryFilters({
             </span>
           )}
           {currentSector && hasCurrentSector && (
-            <span className="flex items-center gap-1.5 rounded-full border border-primary/25 bg-primary/8 px-3 py-1 text-[0.75rem] font-medium text-primary">
+            <span className="flex items-center gap-1.5 rounded-full border border-primary/25 bg-primary/8 px-3 py-1 text-xs font-medium text-primary">
               {sectors.find((s) => s.sector_slug === currentSector)?.sector_name ??
                 currentSector}
               <button
@@ -160,7 +160,7 @@ export function CompanyDirectoryFilters({
           <button
             type="button"
             onClick={handleClear}
-            className="text-[0.75rem] text-muted-foreground hover:text-foreground"
+            className="text-xs text-muted-foreground hover:text-foreground"
           >
             Limpar tudo
           </button>

--- a/apps/web/components/companies/company-directory-list.tsx
+++ b/apps/web/components/companies/company-directory-list.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+﻿import Link from "next/link";
 import { InboxIcon } from "lucide-react";
 
 import { CompanyCard } from "@/components/companies/company-card";
@@ -68,7 +68,7 @@ export function CompanyDirectoryList({
                   <div className="min-w-0 space-y-1">
                     <div className="flex flex-wrap items-center gap-2">
                       <p className="truncate font-medium text-foreground">{item.company_name}</p>
-                      <span className="rounded-full border border-primary/20 bg-primary/8 px-2 py-0.5 text-[0.62rem] font-medium uppercase tracking-[0.14em] text-primary/80">
+                      <span className="rounded-full border border-primary/20 bg-primary/8 px-2 py-0.5 text-xs font-medium uppercase tracking-[0.14em] text-primary/80">
                         Solicitar dados
                       </span>
                     </div>

--- a/apps/web/components/companies/company-row.tsx
+++ b/apps/web/components/companies/company-row.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+﻿import Link from "next/link";
 import { ChevronRightIcon } from "lucide-react";
 
 import type { CompanyDirectoryItem } from "@/lib/api";
@@ -75,12 +75,12 @@ export function CompanyRow({ item }: CompanyRowProps) {
 
       <div className="min-w-0">
         <div className="flex flex-wrap items-center gap-1.5">
-          <span className="truncate text-[0.9rem] font-medium text-foreground">
+          <span className="truncate text-sm font-medium text-foreground">
             {item.company_name}
           </span>
           {item.ticker_b3 ? (
             <span
-              className="shrink-0 rounded-[0.35rem] border px-1.5 py-0.5 font-mono text-[0.68rem] font-medium"
+              className="shrink-0 rounded-[0.35rem] border px-1.5 py-0.5 font-mono text-xs font-medium"
               style={{
                 background: `color-mix(in oklch, ${color} 10%, transparent)`,
                 borderColor: `color-mix(in oklch, ${color} 22%, transparent)`,
@@ -92,22 +92,22 @@ export function CompanyRow({ item }: CompanyRowProps) {
           ) : null}
           <span
             className={cn(
-              "shrink-0 rounded-full border px-2 py-0.5 text-[0.62rem] font-medium uppercase tracking-[0.14em]",
+              "shrink-0 rounded-full border px-2 py-0.5 text-xs font-medium uppercase tracking-[0.14em]",
               getAvailabilityBadgeClassName(availability.kind),
             )}
           >
             {availability.badge}
           </span>
         </div>
-        <p className="mt-0.5 text-[0.72rem] text-muted-foreground">
+        <p className="mt-0.5 text-xs text-muted-foreground">
           CVM {item.cd_cvm}
         </p>
-        <p className="mt-1 hidden text-[0.72rem] text-muted-foreground sm:block">
+        <p className="mt-1 hidden text-xs text-muted-foreground sm:block">
           {availability.detail}
         </p>
       </div>
 
-      <p className="hidden truncate text-[0.82rem] text-muted-foreground sm:block">
+      <p className="hidden truncate text-sm text-muted-foreground sm:block">
         {item.sector_name ?? "--"}
       </p>
 
@@ -124,13 +124,13 @@ export function CompanyRow({ item }: CompanyRowProps) {
             />
           </svg>
         ) : null}
-        <span className="whitespace-nowrap font-mono text-[0.72rem] tabular-nums text-muted-foreground">
+        <span className="whitespace-nowrap font-mono text-xs tabular-nums text-muted-foreground">
           {yearsRange}
         </span>
       </div>
 
       <div className="hidden text-right lg:block">
-        <span className="text-[0.78rem] text-muted-foreground">
+        <span className="text-sm text-muted-foreground">
           {availability.summary}
         </span>
       </div>

--- a/apps/web/components/company/company-analysis-chart.tsx
+++ b/apps/web/components/company/company-analysis-chart.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 import { useMemo, useState } from "react";
 
@@ -393,7 +393,7 @@ export function CompanyAnalysisChart({
 
       {hoveredYear !== null && hoveredEntries.length > 0 ? (
         <div className="rounded-[1.25rem] border border-border/60 bg-muted/18 px-4 py-3">
-          <p className="text-[0.72rem] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+          <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
             Ano em foco
           </p>
           <div className="mt-2 flex flex-wrap items-start gap-3">

--- a/apps/web/components/company/company-analysis-panel.tsx
+++ b/apps/web/components/company/company-analysis-panel.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 import { useMemo, useState, type ReactNode } from "react";
 import { SearchIcon } from "lucide-react";
@@ -83,7 +83,7 @@ export function CompanyAnalysisPanel({
       <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
         <div className="space-y-2">
           <div className="flex items-center gap-2">
-            <p className="text-[0.72rem] font-medium uppercase tracking-[0.2em] text-muted-foreground">
+            <p className="text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground">
               Analise de indicadores
             </p>
             <CompanyHelpTip>
@@ -114,7 +114,7 @@ export function CompanyAnalysisPanel({
       <div className="space-y-4 rounded-[1.35rem] border border-border/60 bg-muted/16 p-4">
         <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
           <div className="flex items-center gap-2">
-            <p className="text-[0.72rem] font-medium uppercase tracking-[0.2em] text-muted-foreground">
+            <p className="text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground">
               Tabela anual
             </p>
             <CompanyHelpTip>

--- a/apps/web/components/company/company-context-card.tsx
+++ b/apps/web/components/company/company-context-card.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+﻿import Link from "next/link";
 
 import { CompanyHelpTip } from "@/components/company/company-help-tip";
 import { SurfaceCard } from "@/components/shared/design-system-recipes";
@@ -25,7 +25,7 @@ export function CompanyContextCard({
     <SurfaceCard tone="subtle" padding="md" className="space-y-4">
       <div className="space-y-2">
         <div className="flex items-center gap-2">
-          <p className="text-[0.72rem] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+          <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
             Contexto
           </p>
           <CompanyHelpTip>

--- a/apps/web/components/company/company-freshness-card.tsx
+++ b/apps/web/components/company/company-freshness-card.tsx
@@ -1,4 +1,4 @@
-import { CompanyRequestRefreshLazy } from "@/components/company/company-request-refresh-lazy";
+﻿import { CompanyRequestRefreshLazy } from "@/components/company/company-request-refresh-lazy";
 import { CompanyHelpTip } from "@/components/company/company-help-tip";
 import { SurfaceCard } from "@/components/shared/design-system-recipes";
 import {
@@ -122,13 +122,13 @@ export async function CompanyFreshnessCard({
         <div className="flex flex-wrap items-center gap-2">
           <span
             className={cn(
-              "rounded-full border px-2.5 py-1 text-[0.64rem] font-medium uppercase tracking-[0.16em]",
+              "rounded-full border px-2.5 py-1 text-xs font-medium uppercase tracking-[0.16em]",
               getStatusBadgeClassName(summary.badgeTone),
             )}
           >
             {summary.badgeLabel}
           </span>
-          <span className="rounded-full border border-border/65 px-2.5 py-1 text-[0.64rem] font-medium uppercase tracking-[0.16em] text-muted-foreground">
+          <span className="rounded-full border border-border/65 px-2.5 py-1 text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
             {sourceLabel}
           </span>
         </div>

--- a/apps/web/components/company/company-header.tsx
+++ b/apps/web/components/company/company-header.tsx
@@ -40,12 +40,7 @@ export function CompanyHeader({ company, selectedYears }: CompanyHeaderProps) {
         </ol>
       </nav>
 
-      <div
-        className="overflow-hidden rounded-2xl border border-border/60 px-6 py-6 lg:px-8 lg:py-8"
-        style={{
-          background: `linear-gradient(135deg, color-mix(in oklch, ${sectorColor} 10%, var(--card)) 0%, var(--card) 70%)`,
-        }}
-      >
+      <div className="overflow-hidden rounded-2xl border border-border/60 bg-[linear-gradient(135deg,color-mix(in_oklch,var(--primary)_10%,var(--card))_0%,var(--card)_70%)] px-6 py-6 lg:px-8 lg:py-8">
         <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
           <div className="flex flex-col gap-5 sm:flex-row sm:items-start">
             <div

--- a/apps/web/components/company/company-hero-chart.tsx
+++ b/apps/web/components/company/company-hero-chart.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 import { useState } from "react";
 
@@ -52,7 +52,7 @@ function SvgBarChart({ points }: { points: ChartPoint[] }) {
   if (points.length < 2) {
     return (
       <div className="flex h-[160px] items-center justify-center text-sm text-muted-foreground">
-        Dados insuficientes para o gráfico.
+        Dados insuficientes para o grÃ¡fico.
       </div>
     );
   }
@@ -183,7 +183,7 @@ export function CompanyHeroChart({ series }: CompanyHeroChartProps) {
 
   const stats = computeStats(filteredPoints);
 
-  const pillBase = "rounded-full border px-3 py-1 text-[0.75rem] font-medium transition-colors";
+  const pillBase = "rounded-full border px-3 py-1 text-xs font-medium transition-colors";
 
   if (series.length === 0 || !currentSeries) return null;
 
@@ -215,7 +215,7 @@ export function CompanyHeroChart({ series }: CompanyHeroChartProps) {
               type="button"
               onClick={() => setActivePeriod(p.id)}
               className={cn(
-                "rounded-full border px-2.5 py-0.5 text-[0.72rem] font-medium transition-colors",
+                "rounded-full border px-2.5 py-0.5 text-xs font-medium transition-colors",
                 p.id === activePeriod
                   ? "border-border bg-muted text-foreground"
                   : "border-transparent text-muted-foreground hover:text-foreground",
@@ -240,17 +240,17 @@ export function CompanyHeroChart({ series }: CompanyHeroChartProps) {
               value:
                 stats.cagr !== null
                   ? `${stats.cagr >= 0 ? "+" : ""}${(stats.cagr * 100).toFixed(1)}%`
-                  : "—",
+                  : "â€”",
             },
-            { label: "Média", value: fmtShort(stats.avg) },
-            { label: "Máx", value: fmtShort(stats.max) },
-            { label: "Mín", value: fmtShort(stats.min) },
+            { label: "MÃ©dia", value: fmtShort(stats.avg) },
+            { label: "MÃ¡x", value: fmtShort(stats.max) },
+            { label: "MÃ­n", value: fmtShort(stats.min) },
           ].map(({ label, value }) => (
             <div key={label} className="px-4 first:pl-0 last:pr-0 text-center">
-              <p className="text-[0.65rem] uppercase tracking-[0.15em] text-muted-foreground">
+              <p className="text-xs uppercase tracking-[0.15em] text-muted-foreground">
                 {label}
               </p>
-              <p className="mt-0.5 font-mono text-[0.85rem] font-medium tabular-nums text-foreground">
+              <p className="mt-0.5 font-mono text-sm font-medium tabular-nums text-foreground">
                 {value}
               </p>
             </div>

--- a/apps/web/components/company/company-kpi-row.tsx
+++ b/apps/web/components/company/company-kpi-row.tsx
@@ -1,4 +1,4 @@
-import type { DashboardKpiCard } from "@/lib/company-dashboard";
+﻿import type { DashboardKpiCard } from "@/lib/company-dashboard";
 import { formatKpiDelta, formatKpiValue } from "@/lib/formatters";
 import { cn } from "@/lib/utils";
 
@@ -21,7 +21,7 @@ export function CompanyKpiRow({ cards }: CompanyKpiRowProps) {
             key={card.id}
             className="rounded-[1.25rem] border border-border/60 bg-card px-5 py-4"
           >
-            <p className="text-[0.72rem] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+            <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
               {card.label}
             </p>
             <p className="mt-2 font-heading text-[1.75rem] font-medium tracking-[-0.04em] text-foreground leading-none">
@@ -31,7 +31,7 @@ export function CompanyKpiRow({ cards }: CompanyKpiRowProps) {
               {card.delta !== null ? (
                 <span
                   className={cn(
-                    "inline-flex items-center rounded-full px-2 py-0.5 text-[0.72rem] font-medium",
+                    "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium",
                     isPositive
                       ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
                       : "bg-destructive/10 text-destructive",
@@ -41,10 +41,10 @@ export function CompanyKpiRow({ cards }: CompanyKpiRowProps) {
                   {formatKpiDelta(card.delta, card.formatType)}
                 </span>
               ) : (
-                <span className="text-[0.72rem] text-muted-foreground/40">sem delta</span>
+                <span className="text-xs text-muted-foreground/40">sem delta</span>
               )}
-              <span className="text-[0.68rem] tabular-nums text-muted-foreground/50">
-                {card.year ?? "â€”"}
+              <span className="text-xs tabular-nums text-muted-foreground/50">
+                {card.year ?? "Ã¢â‚¬â€"}
               </span>
             </div>
           </div>

--- a/apps/web/components/company/company-market-sidebar.tsx
+++ b/apps/web/components/company/company-market-sidebar.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+﻿import Link from "next/link";
 import {
   ArrowUpRightIcon,
   ChevronDownIcon,
@@ -183,7 +183,7 @@ function CompanyQuoteCard({ company }: CompanyMarketSidebarProps) {
       <div className="pointer-events-none absolute inset-x-8 top-0 h-px bg-gradient-to-r from-transparent via-primary/35 to-transparent" />
       <div className="flex items-start justify-between gap-4">
         <div className="space-y-3">
-          <p className="text-[0.68rem] font-semibold uppercase tracking-[0.26em] text-muted-foreground">
+          <p className="text-xs font-semibold uppercase tracking-[0.26em] text-muted-foreground">
             COTACAO
           </p>
           <div className="flex flex-wrap items-center gap-2.5">
@@ -216,7 +216,7 @@ function CompanyQuoteCard({ company }: CompanyMarketSidebarProps) {
         <QuoteSparkline points={quote.points} />
       </div>
 
-      <div className="mt-2 flex items-center gap-1.5 text-[0.72rem] font-semibold text-muted-foreground">
+      <div className="mt-2 flex items-center gap-1.5 text-xs font-semibold text-muted-foreground">
         {PERIODS.map((period) => {
           const isSelected = period === "1A";
 
@@ -269,7 +269,7 @@ function CompanyNewsCard({ company }: CompanyMarketSidebarProps) {
                 {item.title}
               </h4>
               <p className="text-xs leading-4 text-muted-foreground">
-                {item.timeLabel} · {item.source}
+                {item.timeLabel} Â· {item.source}
               </p>
             </div>
           </article>

--- a/apps/web/components/company/company-period-preset.tsx
+++ b/apps/web/components/company/company-period-preset.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 import { startTransition, useState, type FormEvent } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -141,7 +141,7 @@ function CustomCompanyPeriodRange({
     >
       <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] md:items-end">
         <label className="space-y-2">
-          <span className="text-[0.72rem] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+          <span className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
             De:
           </span>
           <Input
@@ -159,8 +159,8 @@ function CustomCompanyPeriodRange({
         </label>
 
         <label className="space-y-2">
-          <span className="text-[0.72rem] font-medium uppercase tracking-[0.18em] text-muted-foreground">
-            Até:
+          <span className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+            AtÃ©:
           </span>
           <Input
             value={toInput}

--- a/apps/web/components/company/company-request-refresh.tsx
+++ b/apps/web/components/company/company-request-refresh.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 import { LoaderCircleIcon, RotateCcwIcon } from "lucide-react";
 import { useRouter } from "next/navigation";
@@ -240,7 +240,7 @@ export function CompanyRequestRefresh({
             <Badge
               variant="outline"
               className={cn(
-                "w-fit rounded-full border px-2.5 py-0.5 text-[0.7rem] uppercase tracking-[0.18em]",
+                "w-fit rounded-full border px-2.5 py-0.5 text-xs uppercase tracking-[0.18em]",
                 view.stepClassName,
               )}
             >
@@ -261,7 +261,7 @@ export function CompanyRequestRefresh({
               <div className="rounded-[1.25rem] border border-border/65 bg-background/82 px-4 py-4 shadow-[0_1px_0_rgba(255,255,255,0.22)]">
                 <div className="mb-3 flex items-start justify-between gap-3">
                   <div>
-                    <p className="text-[0.7rem] font-medium uppercase tracking-[0.22em] text-muted-foreground">
+                    <p className="text-xs font-medium uppercase tracking-[0.22em] text-muted-foreground">
                       Progresso do refresh
                     </p>
                     <p className="mt-1 text-xs text-muted-foreground">

--- a/apps/web/components/company/company-sector-ranking.tsx
+++ b/apps/web/components/company/company-sector-ranking.tsx
@@ -1,5 +1,5 @@
-const RANKING_ITEMS = [
-  { label: "Dívida/EBITDA", rank: null, total: null },
+﻿const RANKING_ITEMS = [
+  { label: "DÃ­vida/EBITDA", rank: null, total: null },
   { label: "ROE", rank: null, total: null },
   { label: "P/L", rank: null, total: null },
   { label: "Margem EBIT", rank: null, total: null },
@@ -19,9 +19,9 @@ function PeerBar({
   return (
     <div className="space-y-1.5">
       <div className="flex items-center justify-between">
-        <span className="text-[0.8rem] text-muted-foreground">{label}</span>
-        <span className="font-mono text-[0.75rem] text-muted-foreground/60 tabular-nums">
-          {rank !== null && total !== null ? `${rank}º / ${total}` : "Em breve"}
+        <span className="text-sm text-muted-foreground">{label}</span>
+        <span className="font-mono text-xs text-muted-foreground/60 tabular-nums">
+          {rank !== null && total !== null ? `${rank}Âº / ${total}` : "Em breve"}
         </span>
       </div>
       <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
@@ -37,7 +37,7 @@ function PeerBar({
 export function CompanySectorRanking() {
   return (
     <div className="rounded-[1.25rem] border border-border/60 bg-card px-5 py-4">
-      <p className="mb-4 text-[0.72rem] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+      <p className="mb-4 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
         Ranking no setor
       </p>
       <div className="space-y-3.5">

--- a/apps/web/components/company/company-statements.tsx
+++ b/apps/web/components/company/company-statements.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 import { startTransition, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
@@ -91,14 +91,14 @@ function StatementRow({
               "leading-tight",
               isSubtotal
                 ? "font-semibold text-sm text-foreground"
-                : "text-[0.82rem] text-muted-foreground",
+                : "text-sm text-muted-foreground",
             )}
           >
             {accountCode ? `${accountCode} ` : ""}
             {String(row.DS_CONTA ?? "Conta")}
           </p>
           {row.STANDARD_NAME && row.STANDARD_NAME !== row.DS_CONTA ? (
-            <p className="text-[0.68rem] uppercase tracking-[0.1em] text-muted-foreground/60">
+            <p className="text-xs uppercase tracking-[0.1em] text-muted-foreground/60">
               {String(row.STANDARD_NAME)}
             </p>
           ) : null}
@@ -115,21 +115,21 @@ function StatementRow({
           <td
             key={col}
             className={cn(
-              "py-2.5 px-3 text-right font-mono text-[0.82rem] tnum tabular-nums",
+              "py-2.5 px-3 text-right font-mono text-sm tnum tabular-nums",
               isNeg ? "text-destructive" : "text-foreground",
               isSubtotal ? "font-semibold" : "",
               isLastYear(col) ? "font-medium text-foreground" : "",
             )}
           >
-            {numericValue === null || isNaN(numericValue) ? "—" : fmtMM(numericValue)}
+            {numericValue === null || isNaN(numericValue) ? "â€”" : fmtMM(numericValue)}
           </td>
         );
       })}
 
       {showYoY ? (
-        <td className="py-2.5 px-3 text-right text-[0.82rem] tabular-nums">
+        <td className="py-2.5 px-3 text-right text-sm tabular-nums">
           {delta === null ? (
-            <span className="text-muted-foreground/50">—</span>
+            <span className="text-muted-foreground/50">â€”</span>
           ) : (
             <span
               className={isDeltaPos ? "text-emerald-600 dark:text-emerald-400" : "text-destructive"}
@@ -176,10 +176,10 @@ export function CompanyStatements({ matrix }: CompanyStatementsProps) {
   if (rows.length === 0) {
     return (
       <SurfaceCard tone="muted" padding="hero" className="items-center text-center">
-        <p className="font-heading text-2xl text-foreground">Sem demonstração disponível.</p>
+        <p className="font-heading text-2xl text-foreground">Sem demonstraÃ§Ã£o disponÃ­vel.</p>
         <p className="max-w-2xl text-sm leading-7 text-muted-foreground">
-          Ajuste o período selecionado ou troque o tipo de demonstração para consultar outra
-          visão disponível.
+          Ajuste o perÃ­odo selecionado ou troque o tipo de demonstraÃ§Ã£o para consultar outra
+          visÃ£o disponÃ­vel.
         </p>
       </SurfaceCard>
     );
@@ -195,7 +195,7 @@ export function CompanyStatements({ matrix }: CompanyStatementsProps) {
             type="button"
             onClick={() => navigateTo(opt.value)}
             className={cn(
-              "rounded-[0.85rem_0.85rem_0_0] border border-b-0 px-4 py-2 text-[0.82rem] font-medium -mb-px transition-colors",
+              "rounded-[0.85rem_0.85rem_0_0] border border-b-0 px-4 py-2 text-sm font-medium -mb-px transition-colors",
               currentStmt === opt.value
                 ? "border-border/60 bg-card text-foreground"
                 : "border-transparent text-muted-foreground hover:text-foreground",
@@ -214,22 +214,22 @@ export function CompanyStatements({ matrix }: CompanyStatementsProps) {
             type="search"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            placeholder="Filtrar linha…"
+            placeholder="Filtrar linhaâ€¦"
             className="h-auto w-44 border-0 bg-transparent p-0 text-sm shadow-none focus-visible:ring-0"
           />
         </div>
-        <label className="flex cursor-pointer items-center gap-2 text-[0.82rem] text-muted-foreground">
+        <label className="flex cursor-pointer items-center gap-2 text-sm text-muted-foreground">
           <Checkbox
             checked={showYoY}
             onCheckedChange={(checked) => setShowYoY(Boolean(checked))}
           />
-          Mostrar variação YoY
+          Mostrar variaÃ§Ã£o YoY
           <CompanyHelpTip>
             Mostra a variacao percentual contra o periodo anterior disponivel na tabela.
           </CompanyHelpTip>
         </label>
-        <span className="ml-auto text-[0.72rem] text-muted-foreground tabular-nums">
-          {filteredRows.length} linhas · R$ milhões
+        <span className="ml-auto text-xs text-muted-foreground tabular-nums">
+          {filteredRows.length} linhas Â· R$ milhÃµes
         </span>
       </div>
 
@@ -254,7 +254,7 @@ export function CompanyStatements({ matrix }: CompanyStatementsProps) {
               ))}
               {showYoY ? (
                 <th className="px-3 py-3 text-right font-medium text-muted-foreground">
-                  Δ YoY
+                  Î” YoY
                 </th>
               ) : null}
             </tr>
@@ -275,7 +275,7 @@ export function CompanyStatements({ matrix }: CompanyStatementsProps) {
       </div>
 
       <div className="flex items-center gap-2 pt-3 text-xs text-muted-foreground">
-        <span>Fonte: CVM · R$ milhoes</span>
+        <span>Fonte: CVM Â· R$ milhoes</span>
         <CompanyHelpTip>
           DFP/ITR consolidados. Linhas em destaque sao totalizadoras. Valores sem ajuste de inflacao.
         </CompanyHelpTip>

--- a/apps/web/components/compare/compare-kpi-table.tsx
+++ b/apps/web/components/compare/compare-kpi-table.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+﻿import Link from "next/link";
 
 import {
   SectionHeading,
@@ -67,7 +67,7 @@ export function CompareKpiTable({
                     >
                       {company.company_name}
                     </Link>
-                    <p className="text-[0.65rem] uppercase tracking-[0.16em] text-muted-foreground">
+                    <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">
                       {company.ticker_b3 ?? "sem ticker"} - CVM {company.cd_cvm}
                       {index === 0 ? " - base" : ""}
                     </p>
@@ -82,7 +82,7 @@ export function CompareKpiTable({
                 <TableCell className="sticky left-0 z-10 bg-background px-5">
                   <div className="space-y-1">
                     <p className="font-medium text-foreground">{row.label}</p>
-                    <p className="text-[0.68rem] uppercase tracking-[0.15em] text-muted-foreground">
+                    <p className="text-xs uppercase tracking-[0.15em] text-muted-foreground">
                       {row.kpiId}
                     </p>
                   </div>

--- a/apps/web/components/compare/compare-selector.tsx
+++ b/apps/web/components/compare/compare-selector.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 import Link from "next/link";
 import { PlusIcon, SearchIcon, XIcon } from "lucide-react";
@@ -306,7 +306,7 @@ export function CompareSelector({
                   onClick={() => addCompany(company)}
                 >
                   <span className="max-w-[14rem] truncate">{company.company_name}</span>
-                  <span className="rounded-full border border-emerald-500/20 bg-emerald-500/8 px-1.5 py-0.5 text-[0.58rem] uppercase tracking-[0.14em] text-emerald-700 dark:text-emerald-300">
+                  <span className="rounded-full border border-emerald-500/20 bg-emerald-500/8 px-1.5 py-0.5 text-xs uppercase tracking-[0.14em] text-emerald-700 dark:text-emerald-300">
                     Pronta
                   </span>
                 </button>

--- a/apps/web/components/feature-carousel.tsx
+++ b/apps/web/components/feature-carousel.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 import React, { useState, useEffect, useCallback } from "react";
 import { motion, AnimatePresence } from "motion/react";
@@ -146,9 +146,9 @@ export function FeatureCarousel() {
   return (
     <div className="w-full max-w-7xl mx-auto md:p-8">
       <div className="relative overflow-hidden rounded-[2.5rem] lg:rounded-[4rem] flex flex-col lg:flex-row min-h-[600px] lg:aspect-video border border-border/40">
-        <div className="w-full lg:w-[40%] min-h-[350px] md:min-h-[450px] lg:h-full relative z-30 flex flex-col items-start justify-center overflow-hidden px-8 md:px-16 lg:pl-16 bg-[#62B2FE] ">
-          <div className="absolute inset-x-0 top-0 h-12 md:h-20 lg:h-16 bg-gradient-to-b from-[#62B2FE] via-[#62B2FE]/80 to-transparent z-40" />
-          <div className="absolute inset-x-0 bottom-0 h-12 md:h-20 lg:h-16 bg-gradient-to-t from-[#62B2FE] via-[#62B2FE]/80 to-transparent z-40" />
+        <div className="w-full lg:w-[40%] min-h-[350px] md:min-h-[450px] lg:h-full relative z-30 flex flex-col items-start justify-center overflow-hidden px-8 md:px-16 lg:pl-16 bg-[var(--chart-3)] ">
+          <div className="absolute inset-x-0 top-0 h-12 md:h-20 lg:h-16 bg-gradient-to-b from-[var(--chart-3)] via-[var(--chart-3)]/80 to-transparent z-40" />
+          <div className="absolute inset-x-0 bottom-0 h-12 md:h-20 lg:h-16 bg-gradient-to-t from-[var(--chart-3)] via-[var(--chart-3)]/80 to-transparent z-40" />
           <div className="relative w-full h-full flex items-center justify-center lg:justify-start z-20">
             {FEATURES.map((feature, index) => {
               const isActive = index === currentIndex;
@@ -185,14 +185,14 @@ export function FeatureCarousel() {
                     className={cn(
                       "relative flex items-center gap-4 px-6 md:px-10 lg:px-8 py-3.5 md:py-5 lg:py-4 rounded-full transition-all duration-700 text-left group border",
                       isActive
-                        ? "bg-white text-[#62B2FE] border-white z-10"
+                        ? "bg-white text-[var(--chart-3)] border-white z-10"
                         : "bg-transparent text-white/60 border-white/20 hover:border-white/40 hover:text-white"
                     )}
                   >
                     <div
                       className={cn(
                         "flex items-center justify-center transition-colors duration-500",
-                        isActive ? "text-[#62B2FE]" : "text-white/40"
+                        isActive ? "text-[var(--chart-3)]" : "text-white/40"
                       )}
                     >
                       <HugeiconsIcon
@@ -261,7 +261,7 @@ export function FeatureCarousel() {
                         className="absolute inset-x-0 bottom-0 p-10 pt-32 bg-gradient-to-t from-black/90 via-black/40 to-transparent flex flex-col justify-end pointer-events-none"
                       >
                         <div className="bg-background text-foreground px-4 py-1.5 rounded-full text-[11px] font-normal uppercase tracking-[0.2em] w-fit shadow-lg mb-3 border border-border/50">
-                          {index + 1} • {feature.label}
+                          {index + 1} â€¢ {feature.label}
                         </div>
                         <p className="text-white font-normal text-xl md:text-2xl leading-tight drop-shadow-md tracking-tight">
                           {feature.description}

--- a/apps/web/components/financial-markets-table.tsx
+++ b/apps/web/components/financial-markets-table.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 import { useState } from "react";
 import { motion, useReducedMotion } from "motion/react";
@@ -159,7 +159,7 @@ export function FinancialTable({
     if (!resolvedTheme) {
       const isPositive = value >= 0;
       return {
-        color: isPositive ? "#22c55e" : "#f87171",
+        color: isPositive ? "var(--chart-1)" : "var(--destructive)",
         bgColor: isPositive ? "bg-green-500/10" : "bg-red-500/10",
         borderColor: isPositive ? "border-green-500/30" : "border-red-500/30",
         textColor: isPositive ? "text-green-400" : "text-red-400"
@@ -168,8 +168,8 @@ export function FinancialTable({
     
     const isPositive = value >= 0;
     const color = isPositive 
-      ? (isDark ? "#22c55e" : "#16a34a")
-      : (isDark ? "#f87171" : "#dc2626");
+      ? (isDark ? "var(--chart-1)" : "var(--chart-1)")
+      : (isDark ? "var(--destructive)" : "var(--destructive)");
     const bgColor = isPositive 
       ? (isDark ? "bg-green-500/10" : "bg-green-50")
       : (isDark ? "bg-red-500/10" : "bg-red-50");
@@ -188,56 +188,56 @@ export function FinancialTable({
       case "US":
         return (
           <svg width="32" height="32" viewBox="0 0 130 120" fill="none" className="scale-125">
-            <rect y="0" fill="#DC4437" width="130" height="13.3"/>
-            <rect y="26.7" fill="#DC4437" width="130" height="13.3"/>
-            <rect y="80" fill="#DC4437" width="130" height="13.3"/>
-            <rect y="106.7" fill="#DC4437" width="130" height="13.3"/>
-            <rect y="53.3" fill="#DC4437" width="130" height="13.3"/>
-            <rect y="13.3" fill="#FFFFFF" width="130" height="13.3"/>
-            <rect y="40" fill="#FFFFFF" width="130" height="13.3"/>
-            <rect y="93.3" fill="#FFFFFF" width="130" height="13.3"/>
-            <rect y="66.7" fill="#FFFFFF" width="130" height="13.3"/>
-            <rect y="0" fill="#2A66B7" width="70" height="66.7"/>
-            <polygon fill="#FFFFFF" points="13.5,4 15.8,8.9 21,9.7 17.2,13.6 18.1,19 13.5,16.4 8.9,19 9.8,13.6 6,9.7 11.2,8.9"/>
-            <polygon fill="#FFFFFF" points="34,4 36.3,8.9 41.5,9.7 37.8,13.6 38.6,19 34,16.4 29.4,19 30.2,13.6 26.5,9.7 31.7,8.9"/>
-            <polygon fill="#FFFFFF" points="54.5,4 56.8,8.9 62,9.7 58.2,13.6 59.1,19 54.5,16.4 49.9,19 50.8,13.6 47,9.7 52.2,8.9"/>
-            <polygon fill="#FFFFFF" points="24,24 26.3,28.9 31.5,29.7 27.8,33.6 28.6,39 24,36.4 19.4,39 20.2,33.6 16.5,29.7 21.7,28.9"/>
-            <polygon fill="#FFFFFF" points="44.5,24 46.8,28.9 52,29.7 48.2,33.6 49.1,39 44.5,36.4 39.9,39 40.8,33.6 37,29.7 42.2,28.9"/>
-            <polygon fill="#FFFFFF" points="13.5,45.2 15.8,50.1 21,50.9 17.2,54.7 18.1,60.2 13.5,57.6 8.9,60.2 9.8,54.7 6,50.9 11.2,50.1"/>
-            <polygon fill="#FFFFFF" points="34,45.2 36.3,50.1 41.5,50.9 37.8,54.7 38.6,60.2 34,57.6 29.4,60.2 30.2,54.7 26.5,50.9 31.7,50.1"/>
-            <polygon fill="#FFFFFF" points="54.5,45.2 56.8,50.1 62,50.9 58.2,54.7 59.1,60.2 54.5,57.6 49.9,60.2 50.8,54.7 47,50.9 52.2,50.1"/>
+            <rect y="0" fill="var(--destructive)" width="130" height="13.3"/>
+            <rect y="26.7" fill="var(--destructive)" width="130" height="13.3"/>
+            <rect y="80" fill="var(--destructive)" width="130" height="13.3"/>
+            <rect y="106.7" fill="var(--destructive)" width="130" height="13.3"/>
+            <rect y="53.3" fill="var(--destructive)" width="130" height="13.3"/>
+            <rect y="13.3" fill="var(--primary-foreground)" width="130" height="13.3"/>
+            <rect y="40" fill="var(--primary-foreground)" width="130" height="13.3"/>
+            <rect y="93.3" fill="var(--primary-foreground)" width="130" height="13.3"/>
+            <rect y="66.7" fill="var(--primary-foreground)" width="130" height="13.3"/>
+            <rect y="0" fill="var(--chart-3)" width="70" height="66.7"/>
+            <polygon fill="var(--primary-foreground)" points="13.5,4 15.8,8.9 21,9.7 17.2,13.6 18.1,19 13.5,16.4 8.9,19 9.8,13.6 6,9.7 11.2,8.9"/>
+            <polygon fill="var(--primary-foreground)" points="34,4 36.3,8.9 41.5,9.7 37.8,13.6 38.6,19 34,16.4 29.4,19 30.2,13.6 26.5,9.7 31.7,8.9"/>
+            <polygon fill="var(--primary-foreground)" points="54.5,4 56.8,8.9 62,9.7 58.2,13.6 59.1,19 54.5,16.4 49.9,19 50.8,13.6 47,9.7 52.2,8.9"/>
+            <polygon fill="var(--primary-foreground)" points="24,24 26.3,28.9 31.5,29.7 27.8,33.6 28.6,39 24,36.4 19.4,39 20.2,33.6 16.5,29.7 21.7,28.9"/>
+            <polygon fill="var(--primary-foreground)" points="44.5,24 46.8,28.9 52,29.7 48.2,33.6 49.1,39 44.5,36.4 39.9,39 40.8,33.6 37,29.7 42.2,28.9"/>
+            <polygon fill="var(--primary-foreground)" points="13.5,45.2 15.8,50.1 21,50.9 17.2,54.7 18.1,60.2 13.5,57.6 8.9,60.2 9.8,54.7 6,50.9 11.2,50.1"/>
+            <polygon fill="var(--primary-foreground)" points="34,45.2 36.3,50.1 41.5,50.9 37.8,54.7 38.6,60.2 34,57.6 29.4,60.2 30.2,54.7 26.5,50.9 31.7,50.1"/>
+            <polygon fill="var(--primary-foreground)" points="54.5,45.2 56.8,50.1 62,50.9 58.2,54.7 59.1,60.2 54.5,57.6 49.9,60.2 50.8,54.7 47,50.9 52.2,50.1"/>
           </svg>
         );
       case "CA":
         return (
           <svg width="32" height="32" viewBox="0 0 90 60" fill="none" className="scale-150">
-            <rect width="90" height="60" fill="#FF0000"/>
-            <rect x="30" width="30" height="60" fill="#FFFFFF"/>
-            <polygon fill="#FF0000" points="45,15 50,20 45,25 40,20"/>
-            <polygon fill="#FF0000" points="45,35 50,40 45,45 40,40"/>
+            <rect width="90" height="60" fill="var(--destructive)"/>
+            <rect x="30" width="30" height="60" fill="var(--primary-foreground)"/>
+            <polygon fill="var(--destructive)" points="45,15 50,20 45,25 40,20"/>
+            <polygon fill="var(--destructive)" points="45,35 50,40 45,45 40,40"/>
           </svg>
         );
       case "MX":
         return (
           <svg width="32" height="32" viewBox="0 0 90 60" fill="none" className="scale-150">
-            <rect width="30" height="60" fill="#006847"/>
-            <rect x="30" width="30" height="60" fill="#FFFFFF"/>
-            <rect x="60" width="30" height="60" fill="#CE1126"/>
+            <rect width="30" height="60" fill="var(--chart-1)"/>
+            <rect x="30" width="30" height="60" fill="var(--primary-foreground)"/>
+            <rect x="60" width="30" height="60" fill="var(--destructive)"/>
           </svg>
         );
       case "BR":
         return (
           <svg width="32" height="32" viewBox="0 0 90 60" fill="none" className="scale-150">
-            <rect width="90" height="60" fill="#009639"/>
-            <polygon fill="#FEDD00" points="45,30 20,15 20,45"/>
-            <circle cx="45" cy="30" r="8" fill="#002776"/>
+            <rect width="90" height="60" fill="var(--chart-1)"/>
+            <polygon fill="var(--chart-2)" points="45,30 20,15 20,45"/>
+            <circle cx="45" cy="30" r="8" fill="var(--chart-3)"/>
           </svg>
         );
       default:
         return (
           <svg width="32" height="32" viewBox="0 0 32 32" fill="none" className="scale-125">
-            <rect width="32" height="32" fill="#E5E7EB" rx="4"/>
-            <text x="16" y="20" textAnchor="middle" fontSize="12" fill="#6B7280">?</text>
+            <rect width="32" height="32" fill="var(--muted)" rx="4"/>
+            <text x="16" y="20" textAnchor="middle" fontSize="12" fill="var(--muted-foreground)">?</text>
           </svg>
         );
     }

--- a/apps/web/components/home/analysis-remotion-player.tsx
+++ b/apps/web/components/home/analysis-remotion-player.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 import { Player } from "@remotion/player";
 import {
@@ -93,8 +93,8 @@ function AnalysisRemotionVideo() {
   const activeIndex = Math.floor(interpolate(loop, [0, 180], [0, capabilities.length])) % capabilities.length;
 
   return (
-    <AbsoluteFill className="overflow-hidden bg-[#050908] text-white">
-      <div className="absolute inset-0 bg-[linear-gradient(135deg,#061410_0%,#09110f_52%,#050605_100%)]" />
+    <AbsoluteFill className="overflow-hidden bg-[var(--background)] text-white">
+      <div className="absolute inset-0 bg-[linear-gradient(135deg,var(--background)_0%,var(--background)_52%,var(--background)_100%)]" />
       <div
         className="absolute -left-20 top-0 h-[28rem] w-[28rem] rounded-full bg-teal-400/14 blur-3xl"
         style={{
@@ -123,14 +123,14 @@ function AnalysisRemotionVideo() {
         <section className="flex min-w-0 flex-col">
           <div className="mb-8 flex items-start justify-between gap-8 border-b border-white/10 pb-6">
             <div>
-              <div className="mb-3 text-[0.7rem] font-medium uppercase tracking-[0.18em] text-teal-100/52">
+              <div className="mb-3 text-xs font-medium uppercase tracking-[0.18em] text-teal-100/52">
                 Analise guiada
               </div>
               <h3 className="max-w-[34rem] font-heading text-[2.65rem] font-semibold leading-[0.95] tracking-[-0.02em]">
                 Financial intelligence for every CVM filing.
               </h3>
             </div>
-            <div className="mt-2 shrink-0 rounded-full border border-teal-200/18 bg-teal-200/[0.08] px-4 py-2 text-[0.78rem] font-medium text-teal-50/86">
+            <div className="mt-2 shrink-0 rounded-full border border-teal-200/18 bg-teal-200/[0.08] px-4 py-2 text-sm font-medium text-teal-50/86">
               Live model
             </div>
           </div>
@@ -140,10 +140,10 @@ function AnalysisRemotionVideo() {
               <div>
                 <div className="mb-3 flex items-center justify-between text-white/58">
                   <div>
-                    <div className="text-[0.84rem] font-medium text-white/72">
+                    <div className="text-sm font-medium text-white/72">
                       Equity command center
                     </div>
-                    <div className="mt-1 text-[0.72rem] text-white/42">
+                    <div className="mt-1 text-xs text-white/42">
                       Annual view with peer signal
                     </div>
                   </div>
@@ -174,7 +174,7 @@ function AnalysisRemotionVideo() {
               <div className="mt-7 space-y-4">
                 {rows.map((row, index) => (
                   <div key={row.label}>
-                    <div className="mb-2 grid grid-cols-[1fr_auto_auto] items-center gap-5 text-[0.84rem]">
+                    <div className="mb-2 grid grid-cols-[1fr_auto_auto] items-center gap-5 text-sm">
                       <span className="text-white/58">{row.label}</span>
                       <span className="font-heading font-semibold text-white/92">
                         {row.value}
@@ -217,7 +217,7 @@ function AnalysisRemotionVideo() {
                   }}
                 >
                   <item.icon className="mb-3 size-4 text-teal-100/80" />
-                  <div className="text-[0.7rem] uppercase tracking-[0.12em] text-white/38">
+                  <div className="text-xs uppercase tracking-[0.12em] text-white/38">
                     {item.label}
                   </div>
                   <div className="mt-1 font-heading text-[1rem] font-semibold">
@@ -231,13 +231,13 @@ function AnalysisRemotionVideo() {
 
         <section className="relative min-w-0 border-l border-white/10 pl-12">
           <div className="mb-8">
-            <div className="mb-3 text-[0.7rem] font-medium uppercase tracking-[0.18em] text-white/42">
+            <div className="mb-3 text-xs font-medium uppercase tracking-[0.18em] text-white/42">
               Recursos em movimento
             </div>
             <h4 className="max-w-[25rem] font-heading text-[2.35rem] font-semibold leading-[0.96] tracking-[-0.02em]">
               One calm flow from source data to decision.
             </h4>
-            <p className="mt-4 max-w-[28rem] text-[0.96rem] leading-6 text-white/58">
+            <p className="mt-4 max-w-[28rem] text-base leading-6 text-white/58">
               Busca, demonstracoes, KPIs, comparacao e setores aparecem como uma
               unica trilha de trabalho, sem blocos competindo pela atencao.
             </p>
@@ -266,7 +266,7 @@ function AnalysisRemotionVideo() {
                     }}
                   >
                     <div
-                      className="relative z-10 flex size-10 items-center justify-center rounded-full border bg-[#07110f]"
+                      className="relative z-10 flex size-10 items-center justify-center rounded-full border bg-[var(--background)]"
                       style={{
                         borderColor: isActive ? feature.color : "rgba(255,255,255,0.13)",
                         color: feature.color,
@@ -282,7 +282,7 @@ function AnalysisRemotionVideo() {
                       <div className="font-heading text-[1.04rem] font-semibold leading-tight">
                         {feature.title}
                       </div>
-                      <div className="mt-1 text-[0.84rem] leading-5 text-white/54">
+                      <div className="mt-1 text-sm leading-5 text-white/54">
                         {feature.detail}
                       </div>
                     </div>

--- a/apps/web/components/home/bento-features.tsx
+++ b/apps/web/components/home/bento-features.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 import dynamic from "next/dynamic";
 
@@ -10,7 +10,7 @@ const AnalysisRemotionPlayer = dynamic(
   {
     ssr: false,
     loading: () => (
-      <div className="aspect-video w-full rounded-[1.35rem] bg-[#07110f]" />
+      <div className="aspect-video w-full rounded-[1.35rem] bg-[var(--background)]" />
     ),
   },
 );
@@ -23,12 +23,12 @@ export function BentoFeatures() {
         <h2 className="font-heading text-[clamp(1.75rem,4vw,2.5rem)] font-medium tracking-[-0.035em] text-foreground">
           Tudo que voce precisa para analisar
         </h2>
-        <p className="mx-auto mt-3 max-w-xl text-[0.95rem] leading-relaxed text-muted-foreground">
+        <p className="mx-auto mt-3 max-w-xl text-base leading-relaxed text-muted-foreground">
           Uma leitura unica para descobrir, comparar e aprofundar companhias abertas brasileiras.
         </p>
       </div>
 
-      <div className="aspect-video w-full overflow-hidden rounded-[1.75rem] border border-white/10 bg-[#07110f] shadow-[0_34px_110px_-50px_rgba(7,18,15,0.72)]">
+      <div className="aspect-video w-full overflow-hidden rounded-[1.75rem] border border-white/10 bg-[var(--background)] shadow-[0_34px_110px_-50px_rgba(7,18,15,0.72)]">
         <AnalysisRemotionPlayer />
       </div>
     </section>

--- a/apps/web/components/home/company-search-hero.tsx
+++ b/apps/web/components/home/company-search-hero.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 import { ArrowRightIcon, SearchIcon, XIcon } from "lucide-react";
 import { useDeferredValue, useEffect, useRef, useState, useTransition } from "react";
@@ -102,7 +102,7 @@ export function CompanySearchHero() {
             de quem esta na bolsa.
           </span>
         </h1>
-        <p className="max-w-[560px] mx-auto text-[1.0625rem] leading-[1.55] text-muted-foreground">
+        <p className="max-w-[560px] mx-auto text-lg leading-[1.55] text-muted-foreground">
           Pesquise qualquer companhia aberta brasileira. Leia DRE, balanco e KPIs
           com 10+ anos de historico, direto da CVM.
         </p>
@@ -157,7 +157,7 @@ export function CompanySearchHero() {
 
         {showDropdown ? (
           <div className="absolute inset-x-0 top-full z-20 overflow-hidden rounded-[0_0_1.25rem_1.25rem] border border-t-0 border-ring/50 bg-card shadow-[0_20px_60px_-30px_rgba(16,30,24,0.25)]">
-            <div className="border-t border-border bg-muted/30 px-5 py-1.5 text-[0.7rem] font-medium uppercase tracking-[0.2em] text-muted-foreground">
+            <div className="border-t border-border bg-muted/30 px-5 py-1.5 text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground">
               {loadingSuggestions
                 ? "Buscando..."
                 : suggestionError
@@ -197,7 +197,7 @@ export function CompanySearchHero() {
                       <span className="font-semibold text-sm text-foreground">{item.company_name}</span>
                       {item.ticker_b3 ? (
                         <span
-                          className="font-mono text-[0.7rem] font-medium px-1.5 py-0.5 rounded-[0.35rem]"
+                          className="font-mono text-xs font-medium px-1.5 py-0.5 rounded-[0.35rem]"
                           style={{
                             background: `color-mix(in oklch, ${color} 12%, transparent)`,
                             border: `1px solid color-mix(in oklch, ${color} 25%, transparent)`,
@@ -208,18 +208,18 @@ export function CompanySearchHero() {
                         </span>
                       ) : null}
                     </div>
-                    <p className="text-[0.8rem] text-muted-foreground mt-0.5">
+                    <p className="text-sm text-muted-foreground mt-0.5">
                       {sectorName ?? "Setor nao informado"}
                     </p>
-                    <p className="text-[0.72rem] text-muted-foreground mt-1">
+                    <p className="text-xs text-muted-foreground mt-1">
                       Abra a pagina; se faltar historico local, solicite dados on-demand.
                     </p>
                   </div>
                   <div className="text-right shrink-0">
-                    <p className="text-[0.72rem] uppercase tracking-[0.15em] text-muted-foreground">
+                    <p className="text-xs uppercase tracking-[0.15em] text-muted-foreground">
                       CVM
                     </p>
-                    <p className="mt-0.5 font-mono text-[0.78rem] font-medium text-foreground tabular-nums">
+                    <p className="mt-0.5 font-mono text-sm font-medium text-foreground tabular-nums">
                       {item.cd_cvm}
                     </p>
                   </div>
@@ -231,7 +231,7 @@ export function CompanySearchHero() {
       </div>
 
       <div className="flex flex-wrap justify-center items-center gap-2">
-        <span className="text-[0.8rem] text-muted-foreground">Tente:</span>
+        <span className="text-sm text-muted-foreground">Tente:</span>
         {QUICK_CHIPS.map((chip) => (
           <button
             key={chip}
@@ -240,7 +240,7 @@ export function CompanySearchHero() {
               setQuery(chip);
               setTimeout(() => inputRef.current?.focus(), 0);
             }}
-            className="rounded-full border border-border bg-card px-3 py-1 font-mono text-[0.75rem] text-muted-foreground transition-colors hover:border-primary/35 hover:text-primary"
+            className="rounded-full border border-border bg-card px-3 py-1 font-mono text-xs text-muted-foreground transition-colors hover:border-primary/35 hover:text-primary"
           >
             {chip}
           </button>

--- a/apps/web/components/home/cta-section.tsx
+++ b/apps/web/components/home/cta-section.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+﻿import Link from "next/link";
 import { ArrowRightIcon, GitCompareArrowsIcon } from "lucide-react";
 import { buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -21,12 +21,12 @@ export function CtaSection() {
           <div className="max-w-lg">
             <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/8 px-3 py-1.5">
               <GitCompareArrowsIcon className="size-4 text-primary" />
-              <span className="text-[0.75rem] font-medium text-primary">Comparacao avancada</span>
+              <span className="text-xs font-medium text-primary">Comparacao avancada</span>
             </div>
             <h2 className="font-heading text-[clamp(1.5rem,4vw,2rem)] font-medium tracking-[-0.03em] text-foreground">
               Compare ate 4 empresas lado a lado
             </h2>
-            <p className="mt-3 text-[0.95rem] leading-relaxed text-muted-foreground">
+            <p className="mt-3 text-base leading-relaxed text-muted-foreground">
               KPIs sincronizados, diferencas em destaque, periodos alinhados. 
               Veja onde as empresas divergem em segundos.
             </p>

--- a/apps/web/components/home/discovery-section.tsx
+++ b/apps/web/components/home/discovery-section.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 import Link from "next/link";
 import { useState } from "react";
@@ -69,7 +69,7 @@ function CompanyCard({ co }: { co: CompanyDirectoryItem }) {
         <div className="min-w-0 flex-1">
           <div className="mb-2 flex flex-wrap items-center gap-2">
             <div
-              className="inline-block rounded-[0.35rem] px-1.5 py-0.5 font-mono text-[0.7rem] font-medium"
+              className="inline-block rounded-[0.35rem] px-1.5 py-0.5 font-mono text-xs font-medium"
               style={{
                 background: `color-mix(in oklch, ${color} 12%, transparent)`,
                 border: `1px solid color-mix(in oklch, ${color} 25%, transparent)`,
@@ -80,20 +80,20 @@ function CompanyCard({ co }: { co: CompanyDirectoryItem }) {
             </div>
             <span
               className={cn(
-                "rounded-full border px-2 py-0.5 text-[0.62rem] font-medium uppercase tracking-[0.14em]",
+                "rounded-full border px-2 py-0.5 text-xs font-medium uppercase tracking-[0.14em]",
                 getAvailabilityBadgeClassName(availability.kind),
               )}
             >
               {availability.badge}
             </span>
           </div>
-          <p className="line-clamp-1 text-[0.95rem] font-semibold text-foreground">
+          <p className="line-clamp-1 text-base font-semibold text-foreground">
             {co.company_name}
           </p>
           {co.sector_name ? (
-            <p className="mt-0.5 text-[0.75rem] text-muted-foreground">{co.sector_name}</p>
+            <p className="mt-0.5 text-xs text-muted-foreground">{co.sector_name}</p>
           ) : null}
-          <p className="mt-2 text-[0.78rem] leading-6 text-muted-foreground">
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
             {availability.detail}
           </p>
         </div>
@@ -124,14 +124,14 @@ function CompanyCard({ co }: { co: CompanyDirectoryItem }) {
       </div>
       <div className="flex items-end justify-between border-t border-dashed border-border/60 pt-3">
         <div>
-          <p className="text-[0.65rem] uppercase tracking-[0.15em] text-muted-foreground">
+          <p className="text-xs uppercase tracking-[0.15em] text-muted-foreground">
             Historico local
           </p>
           <p className="mt-0.5 font-mono text-sm font-medium text-foreground tabular-nums">
             {historyLabel}
           </p>
         </div>
-        <div className="flex items-center gap-1 text-[0.8rem] font-medium text-muted-foreground transition-colors group-hover:text-primary">
+        <div className="flex items-center gap-1 text-sm font-medium text-muted-foreground transition-colors group-hover:text-primary">
           <span>{availability.actionLabel}</span>
           <ArrowRightIcon className="size-3.5" />
         </div>
@@ -153,11 +153,11 @@ function DestaquCard({ co, rank }: { co: CompanyDirectoryItem; rank: number }) {
       onClick={() => window.location.assign(`/empresas/${co.cd_cvm}`)}
       className="flex w-full items-center gap-3 rounded-[10px] px-3 py-2.5 text-left transition-colors hover:bg-accent/60"
     >
-      <span className="w-5 shrink-0 font-mono text-[0.8rem] text-muted-foreground tabular-nums">
+      <span className="w-5 shrink-0 font-mono text-sm text-muted-foreground tabular-nums">
         {rank}
       </span>
       <span
-        className="shrink-0 rounded-[0.35rem] px-1.5 py-0.5 font-mono text-[0.7rem] font-medium"
+        className="shrink-0 rounded-[0.35rem] px-1.5 py-0.5 font-mono text-xs font-medium"
         style={{
           background: `color-mix(in oklch, ${color} 12%, transparent)`,
           border: `1px solid color-mix(in oklch, ${color} 25%, transparent)`,
@@ -166,7 +166,7 @@ function DestaquCard({ co, rank }: { co: CompanyDirectoryItem; rank: number }) {
       >
         {co.ticker_b3 ?? `${co.cd_cvm}`}
       </span>
-      <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[0.9rem] text-foreground">
+      <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-sm text-foreground">
         {co.company_name}
       </span>
       {sparkPts ? (
@@ -183,7 +183,7 @@ function DestaquCard({ co, rank }: { co: CompanyDirectoryItem; rank: number }) {
       ) : null}
       <span
         className={cn(
-          "shrink-0 rounded-full border px-2 py-0.5 text-[0.62rem] font-medium uppercase tracking-[0.14em]",
+          "shrink-0 rounded-full border px-2 py-0.5 text-xs font-medium uppercase tracking-[0.14em]",
           getAvailabilityBadgeClassName(availability.kind),
         )}
       >
@@ -203,7 +203,7 @@ export function DiscoverySection({
     <section className="w-full max-w-5xl mx-auto space-y-6 text-left">
       <div className="flex items-end justify-between flex-wrap gap-4">
         <div>
-          <p className="mb-1 text-[0.72rem] font-medium uppercase tracking-[0.26em] text-muted-foreground">
+          <p className="mb-1 text-xs font-medium uppercase tracking-[0.26em] text-muted-foreground">
             Descobrir
           </p>
           <h2 className="font-heading text-[2rem] font-medium leading-tight tracking-[-0.04em] text-foreground">
@@ -221,7 +221,7 @@ export function DiscoverySection({
               type="button"
               onClick={() => setActiveTab(tab.id)}
               className={cn(
-                "rounded-full px-3.5 py-1.5 text-[0.8rem] font-medium transition-all duration-150",
+                "rounded-full px-3.5 py-1.5 text-sm font-medium transition-all duration-150",
                 activeTab === tab.id
                   ? "bg-card text-foreground shadow-sm"
                   : "text-muted-foreground hover:text-foreground",
@@ -249,7 +249,7 @@ export function DiscoverySection({
         <div className="rounded-[1.25rem] border border-border/60 bg-card p-5">
           <div className="mb-3 flex items-center gap-2">
             <TrendingUpIcon className="size-4 text-[color:var(--chart-1)]" />
-            <span className="text-[0.95rem] font-semibold">Mais visitadas</span>
+            <span className="text-base font-semibold">Mais visitadas</span>
           </div>
           <div className="flex flex-col gap-0.5">
             {destaqueCompanies.length > 0 ? (
@@ -282,10 +282,10 @@ export function DiscoverySection({
                 <div className="size-3 rounded-full" style={{ backgroundColor: color }} />
               </div>
               <div className="min-w-0 flex-1">
-                <p className="text-[0.88rem] font-semibold text-foreground leading-tight">
+                <p className="text-sm font-semibold text-foreground leading-tight">
                   {sector}
                 </p>
-                <p className="mt-0.5 text-[0.72rem] text-muted-foreground">Ver empresas</p>
+                <p className="mt-0.5 text-xs text-muted-foreground">Ver empresas</p>
               </div>
             </Link>
           ))}

--- a/apps/web/components/home/stats-strip.tsx
+++ b/apps/web/components/home/stats-strip.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 import { useEffect, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
@@ -60,7 +60,7 @@ function StatItem({ value, suffix, label }: StatItemProps) {
       <span className="font-heading text-[clamp(2rem,5vw,3rem)] font-semibold tracking-tight text-foreground">
         <AnimatedNumber value={value} suffix={suffix} />
       </span>
-      <span className="text-[0.78rem] uppercase tracking-[0.15em] text-muted-foreground">
+      <span className="text-sm uppercase tracking-[0.15em] text-muted-foreground">
         {label}
       </span>
     </div>

--- a/apps/web/components/home/trust-strip.tsx
+++ b/apps/web/components/home/trust-strip.tsx
@@ -1,4 +1,4 @@
-import type { LucideIcon } from "lucide-react";
+﻿import type { LucideIcon } from "lucide-react";
 import { Building2, FileText, BarChart3, Zap } from "lucide-react";
 
 import type { HealthResponse } from "@/lib/api";
@@ -36,10 +36,10 @@ function TrustStat({ icon: Icon, label, value, hint, live }: TrustStatProps) {
             />
           ) : null}
         </div>
-        <p className="mt-0.5 text-[0.72rem] font-medium uppercase tracking-[0.15em] text-muted-foreground">
+        <p className="mt-0.5 text-xs font-medium uppercase tracking-[0.15em] text-muted-foreground">
           {label}
         </p>
-        <p className="mt-0.5 text-[0.72rem] text-muted-foreground/70">{hint}</p>
+        <p className="mt-0.5 text-xs text-muted-foreground/70">{hint}</p>
       </div>
     </div>
   );

--- a/apps/web/components/horizontal-bar-chart.tsx
+++ b/apps/web/components/horizontal-bar-chart.tsx
@@ -1,4 +1,4 @@
-'use client';
+﻿'use client';
 
 import type { JSX } from 'react';
 
@@ -22,17 +22,17 @@ type MetricItem = {
 };
 
 const CATEGORY_DATA: CategoryData[] = [
-  { key: 'Brute Force', value: 100, color: '#9152EE' },
-  { key: 'Web Attack', value: 80, color: '#40D3F4' },
-  { key: 'Malware', value: 120, color: '#40E5D1' },
-  { key: 'Phishing', value: 90, color: '#4C86FF' },
+  { key: 'Brute Force', value: 100, color: 'var(--chart-5)' },
+  { key: 'Web Attack', value: 80, color: 'var(--chart-4)' },
+  { key: 'Malware', value: 120, color: 'var(--chart-1)' },
+  { key: 'Phishing', value: 90, color: 'var(--chart-3)' },
 ];
 
 const MAX_CATEGORY_VALUE = Math.max(...CATEGORY_DATA.map((item) => item.value));
 
 function DiamondAlertIcon({
   className,
-  fill = '#E84045',
+  fill = 'var(--destructive)',
 }: {
   className?: string;
   fill?: string;
@@ -48,7 +48,7 @@ function DiamondAlertIcon({
 
 function CircleAlertIcon({
   className,
-  fill = '#E84045',
+  fill = 'var(--destructive)',
 }: {
   className?: string;
   fill?: string;
@@ -64,7 +64,7 @@ function CircleAlertIcon({
 
 function TriangleAlertIcon({
   className,
-  fill = '#40E5D1',
+  fill = 'var(--chart-1)',
 }: {
   className?: string;
   fill?: string;
@@ -72,8 +72,8 @@ function TriangleAlertIcon({
   return (
     <svg className={className} width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden>
       <path d="M10 2.5 18 17H2L10 2.5Z" fill={fill} />
-      <rect x="9.2" y="7" width="1.6" height="5.8" rx="0.8" fill="#05211D" />
-      <circle cx="10" cy="14.8" r="1" fill="#05211D" />
+      <rect x="9.2" y="7" width="1.6" height="5.8" rx="0.8" fill="var(--background)" />
+      <circle cx="10" cy="14.8" r="1" fill="var(--background)" />
     </svg>
   );
 }
@@ -85,8 +85,8 @@ function TrendBadge({ direction }: { direction: TrendDirection }) {
     <span
       className={
         isUp
-          ? 'inline-flex h-7 w-7 items-center justify-center rounded-full bg-[rgba(232,64,69,0.18)] text-[#F08083]'
-          : 'inline-flex h-7 w-7 items-center justify-center rounded-full bg-[rgba(64,229,209,0.22)] text-[#40E5D1]'
+          ? 'inline-flex h-7 w-7 items-center justify-center rounded-full bg-[rgba(232,64,69,0.18)] text-[var(--destructive)]'
+          : 'inline-flex h-7 w-7 items-center justify-center rounded-full bg-[rgba(64,229,209,0.22)] text-[var(--chart-1)]'
       }
       aria-hidden
     >
@@ -138,11 +138,11 @@ function ChartBar({ item, index }: { item: CategoryData; index: number }) {
       transition={{ delay: 0.05 * index }}
       className="space-y-2"
     >
-      <div className="flex items-center justify-between gap-3 text-xs uppercase tracking-[0.18em] text-neutral-500 dark:text-[#9A9AAF]">
+      <div className="flex items-center justify-between gap-3 text-xs uppercase tracking-[0.18em] text-neutral-500 dark:text-[var(--muted-foreground)]">
         <span>{item.key}</span>
-        <span className="font-mono text-[0.72rem]">{item.value}</span>
+        <span className="font-mono text-xs">{item.value}</span>
       </div>
-      <div className="h-3 overflow-hidden rounded-full bg-neutral-200 dark:bg-[#1A1A23]">
+      <div className="h-3 overflow-hidden rounded-full bg-neutral-200 dark:bg-[var(--muted)]">
         <motion.div
           initial={{ width: 0 }}
           animate={{ width }}
@@ -163,12 +163,12 @@ function IncidentSummaryCard(): JSX.Element {
       </h3>
 
       <div className="flex-grow px-6">
-        <div className="rounded-[1.5rem] border border-neutral-200/80 bg-neutral-50/90 p-5 dark:border-[#1F1F29] dark:bg-[#101018]">
+        <div className="rounded-[1.5rem] border border-neutral-200/80 bg-neutral-50/90 p-5 dark:border-[var(--border)] dark:bg-[var(--card)]">
           <div className="mb-4 flex items-center justify-between">
-            <span className="text-xs font-semibold uppercase tracking-[0.24em] text-neutral-500 dark:text-[#9A9AAF]">
+            <span className="text-xs font-semibold uppercase tracking-[0.24em] text-neutral-500 dark:text-[var(--muted-foreground)]">
               Threat mix
             </span>
-            <span className="rounded-full border border-neutral-200 px-2.5 py-1 text-[0.7rem] font-medium text-neutral-500 dark:border-[#262631] dark:text-[#9A9AAF]">
+            <span className="rounded-full border border-neutral-200 px-2.5 py-1 text-xs font-medium text-neutral-500 dark:border-[var(--muted)] dark:text-[var(--muted-foreground)]">
               Placeholder demo
             </span>
           </div>
@@ -180,7 +180,7 @@ function IncidentSummaryCard(): JSX.Element {
         </div>
       </div>
 
-      <div className="flex flex-col divide-y divide-neutral-200 px-8 pt-8 font-mono dark:divide-[#262631]">
+      <div className="flex flex-col divide-y divide-neutral-200 px-8 pt-8 font-mono dark:divide-[var(--muted)]">
         {METRICS.map((metric) => (
           <motion.div
             key={metric.id}
@@ -189,7 +189,7 @@ function IncidentSummaryCard(): JSX.Element {
             transition={{ delay: metric.delay }}
             className="flex w-full items-center gap-2 pt-4 pb-4"
           >
-            <div className="flex w-1/2 items-center gap-2 text-base text-neutral-500 dark:text-[#9A9AAF]">
+            <div className="flex w-1/2 items-center gap-2 text-base text-neutral-500 dark:text-[var(--muted-foreground)]">
               <metric.icon />
               <span className="truncate" title={metric.label}>
                 {metric.label}

--- a/apps/web/components/leads-data-table.tsx
+++ b/apps/web/components/leads-data-table.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 import { useState } from "react";
 import { motion, AnimatePresence } from "motion/react";
@@ -209,7 +209,7 @@ export function LeadsTable({
       }`}>
         {source}
         {!isOrganic && (
-          <span className="ml-1 text-xs opacity-60">↗</span>
+          <span className="ml-1 text-xs opacity-60">â†—</span>
         )}
       </div>
     );
@@ -270,8 +270,8 @@ export function LeadsTable({
     }).join(' ');
 
     // Better colors for dark mode
-    const upColor = isDark ? "#22c55e" : "#16a34a";   // Softer green for dark mode
-    const downColor = isDark ? "#f87171" : "#dc2626"; // Softer red for dark mode
+    const upColor = isDark ? "var(--chart-1)" : "var(--chart-1)";   // Softer green for dark mode
+    const downColor = isDark ? "var(--destructive)" : "var(--destructive)"; // Softer red for dark mode
 
     return (
       <div className="w-16 h-6">

--- a/apps/web/components/sectors/sector-overview.tsx
+++ b/apps/web/components/sectors/sector-overview.tsx
@@ -1,4 +1,4 @@
-import { Badge } from "@/components/ui/badge";
+﻿import { Badge } from "@/components/ui/badge";
 import {
   Table,
   TableBody,
@@ -49,7 +49,7 @@ export function SectorOverview({ detail }: SectorOverviewProps) {
                   <p className="text-sm text-muted-foreground">{metric.label}</p>
                   <Badge
                     variant="outline"
-                    className="rounded-full border-border/75 bg-background/70 text-[0.68rem] uppercase tracking-[0.16em] text-muted-foreground"
+                    className="rounded-full border-border/75 bg-background/70 text-xs uppercase tracking-[0.16em] text-muted-foreground"
                   >
                     {detail.selected_year}
                   </Badge>

--- a/apps/web/components/shared/design-system-recipes.tsx
+++ b/apps/web/components/shared/design-system-recipes.tsx
@@ -1,4 +1,4 @@
-import type { ComponentPropsWithoutRef, ElementType, ReactNode } from "react";
+﻿import type { ComponentPropsWithoutRef, ElementType, ReactNode } from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
@@ -72,7 +72,7 @@ export function SurfaceCard({
 }
 
 export const infoChipVariants = cva(
-  "inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-[0.68rem] font-medium uppercase tracking-[0.18em]",
+  "inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-medium uppercase tracking-[0.18em]",
   {
     variants: {
       tone: {

--- a/apps/web/components/shared/site-header.tsx
+++ b/apps/web/components/shared/site-header.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 import Link from "next/link";
 import {
@@ -117,9 +117,10 @@ function NavDropdown({ label, items }: DropdownMenuProps) {
         type="button"
         className={cn(
           buttonVariants({ variant: "ghost", size: "sm" }),
-          "rounded-full px-4 text-[0.84rem] text-foreground/78 hover:text-foreground gap-1"
+          "rounded-full px-4 text-sm text-foreground/78 hover:text-foreground gap-1"
         )}
         aria-expanded={open}
+        aria-label={`Abrir menu ${label}`}
       >
         {label}
         <ChevronDownIcon
@@ -141,16 +142,16 @@ function NavDropdown({ label, items }: DropdownMenuProps) {
                   </div>
                   <div className="flex-1">
                     <div className="flex items-center gap-2">
-                      <span className="text-[0.88rem] font-medium text-foreground">
+                      <span className="text-sm font-medium text-foreground">
                         {item.label}
                       </span>
                       {item.soon && (
-                        <span className="rounded-full bg-muted px-1.5 py-0.5 text-[0.58rem] font-medium uppercase tracking-[0.1em] text-muted-foreground">
+                        <span className="rounded-full bg-muted px-1.5 py-0.5 text-xs font-medium uppercase tracking-[0.1em] text-muted-foreground">
                           Em breve
                         </span>
                       )}
                     </div>
-                    <p className="mt-0.5 text-[0.75rem] text-muted-foreground">
+                    <p className="mt-0.5 text-xs text-muted-foreground">
                       {item.description}
                     </p>
                   </div>
@@ -212,7 +213,7 @@ export function SiteHeader() {
               href={item.href}
               className={cn(
                 buttonVariants({ variant: "ghost", size: "sm" }),
-                "rounded-full px-4 text-[0.84rem] text-foreground/78 hover:text-foreground",
+                "rounded-full px-4 text-sm text-foreground/78 hover:text-foreground",
                 pathname === item.href && "bg-muted text-foreground",
               )}
             >
@@ -259,7 +260,7 @@ export function SiteHeader() {
                 href={item.href}
                 className={cn(
                   buttonVariants({ variant: "ghost", size: "sm" }),
-                  "justify-start rounded-2xl px-4 py-3 text-[0.95rem] text-foreground/80",
+                  "justify-start rounded-2xl px-4 py-3 text-base text-foreground/80",
                   pathname === item.href && "bg-muted text-foreground",
                 )}
               >
@@ -269,7 +270,7 @@ export function SiteHeader() {
 
             {/* Mobile Dropdown Sections */}
             <div className="mt-2 border-t border-border/60 pt-4">
-              <p className="mb-2 px-4 text-[0.68rem] font-medium uppercase tracking-[0.2em] text-muted-foreground">
+              <p className="mb-2 px-4 text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground">
                 Analise
               </p>
               {DROPDOWN_ITEMS.analise.map((item) =>
@@ -279,7 +280,7 @@ export function SiteHeader() {
                     href={item.href}
                     className={cn(
                       buttonVariants({ variant: "ghost", size: "sm" }),
-                      "w-full justify-start gap-3 rounded-2xl px-4 py-3 text-[0.95rem] text-foreground/80",
+                      "w-full justify-start gap-3 rounded-2xl px-4 py-3 text-base text-foreground/80",
                     )}
                   >
                     <item.icon className="size-4 text-primary" />
@@ -288,13 +289,13 @@ export function SiteHeader() {
                 ) : (
                   <div
                     key={item.label}
-                    className="flex items-center justify-between rounded-2xl px-4 py-3 text-[0.95rem] text-muted-foreground"
+                    className="flex items-center justify-between rounded-2xl px-4 py-3 text-base text-muted-foreground"
                   >
                     <div className="flex items-center gap-3">
                       <item.icon className="size-4" />
                       <span>{item.label}</span>
                     </div>
-                    <span className="text-[0.68rem] font-medium uppercase tracking-[0.15em]">
+                    <span className="text-xs font-medium uppercase tracking-[0.15em]">
                       Em breve
                     </span>
                   </div>
@@ -303,7 +304,7 @@ export function SiteHeader() {
             </div>
 
             <div className="mt-2 border-t border-border/60 pt-4">
-              <p className="mb-2 px-4 text-[0.68rem] font-medium uppercase tracking-[0.2em] text-muted-foreground">
+              <p className="mb-2 px-4 text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground">
                 Recursos
               </p>
               {DROPDOWN_ITEMS.recursos.map((item) =>
@@ -313,7 +314,7 @@ export function SiteHeader() {
                     href={item.href}
                     className={cn(
                       buttonVariants({ variant: "ghost", size: "sm" }),
-                      "w-full justify-start gap-3 rounded-2xl px-4 py-3 text-[0.95rem] text-foreground/80",
+                      "w-full justify-start gap-3 rounded-2xl px-4 py-3 text-base text-foreground/80",
                     )}
                   >
                     <item.icon className="size-4 text-primary" />
@@ -322,13 +323,13 @@ export function SiteHeader() {
                 ) : (
                   <div
                     key={item.label}
-                    className="flex items-center justify-between rounded-2xl px-4 py-3 text-[0.95rem] text-muted-foreground"
+                    className="flex items-center justify-between rounded-2xl px-4 py-3 text-base text-muted-foreground"
                   >
                     <div className="flex items-center gap-3">
                       <item.icon className="size-4" />
                       <span>{item.label}</span>
                     </div>
-                    <span className="text-[0.68rem] font-medium uppercase tracking-[0.15em]">
+                    <span className="text-xs font-medium uppercase tracking-[0.15em]">
                       Em breve
                     </span>
                   </div>

--- a/apps/web/components/ui/alert.tsx
+++ b/apps/web/components/ui/alert.tsx
@@ -11,6 +11,8 @@ const alertVariants = cva(
         default: "bg-card text-card-foreground",
         destructive:
           "bg-card text-destructive *:data-[slot=alert-description]:text-destructive/90 *:[svg]:text-current",
+        "destructive-soft":
+          "rounded-3xl border-destructive/25 bg-destructive/6 px-5 py-5 text-left text-foreground *:data-[slot=alert-description]:text-muted-foreground *:[svg]:text-destructive",
       },
     },
     defaultVariants: {

--- a/apps/web/components/ui/button.tsx
+++ b/apps/web/components/ui/button.tsx
@@ -1,4 +1,4 @@
-import { Button as ButtonPrimitive } from "@base-ui/react/button"
+﻿import { Button as ButtonPrimitive } from "@base-ui/react/button"
 import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
@@ -23,7 +23,7 @@ const buttonVariants = cva(
         default:
           "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
         xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-sm in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
         lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
         icon: "size-8",
         "icon-xs":

--- a/apps/web/components/update-base/update-base-page.tsx
+++ b/apps/web/components/update-base/update-base-page.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 import {
   AlertTriangleIcon,
@@ -205,7 +205,7 @@ function nowAsLogTime() {
 
 function Eyebrow({ children, className }: { children: React.ReactNode; className?: string }) {
   return (
-    <p className={cn("text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-muted-foreground", className)}>
+    <p className={cn("text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground", className)}>
       {children}
     </p>
   );
@@ -227,7 +227,7 @@ function StatusBadge({
   };
 
   return (
-    <span className={cn("inline-flex items-center rounded-full border px-2.5 py-1 text-[0.62rem] font-semibold uppercase tracking-[0.14em]", styles[tone])}>
+    <span className={cn("inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-semibold uppercase tracking-[0.14em]", styles[tone])}>
       {children}
     </span>
   );
@@ -321,7 +321,7 @@ function AdminSelect({
 }) {
   return (
     <label className="flex flex-col gap-1.5">
-      <span className="text-[0.7rem] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+      <span className="text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">
         {label}
       </span>
       <select
@@ -358,7 +358,7 @@ function AdminInput({
 }) {
   return (
     <label className="flex flex-col gap-1.5">
-      <span className="text-[0.7rem] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+      <span className="text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">
         {label}
       </span>
       <input
@@ -382,7 +382,7 @@ function LogEntry({ line }: { line: LogLine }) {
   };
 
   return (
-    <div className="grid grid-cols-[4rem_1fr] gap-3 py-0.5 font-mono text-[0.75rem] leading-5">
+    <div className="grid grid-cols-[4rem_1fr] gap-3 py-0.5 font-mono text-xs leading-5">
       <span className="text-muted-foreground">{line.time}</span>
       <span className={colors[line.type]}>{line.message}</span>
     </div>
@@ -763,7 +763,7 @@ export function UpdateBasePage() {
                       setAppState(state);
                     }}
                     className={cn(
-                      "rounded-[0.7rem] px-2.5 py-1.5 font-mono text-[0.65rem] transition",
+                      "rounded-[0.7rem] px-2.5 py-1.5 font-mono text-xs transition",
                       appState === state ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground",
                     )}
                   >
@@ -952,7 +952,7 @@ export function UpdateBasePage() {
                             <span
                               key={step}
                               className={cn(
-                                "rounded-full border px-2.5 py-1 font-mono text-[0.68rem]",
+                                "rounded-full border px-2.5 py-1 font-mono text-xs",
                                 currentStep === step
                                   ? "border-primary/35 bg-primary/12 text-primary"
                                   : "border-border/55 text-muted-foreground",


### PR DESCRIPTION
Closes #238

## Summary
- Centralizes destructive-soft alerts in `components/ui/alert.tsx` and replaces duplicated alert styling.
- Normalizes fractional `text-[0.xrem]` classes to standard text tokens across the web app.
- Moves component hex colors to theme variables/tokens and replaces the inline company header gradient with a Tailwind class.
- Uses the shared Badge component for portfolio badge cases and adds aria-labels to the portfolio filter and nav dropdown buttons.

## Validation
- `npm run typecheck` passed
- `npm run lint` passed with 5 existing warnings in unrelated files
- `npm run build` passed
- `npm run test:unit` passed, 93 tests
- `Get-ChildItem -Path apps/web -Recurse -Include *.tsx,*.ts,*.css | Select-String -Pattern 'text-\[0\.\d+rem\]'` returned no matches
- `Get-ChildItem -Path apps/web/components -Recurse -Include *.tsx,*.ts,*.css | Select-String -Pattern '#[0-9A-Fa-f]{6}'` returned no matches
- `git diff --check` passed

## E2E note
- `npm run test:e2e` ran 15 tests: 9 passed, 6 failed. Failures are fixture/data-selector drift outside this visual cleanup: compare received quick suggestions where the test expected zero, sector `ROE` locator is ambiguous, and one company detail smoke expects copy absent in the current API state.
