### PR TITLE
Add batch refresh API

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -18,8 +18,10 @@ from apps.api.app.presenters import ErrorResponsePayload
 from apps.api.app.routes.analytics import router as analytics_router
 from apps.api.app.routes.companies import router as companies_router
 from apps.api.app.routes.health import router as health_router
+from apps.api.app.routes.refresh import router as refresh_router
 from apps.api.app.routes.sectors import router as sectors_router
 from apps.api.app.routes.status import router as status_router
+from apps.api.app.services.refresh_jobs import ApiRefreshJobManager
 from src.database import init_db_tables
 from src.read_service import CVMReadService
 from src.settings import AppSettings, get_settings as get_shared_settings
@@ -49,6 +51,7 @@ def create_app(
     *,
     settings: AppSettings | None = None,
     read_service: CVMReadService | None = None,
+    refresh_job_manager: ApiRefreshJobManager | None = None,
 ) -> FastAPI:
     _init_sentry()
     resolved_settings = settings or get_shared_settings()
@@ -70,6 +73,10 @@ def create_app(
     )
     app.state.settings = resolved_settings
     app.state.read_service = resolved_service
+    app.state.refresh_job_manager = refresh_job_manager or ApiRefreshJobManager(
+        settings=resolved_settings,
+        read_service=resolved_service,
+    )
 
     _raw_origins = os.getenv("ALLOWED_ORIGINS", "http://localhost:3000")
     _allowed_origins = [origin.strip() for origin in _raw_origins.split(",") if origin.strip()]
@@ -137,6 +144,7 @@ def create_app(
     app.include_router(sectors_router)
     app.include_router(status_router)
     app.include_router(analytics_router)
+    app.include_router(refresh_router)
     return app
 
 

--- a/apps/api/app/routes/refresh.py
+++ b/apps/api/app/routes/refresh.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, Path, Request
+from pydantic import BaseModel, Field
+
+from apps.api.app.dependencies import (
+    InvalidRequestError,
+    NotFoundError,
+    ensure_api_ready,
+    get_settings,
+)
+from apps.api.app.services.refresh_jobs import ApiRefreshJobManager, RefreshBatchRequestError
+
+router = APIRouter(prefix="/refresh", tags=["operations"])
+
+
+class RefreshBatchRequestPayload(BaseModel):
+    mode: str = Field(default="missing", description="full, missing, outdated ou failed.")
+    sector_slug: str | None = None
+    cvm_range: dict[str, int] | list[int] | str | None = None
+    status_filter: str | None = None
+    search: str | None = None
+    cd_cvm: int | None = None
+    start_year: int | None = None
+    end_year: int | None = None
+    limit: int | None = Field(default=None, ge=1, le=10000)
+
+
+class RefreshBatchAcceptedPayload(BaseModel):
+    job_id: str | None = None
+    status: str
+    accepted_at: str | None = None
+    queued: int = 0
+    message: str | None = None
+    status_reason_code: str | None = None
+    is_retry_allowed: bool = False
+
+
+class RefreshJobPayload(BaseModel):
+    job_id: str
+    state: str
+    status: str
+    stage: str | None = None
+    queued: int
+    processed: int
+    failures: int
+    current_cvm: int | None = None
+    progress_current: int | None = None
+    progress_total: int | None = None
+    log_lines: list[str]
+    accepted_at: str | None = None
+    started_at: str | None = None
+    finished_at: str | None = None
+    updated_at: str | None = None
+    error: str | None = None
+    result: dict[str, Any] | None = None
+
+
+class RefreshJobListPayload(BaseModel):
+    items: list[RefreshJobPayload]
+
+
+def get_refresh_job_manager(request: Request) -> ApiRefreshJobManager:
+    manager = getattr(request.app.state, "refresh_job_manager", None)
+    if manager is None:
+        raise RuntimeError("refresh_job_manager is not configured")
+    return manager
+
+
+@router.post(
+    "/batch",
+    response_model=RefreshBatchAcceptedPayload,
+    status_code=202,
+    summary="Dispara refresh em lote em background.",
+)
+def request_batch_refresh(
+    payload: RefreshBatchRequestPayload,
+    request: Request,
+    manager: ApiRefreshJobManager = Depends(get_refresh_job_manager),
+) -> RefreshBatchAcceptedPayload:
+    ensure_api_ready(get_settings(request))
+    try:
+        result = manager.request_refresh(payload.model_dump(exclude_none=True))
+    except RefreshBatchRequestError as exc:
+        raise InvalidRequestError(str(exc)) from exc
+    return RefreshBatchAcceptedPayload(**result)
+
+
+@router.get(
+    "/jobs",
+    response_model=RefreshJobListPayload,
+    summary="Lista os jobs ativos de refresh em lote.",
+)
+def list_refresh_jobs(
+    request: Request,
+    manager: ApiRefreshJobManager = Depends(get_refresh_job_manager),
+) -> RefreshJobListPayload:
+    ensure_api_ready(get_settings(request))
+    return RefreshJobListPayload(items=manager.list_jobs(active_only=True))
+
+
+@router.get(
+    "/jobs/{job_id}",
+    response_model=RefreshJobPayload,
+    summary="Retorna o progresso de um job de refresh em lote.",
+)
+def get_refresh_job(
+    request: Request,
+    job_id: str = Path(...),
+    manager: ApiRefreshJobManager = Depends(get_refresh_job_manager),
+) -> RefreshJobPayload:
+    ensure_api_ready(get_settings(request))
+    job = manager.get_job(job_id)
+    if job is None:
+        raise NotFoundError(f"Job de refresh {job_id} nao encontrado.")
+    return RefreshJobPayload(**job)

--- a/apps/api/app/services/__init__.py
+++ b/apps/api/app/services/__init__.py
@@ -1,0 +1,1 @@
+"""Application-local service helpers for the FastAPI app."""

--- a/apps/api/app/services/refresh_jobs.py
+++ b/apps/api/app/services/refresh_jobs.py
@@ -1,0 +1,367 @@
+from __future__ import annotations
+
+import threading
+from datetime import datetime
+from typing import Any
+from uuid import uuid4
+
+from src.contracts import RefreshPolicy, RefreshProgressUpdate, RefreshRequest
+from src.refresh_service import HeadlessRefreshService
+from src.settings import AppSettings
+
+
+class RefreshBatchRequestError(ValueError):
+    """Raised when the batch refresh request is not executable."""
+
+
+class ApiRefreshJobManager:
+    """In-process background queue for API-triggered batch refreshes."""
+
+    VALID_MODES = {"full", "missing", "outdated", "failed"}
+    ACTIVE_STATES = {"queued", "running"}
+    DEFAULT_START_YEAR = 2010
+    MAX_LOG_LINES = 200
+
+    def __init__(
+        self,
+        *,
+        settings: AppSettings,
+        read_service: Any,
+        refresh_service: HeadlessRefreshService | None = None,
+        autostart: bool = True,
+    ) -> None:
+        self.settings = settings
+        self.read_service = read_service
+        self.refresh_service = refresh_service or HeadlessRefreshService(settings=settings)
+        self.autostart = bool(autostart)
+        self._lock = threading.RLock()
+        self._jobs: dict[str, dict[str, Any]] = {}
+        self._threads: dict[str, threading.Thread] = {}
+
+    def request_refresh(self, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        request_params = dict(params or {})
+        mode = str(request_params.get("mode") or "missing").strip().lower()
+        if mode not in self.VALID_MODES:
+            raise RefreshBatchRequestError(f"Modo de refresh invalido: {mode}")
+
+        companies = self._resolve_companies(request_params, mode=mode)
+        start_year, end_year = self._resolve_year_range(request_params)
+        if not companies:
+            now = self._now_iso()
+            return {
+                "status": "already_current",
+                "job_id": None,
+                "accepted_at": now,
+                "queued": 0,
+                "message": "Nenhuma empresa elegivel para refresh.",
+                "status_reason_code": "empty_scope",
+                "is_retry_allowed": False,
+            }
+
+        active_job = self._find_active_job()
+        if active_job is not None:
+            return {
+                "status": "already_running",
+                "job_id": active_job["job_id"],
+                "accepted_at": active_job.get("accepted_at"),
+                "queued": int(active_job.get("queued") or 0),
+                "message": "Ja existe um refresh em andamento.",
+                "status_reason_code": "already_running",
+                "is_retry_allowed": False,
+            }
+
+        job_id = uuid4().hex
+        now = self._now_iso()
+        job = {
+            "job_id": job_id,
+            "state": "queued",
+            "status": "queued",
+            "mode": mode,
+            "accepted_at": now,
+            "created_at": now,
+            "updated_at": now,
+            "started_at": None,
+            "finished_at": None,
+            "queued": len(companies),
+            "processed": 0,
+            "failures": 0,
+            "current_cvm": None,
+            "stage": None,
+            "progress_current": None,
+            "progress_total": None,
+            "log_lines": ["Refresh em lote enfileirado."],
+            "params": request_params,
+            "request": {
+                "companies": [str(company) for company in companies],
+                "start_year": int(start_year),
+                "end_year": int(end_year),
+            },
+            "error": None,
+            "result": None,
+        }
+        with self._lock:
+            self._jobs[job_id] = job
+
+        if self.autostart:
+            self._start_job(job_id)
+
+        return {
+            "status": "running" if self.autostart else "queued",
+            "job_id": job_id,
+            "accepted_at": now,
+            "queued": len(companies),
+            "message": "Refresh em lote iniciado em background.",
+            "status_reason_code": "refresh_started",
+            "is_retry_allowed": False,
+        }
+
+    def get_job(self, job_id: str) -> dict[str, Any] | None:
+        with self._lock:
+            job = self._jobs.get(str(job_id))
+            return self._public_job(job) if job is not None else None
+
+    def list_jobs(self, *, active_only: bool = True) -> list[dict[str, Any]]:
+        with self._lock:
+            jobs = [self._public_job(job) for job in self._jobs.values()]
+        if active_only:
+            jobs = [
+                job for job in jobs if str(job.get("state") or "") in self.ACTIVE_STATES
+            ]
+        jobs.sort(key=lambda row: str(row.get("updated_at") or ""), reverse=True)
+        return jobs
+
+    def _start_job(self, job_id: str) -> None:
+        thread = threading.Thread(
+            target=self._run_job,
+            args=(job_id,),
+            name=f"api-refresh-{job_id[:8]}",
+            daemon=True,
+        )
+        self._threads[job_id] = thread
+        thread.start()
+
+    def _run_job(self, job_id: str) -> None:
+        self._update_job(
+            job_id,
+            state="running",
+            status="running",
+            started_at=self._now_iso(),
+            log_line="Refresh em lote em execucao.",
+        )
+        try:
+            with self._lock:
+                job = dict(self._jobs[job_id])
+            payload = dict(job["request"])
+            mode = str(job.get("mode") or "missing")
+            request = RefreshRequest(
+                companies=tuple(str(company) for company in payload["companies"]),
+                start_year=int(payload["start_year"]),
+                end_year=int(payload["end_year"]),
+                policy=RefreshPolicy(
+                    skip_complete_company_years=mode != "full",
+                    enable_fast_lane=mode == "missing",
+                    force_refresh=mode == "full",
+                ),
+            )
+            result = self.refresh_service.execute(
+                request,
+                progress_callback=lambda current, total, message: self._handle_progress(
+                    job_id,
+                    current=current,
+                    total=total,
+                    message=message,
+                ),
+                stage_callback=lambda update: self._handle_stage(job_id, update),
+            )
+        except Exception as exc:
+            self._update_job(
+                job_id,
+                state="error",
+                status="error",
+                finished_at=self._now_iso(),
+                error=f"{exc.__class__.__name__}: {exc}",
+                log_line=f"Falha no refresh em lote: {exc}",
+            )
+            self._threads.pop(job_id, None)
+            return
+
+        state = "cancelled" if result.cancelled else "success"
+        failures = int(result.error_count)
+        if failures and not result.cancelled:
+            state = "error"
+        self._update_job(
+            job_id,
+            state=state,
+            status=state,
+            processed=len(result.companies),
+            failures=failures,
+            finished_at=self._now_iso(),
+            result=result.to_dict(),
+            log_line="Refresh em lote finalizado.",
+        )
+        self._threads.pop(job_id, None)
+
+    def _resolve_companies(self, params: dict[str, Any], *, mode: str) -> list[str]:
+        cd_cvm = params.get("cd_cvm")
+        if cd_cvm not in (None, ""):
+            return [str(int(cd_cvm))]
+
+        sector_slug = params.get("sector_slug") or params.get("sector")
+        page = self.read_service.list_companies(
+            search=str(params.get("search") or ""),
+            sector_slug=str(sector_slug) if sector_slug else None,
+            page=1,
+            page_size=int(params.get("limit") or 10000),
+        )
+        companies = [str(item.cd_cvm) for item in page.items]
+        companies = self._filter_cvm_range(companies, params.get("cvm_range"))
+
+        status_filter = params.get("status_filter")
+        if mode == "failed" and not status_filter:
+            status_filter = "failed"
+        if status_filter:
+            companies = self._filter_by_status(companies, str(status_filter))
+        return companies
+
+    def _filter_by_status(self, companies: list[str], status_filter: str) -> list[str]:
+        normalized = status_filter.strip().lower()
+        if not normalized or normalized in {"all", "todos"}:
+            return companies
+
+        failed_states = {"failed", "error", "dispatch_failed"}
+        statuses = {
+            int(item.cd_cvm): str(
+                item.tracking_state or item.last_status or item.latest_attempt_outcome or ""
+            ).strip().lower()
+            for item in self.read_service.list_refresh_status()
+        }
+        selected: list[str] = []
+        for raw_code in companies:
+            code = int(raw_code)
+            state = statuses.get(code, "")
+            if normalized == "failed":
+                if state in failed_states:
+                    selected.append(raw_code)
+            elif state == normalized:
+                selected.append(raw_code)
+        return selected
+
+    @staticmethod
+    def _filter_cvm_range(companies: list[str], raw_range: Any) -> list[str]:
+        if raw_range in (None, ""):
+            return companies
+        start: Any | None = None
+        end: Any | None = None
+        if isinstance(raw_range, dict):
+            start = raw_range.get("start") or raw_range.get("from")
+            end = raw_range.get("end") or raw_range.get("to")
+        elif isinstance(raw_range, (list, tuple)) and len(raw_range) >= 2:
+            start, end = raw_range[0], raw_range[1]
+        elif isinstance(raw_range, str) and "-" in raw_range:
+            left, right = raw_range.split("-", 1)
+            start, end = left.strip(), right.strip()
+        if start in (None, "") and end in (None, ""):
+            return companies
+        start_int = int(start) if start not in (None, "") else -1
+        end_int = int(end) if end not in (None, "") else 10**9
+        if start_int > end_int:
+            raise RefreshBatchRequestError("cvm_range.start nao pode ser maior que cvm_range.end.")
+        return [
+            raw_code
+            for raw_code in companies
+            if start_int <= int(raw_code) <= end_int
+        ]
+
+    @classmethod
+    def _resolve_year_range(cls, params: dict[str, Any]) -> tuple[int, int]:
+        end_year = int(params.get("end_year") or datetime.now().year - 1)
+        start_year = int(params.get("start_year") or cls.DEFAULT_START_YEAR)
+        if start_year > end_year:
+            raise RefreshBatchRequestError("start_year nao pode ser maior que end_year.")
+        return start_year, end_year
+
+    def _find_active_job(self) -> dict[str, Any] | None:
+        with self._lock:
+            for job in self._jobs.values():
+                if str(job.get("state") or "") in self.ACTIVE_STATES:
+                    return self._public_job(job)
+        return None
+
+    def _handle_stage(self, job_id: str, update: RefreshProgressUpdate) -> None:
+        self._update_job(
+            job_id,
+            stage=update.stage,
+            progress_current=int(update.current),
+            progress_total=max(1, int(update.total)),
+            log_line=update.message,
+        )
+
+    def _handle_progress(
+        self,
+        job_id: str,
+        *,
+        current: int,
+        total: int,
+        message: str,
+    ) -> None:
+        current_cvm = self._extract_current_cvm(message)
+        self._update_job(
+            job_id,
+            processed=max(0, int(current) - 1),
+            progress_current=int(current),
+            progress_total=max(1, int(total)),
+            current_cvm=current_cvm,
+            log_line=message,
+        )
+
+    @staticmethod
+    def _extract_current_cvm(message: str) -> int | None:
+        for token in str(message or "").replace("=", " ").split():
+            if token.isdigit():
+                return int(token)
+        return None
+
+    def _update_job(self, job_id: str, **changes: Any) -> None:
+        log_line = changes.pop("log_line", None)
+        with self._lock:
+            job = self._jobs.get(job_id)
+            if job is None:
+                return
+            for key, value in changes.items():
+                if value is not None or key in {"current_cvm", "error", "finished_at"}:
+                    job[key] = value
+            job["updated_at"] = self._now_iso()
+            if log_line:
+                self._append_log_locked(job, str(log_line))
+
+    @classmethod
+    def _append_log_locked(cls, job: dict[str, Any], message: str) -> None:
+        log_lines = list(job.get("log_lines") or [])
+        log_lines.append(message)
+        job["log_lines"] = log_lines[-cls.MAX_LOG_LINES :]
+
+    @staticmethod
+    def _public_job(job: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "job_id": job.get("job_id"),
+            "state": job.get("state"),
+            "status": job.get("status") or job.get("state"),
+            "stage": job.get("stage"),
+            "queued": int(job.get("queued") or 0),
+            "processed": int(job.get("processed") or 0),
+            "failures": int(job.get("failures") or 0),
+            "current_cvm": job.get("current_cvm"),
+            "progress_current": job.get("progress_current"),
+            "progress_total": job.get("progress_total"),
+            "log_lines": list(job.get("log_lines") or []),
+            "accepted_at": job.get("accepted_at"),
+            "started_at": job.get("started_at"),
+            "finished_at": job.get("finished_at"),
+            "updated_at": job.get("updated_at"),
+            "error": job.get("error"),
+            "result": job.get("result"),
+        }
+
+    @staticmethod
+    def _now_iso() -> str:
+        return datetime.now().replace(microsecond=0).isoformat()

--- a/apps/api/tests/test_refresh_api.py
+++ b/apps/api/tests/test_refresh_api.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+from apps.api.app.services.refresh_jobs import ApiRefreshJobManager, RefreshBatchRequestError
+from src.settings import AppSettings
+
+
+def _running_job(job_id: str = "job-batch-1") -> dict[str, object]:
+    return {
+        "job_id": job_id,
+        "state": "running",
+        "status": "running",
+        "stage": "download_extract",
+        "queued": 2,
+        "processed": 1,
+        "failures": 0,
+        "current_cvm": 9512,
+        "progress_current": 1,
+        "progress_total": 2,
+        "log_lines": ["Refresh em lote em execucao.", "Processando CVM 9512."],
+        "accepted_at": "2026-05-03T10:00:00",
+        "started_at": "2026-05-03T10:00:01",
+        "finished_at": None,
+        "updated_at": "2026-05-03T10:00:02",
+        "error": None,
+        "result": None,
+    }
+
+
+class FakeRefreshJobManager:
+    def __init__(self) -> None:
+        self.requests: list[dict[str, object]] = []
+        self.active_only_args: list[bool] = []
+        self.jobs = {"job-batch-1": _running_job()}
+
+    def request_refresh(self, params: dict[str, object]) -> dict[str, object]:
+        self.requests.append(dict(params))
+        return {
+            "job_id": "job-batch-1",
+            "status": "running",
+            "accepted_at": "2026-05-03T10:00:00",
+            "queued": 2,
+            "message": "Refresh em lote iniciado em background.",
+            "status_reason_code": "refresh_started",
+            "is_retry_allowed": False,
+        }
+
+    def get_job(self, job_id: str) -> dict[str, object] | None:
+        return self.jobs.get(job_id)
+
+    def list_jobs(self, *, active_only: bool = True) -> list[dict[str, object]]:
+        self.active_only_args.append(active_only)
+        return list(self.jobs.values())
+
+
+def test_refresh_batch_dispatch_returns_202(client: TestClient) -> None:
+    manager = FakeRefreshJobManager()
+    client.app.state.refresh_job_manager = manager
+
+    response = client.post("/refresh/batch", json={"mode": "missing"})
+
+    assert response.status_code == 202
+    payload = response.json()
+    assert payload["job_id"] == "job-batch-1"
+    assert payload["status"] == "running"
+    assert payload["queued"] == 2
+    assert manager.requests == [{"mode": "missing"}]
+
+
+def test_refresh_batch_accepts_bridge_filter_params(client: TestClient) -> None:
+    manager = FakeRefreshJobManager()
+    client.app.state.refresh_job_manager = manager
+
+    response = client.post(
+        "/refresh/batch",
+        json={
+            "mode": "failed",
+            "sector_slug": "energia",
+            "cvm_range": {"start": 4000, "end": 12000},
+            "status_filter": "error",
+            "start_year": 2023,
+            "end_year": 2024,
+        },
+    )
+
+    assert response.status_code == 202
+    assert manager.requests == [
+        {
+            "mode": "failed",
+            "sector_slug": "energia",
+            "cvm_range": {"start": 4000, "end": 12000},
+            "status_filter": "error",
+            "start_year": 2023,
+            "end_year": 2024,
+        }
+    ]
+
+
+def test_refresh_job_polling_returns_progress(client: TestClient) -> None:
+    manager = FakeRefreshJobManager()
+    client.app.state.refresh_job_manager = manager
+
+    response = client.get("/refresh/jobs/job-batch-1")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["state"] == "running"
+    assert payload["processed"] == 1
+    assert payload["failures"] == 0
+    assert payload["current_cvm"] == 9512
+    assert payload["log_lines"][-1] == "Processando CVM 9512."
+
+
+def test_refresh_jobs_lists_active_jobs(client: TestClient) -> None:
+    manager = FakeRefreshJobManager()
+    client.app.state.refresh_job_manager = manager
+
+    response = client.get("/refresh/jobs")
+
+    assert response.status_code == 200
+    assert response.json()["items"][0]["job_id"] == "job-batch-1"
+    assert manager.active_only_args == [True]
+
+
+def test_refresh_job_polling_unknown_id_returns_404(client: TestClient) -> None:
+    manager = FakeRefreshJobManager()
+    client.app.state.refresh_job_manager = manager
+
+    response = client.get("/refresh/jobs/missing-job")
+
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "not_found"
+
+
+class FakeReadService:
+    def __init__(self) -> None:
+        self.list_company_calls: list[dict[str, object]] = []
+
+    def list_companies(self, **kwargs: object) -> SimpleNamespace:
+        self.list_company_calls.append(dict(kwargs))
+        return SimpleNamespace(
+            items=[
+                SimpleNamespace(cd_cvm=9512),
+                SimpleNamespace(cd_cvm=4170),
+                SimpleNamespace(cd_cvm=11223),
+            ]
+        )
+
+    def list_refresh_status(self) -> list[SimpleNamespace]:
+        return [
+            SimpleNamespace(
+                cd_cvm=9512,
+                tracking_state="success",
+                last_status="success",
+                latest_attempt_outcome="success",
+            ),
+            SimpleNamespace(
+                cd_cvm=4170,
+                tracking_state="error",
+                last_status="error",
+                latest_attempt_outcome="error",
+            ),
+            SimpleNamespace(
+                cd_cvm=11223,
+                tracking_state="queued",
+                last_status="queued",
+                latest_attempt_outcome="queued",
+            ),
+        ]
+
+
+def test_refresh_job_manager_reuses_bridge_filter_semantics(api_settings: AppSettings) -> None:
+    read_service = FakeReadService()
+    manager = ApiRefreshJobManager(
+        settings=api_settings,
+        read_service=read_service,
+        autostart=False,
+    )
+
+    result = manager.request_refresh(
+        {
+            "mode": "failed",
+            "sector_slug": "energia",
+            "cvm_range": {"start": 4000, "end": 10000},
+        }
+    )
+
+    assert result["status"] == "queued"
+    assert result["queued"] == 1
+    job = manager._jobs[str(result["job_id"])]
+    assert job["request"]["companies"] == ["4170"]
+    assert read_service.list_company_calls == [
+        {
+            "search": "",
+            "sector_slug": "energia",
+            "page": 1,
+            "page_size": 10000,
+        }
+    ]
+
+
+def test_refresh_job_manager_rejects_invalid_mode(api_settings: AppSettings) -> None:
+    manager = ApiRefreshJobManager(
+        settings=api_settings,
+        read_service=FakeReadService(),
+        autostart=False,
+    )
+
+    with pytest.raises(RefreshBatchRequestError):
+        manager.request_refresh({"mode": "unknown"})

--- a/docs/INTERFACE_MAP.md
+++ b/docs/INTERFACE_MAP.md
@@ -228,17 +228,23 @@ Defaults:
 e simular o fluxo de atualizacao em massa por tipo, filtros, confirmacao,
 progresso, logs, resultados e historico.
 
-**Status**: rota frontend entregue com dados simulados. Nao executa operacao
-real de backend nesta fase.
+**Status**: rota frontend entregue com dados simulados. Backend de refresh em
+lote disponivel para consumo.
 
-**Endpoints consumidos**: nenhum.
+**Endpoints disponiveis para consumo**:
+
+| Endpoint | Params | Para que serve |
+|---|---|---|
+| `POST /refresh/batch` | body `{mode, sector_slug?, cvm_range?, status_filter?}` | Dispara refresh em lote com os filtros do painel |
+| `GET /refresh/jobs` | - | Lista jobs ativos do refresh em lote |
+| `GET /refresh/jobs/{job_id}` | - | Polling de progresso, falhas, CVM atual e logs |
 
 **Notas de implementacao**:
 - a pagina recria o handoff `Update Base.html` como componente React client;
-- os estados de fonte indisponivel, permissao insuficiente e operacao ja em
-  execucao sao simulados na propria tela;
-- quando houver backend dedicado, esta secao deve ser atualizada com os
-  contratos reais de status, start/cancel, progresso e historico.
+- os estados de fonte indisponivel e permissao insuficiente seguem simulados
+  na propria tela ate existir contrato dedicado de auth/roles;
+- a API de batch exposta nesta fase cobre start, lista de jobs ativos e polling
+  de progresso; cancelamento e historico ficam para contrato futuro.
 
 ---
 
@@ -267,6 +273,9 @@ de produto. Nao consome endpoints de API.
 | `GET /sectors` | `/setores` |
 | `GET /sectors/{slug}` | `/setores/[slug]` |
 | `GET /refresh-status` | `/empresas/[cd_cvm]` |
+| `POST /refresh/batch` | `/atualizar-base` |
+| `GET /refresh/jobs` | `/atualizar-base` |
+| `GET /refresh/jobs/{job_id}` | `/atualizar-base` |
 | `GET /base-health` | `/` (parcialmente, se trust strip expandir) |
 
 ---
@@ -311,4 +320,4 @@ for entregue.
 
 ---
 
-_Ultima atualizacao: 2026-05-02 - PG-11 Atualizar Base Admin_
+_Ultima atualizacao: 2026-05-03 - API batch de atualizacao da base_

--- a/docs/V2_API_CONTRACT.md
+++ b/docs/V2_API_CONTRACT.md
@@ -185,6 +185,87 @@ Regras do endpoint:
 - `job_id` so vem preenchido quando `status = queued`
 - o clique do usuario nao dispara mais GitHub Actions; a execucao publica usa fila interna com worker dedicado
 
+### `POST /refresh/batch`
+
+Uso:
+- dispara um refresh em lote em background para o painel administrativo de atualizacao da base
+- reaproveita o mesmo contrato de parametros do bridge desktop
+- o endpoint e aditivo e nao altera o comportamento de `POST /companies/{cd_cvm}/request-refresh`
+
+Body:
+
+```json
+{
+  "mode": "missing",
+  "sector_slug": "energia",
+  "cvm_range": {"start": 4000, "end": 12000},
+  "status_filter": "failed",
+  "start_year": 2023,
+  "end_year": 2024
+}
+```
+
+Resposta exemplo:
+
+```json
+{
+  "job_id": "9d2e08f7bb8e4ef6a9918d859b5ccf5d",
+  "status": "running",
+  "accepted_at": "2026-05-03T10:00:00",
+  "queued": 12,
+  "message": "Refresh em lote iniciado em background.",
+  "status_reason_code": "refresh_started",
+  "is_retry_allowed": false
+}
+```
+
+Regras do endpoint:
+- `202` quando o lote foi aceito, ja esta em execucao, ou nao encontrou empresas elegiveis
+- `mode` aceita `full`, `missing`, `outdated` e `failed`
+- `sector_slug`, `cvm_range`, `status_filter`, `search`, `cd_cvm`, `start_year`, `end_year` e `limit` sao filtros opcionais
+- `mode = failed` aplica `status_filter = failed` quando nenhum filtro de status foi informado
+- `cvm_range` aceita objeto `{start, end}`, objeto `{from, to}`, lista `[start, end]` ou string `"start-end"`
+- a API permite um job de batch ativo por processo; novo disparo durante execucao retorna `already_running` com o `job_id` ativo
+- `job_id` pode vir `null` quando `status = already_current`
+
+### `GET /refresh/jobs`
+
+Uso:
+- lista jobs ativos de refresh em lote (`queued` ou `running`)
+
+Resposta exemplo:
+
+```json
+{
+  "items": [
+    {
+      "job_id": "9d2e08f7bb8e4ef6a9918d859b5ccf5d",
+      "state": "running",
+      "status": "running",
+      "stage": "download_extract",
+      "queued": 12,
+      "processed": 3,
+      "failures": 0,
+      "current_cvm": 9512,
+      "progress_current": 3,
+      "progress_total": 12,
+      "log_lines": ["Refresh em lote em execucao."]
+    }
+  ]
+}
+```
+
+### `GET /refresh/jobs/{job_id}`
+
+Uso:
+- retorna o progresso de um job de refresh em lote
+
+Regras do endpoint:
+- `200` para job conhecido, inclusive em estado final
+- `404` quando o `job_id` nao existe no processo atual
+- campos minimos de progresso: `state`, `processed`, `failures`, `current_cvm`, `log_lines`
+- `state` usa `queued | running | success | error | cancelled`
+
 ### `GET /sectors`
 
 Uso:


### PR DESCRIPTION
﻿## Summary
- Adds `POST /refresh/batch` for filtered background batch refresh dispatch.
- Adds `GET /refresh/jobs` and `GET /refresh/jobs/{job_id}` for active-job listing and polling.
- Documents the additive batch refresh contract in `docs/V2_API_CONTRACT.md` and maps it to PG-11 in `docs/INTERFACE_MAP.md`.

## Compatibilidade
- additive-only API change. Existing `/companies/{cd_cvm}/request-refresh` and `/refresh-status` contracts are unchanged.
- The new batch job registry is process-local; unknown job ids return 404 as documented.

## Validation
- `python -m pytest apps\\api\\tests\\test_refresh_api.py`
- `python -m pytest apps\\api\\tests`

Closes #235
