### PR TITLE
Classify backend governance paths

### DIFF
--- a/.github/guardrails/path-policy.json
+++ b/.github/guardrails/path-policy.json
@@ -39,7 +39,9 @@
       "tests/**",
       "apps/api/tests/**",
       "main.py",
-      "requirements.txt"
+      "requirements.txt",
+      "requirements-dashboard.txt",
+      "migrations/**"
     ],
     "master": [
       "apps/web/**",
@@ -50,7 +52,9 @@
       "tests/**",
       "apps/api/tests/**",
       "main.py",
-      "requirements.txt"
+      "requirements.txt",
+      "requirements-dashboard.txt",
+      "migrations/**"
     ],
     "ops-quality": [
       ".github/**",
@@ -86,6 +90,7 @@
         "README.md",
         "COMO_RODAR.md",
         "docs/AGENTS.md",
+        "docs/INTERFACE_MAP.md",
         "docs/GOVERNANCE_QUICK_REFERENCE.md",
         "docs/governance/**",
         ".claude/launch.json",
@@ -94,6 +99,7 @@
         ".claude/skills/**",
         ".claudeignore",
         "docs/STUDENT_PACK_PLAN.md",
+        "docs/PERF_BASELINE.md",
         ".github/**",
         "skills/**",
         ".gitignore"


### PR DESCRIPTION
## Summary
- Classifies `docs/INTERFACE_MAP.md` and `docs/PERF_BASELINE.md` as shared-governance paths available to backend PRs.
- Allows backend/master tasks to touch `requirements-dashboard.txt` and `migrations/**`.
- Keeps the policy change isolated so backend PRs #248 and the upcoming #239 PR validate against policy already present on `main`.

## Validation
- Parsed `.github/guardrails/path-policy.json` as JSON successfully.

Closes #249

Parent task #235 now lists child task #249 and is marked blocked while this prerequisite is pending.
