### PR TITLE
feat(web): UpdatePrompt modal for desktop auto-updater

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -5,6 +5,7 @@ import { IBM_Plex_Mono, Manrope, Space_Grotesk } from "next/font/google";
 import { Providers } from "@/components/providers";
 import { SiteFooter } from "@/components/shared/site-footer";
 import { SiteHeader } from "@/components/shared/site-header";
+import { UpdatePrompt } from "@/components/update-prompt";
 import "./globals.css";
 
 const bodyFont = Manrope({
@@ -58,6 +59,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
             <main className="flex-1">{children}</main>
             <SiteFooter />
           </div>
+          <UpdatePrompt />
         </Providers>
       </body>
     </html>

--- a/apps/web/components/update-prompt.tsx
+++ b/apps/web/components/update-prompt.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { AlertCircle, ArrowUpCircle, Loader2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  bridgeApplyUpdate,
+  bridgeCheckUpdate,
+  isDesktopMode,
+} from "@/lib/desktop-bridge";
+
+const SNOOZE_KEY = "update-prompt-snooze-until";
+
+function isSnoozed(): boolean {
+  try {
+    const val = localStorage.getItem(SNOOZE_KEY);
+    if (!val) return false;
+    return Date.now() < Number(val);
+  } catch {
+    return false;
+  }
+}
+
+function snooze7Days(): void {
+  try {
+    localStorage.setItem(
+      SNOOZE_KEY,
+      String(Date.now() + 7 * 24 * 60 * 60 * 1000),
+    );
+  } catch {
+    // ignore storage errors
+  }
+}
+
+type ModalState = "closed" | "available" | "updating" | "error";
+
+export function UpdatePrompt() {
+  const [modalState, setModalState] = useState<ModalState>("closed");
+  const [version, setVersion] = useState("");
+
+  useEffect(() => {
+    if (!isDesktopMode()) return;
+    if (isSnoozed()) return;
+
+    bridgeCheckUpdate()
+      .then((result) => {
+        if (result.available) {
+          setVersion(result.version);
+          setModalState("available");
+        }
+      })
+      .catch(() => {
+        // silent — update check failure must not disrupt the user
+      });
+  }, []);
+
+  async function handleUpdate() {
+    setModalState("updating");
+    try {
+      await bridgeApplyUpdate();
+      // app will restart; if we somehow return, close modal
+      setModalState("closed");
+    } catch {
+      setModalState("error");
+    }
+  }
+
+  function handleSnooze() {
+    snooze7Days();
+    setModalState("closed");
+  }
+
+  if (modalState === "closed") return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/55 p-4 backdrop-blur-sm">
+      <Card className="w-full max-w-md rounded-[1.35rem] border-border/70 bg-card">
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center gap-2 text-base">
+            {modalState === "error" ? (
+              <AlertCircle className="size-5 text-destructive" />
+            ) : (
+              <ArrowUpCircle className="size-5 text-primary" />
+            )}
+            {modalState === "error"
+              ? "Falha na atualização"
+              : "Nova versão disponível"}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {(modalState === "available") && (
+            <>
+              <p className="text-sm text-muted-foreground">
+                A versão{" "}
+                <strong className="text-foreground">{version}</strong> está
+                disponível. Deseja atualizar agora?
+              </p>
+              <div className="flex justify-end gap-2">
+                <Button variant="ghost" size="sm" onClick={handleSnooze}>
+                  Lembrar depois
+                </Button>
+                <Button size="sm" onClick={handleUpdate}>
+                  Atualizar agora
+                </Button>
+              </div>
+            </>
+          )}
+          {modalState === "updating" && (
+            <div className="flex items-center gap-3 text-sm text-muted-foreground">
+              <Loader2 className="size-4 animate-spin" />
+              Baixando e instalando atualização…
+            </div>
+          )}
+          {modalState === "error" && (
+            <>
+              <p className="text-sm text-destructive">
+                Não foi possível aplicar a atualização. Tente novamente mais
+                tarde.
+              </p>
+              <div className="flex justify-end">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setModalState("closed")}
+                >
+                  Fechar
+                </Button>
+              </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/lib/desktop-bridge.ts
+++ b/apps/web/lib/desktop-bridge.ts
@@ -57,6 +57,8 @@ interface PywebviewApi {
   get_refresh_status(params?: Record<string, unknown>): Promise<unknown>;
   request_refresh(params: Record<string, unknown>): Promise<unknown>;
   cancel_refresh(params: Record<string, unknown>): Promise<unknown>;
+  check_update(params?: Record<string, unknown>): Promise<unknown>;
+  apply_update(params?: Record<string, unknown>): Promise<unknown>;
 }
 
 // ---------------------------------------------------------------------------
@@ -256,4 +258,18 @@ export async function bridgeCancelRefresh(
   jobId: string,
 ): Promise<{ ok: boolean; message: string }> {
   return callBridge<{ ok: boolean; message: string }>("cancel_refresh", { job_id: jobId });
+}
+
+export type CheckUpdateResponse = {
+  available: boolean;
+  version: string;
+  url: string;
+};
+
+export async function bridgeCheckUpdate(): Promise<CheckUpdateResponse> {
+  return callBridge<CheckUpdateResponse>("check_update", {});
+}
+
+export async function bridgeApplyUpdate(): Promise<void> {
+  await callBridge<unknown>("apply_update", {});
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "eslint",
     "typecheck": "tsc --noEmit",
-    "test:unit": "node --experimental-strip-types --experimental-specifier-resolution=node --test tests/api-client.test.ts tests/companies-page-data.test.ts tests/company-dashboard.test.ts tests/company-detail-handoff.test.ts tests/company-discovery.test.ts tests/company-period-range.test.ts tests/company-refresh-state.test.ts tests/compare-utils.test.ts tests/compare-page-data.test.ts tests/sectors-page-data.test.ts tests/desktop-bridge.test.ts tests/update-base.test.ts",
+    "test:unit": "node --experimental-strip-types --experimental-specifier-resolution=node --test tests/api-client.test.ts tests/companies-page-data.test.ts tests/company-dashboard.test.ts tests/company-detail-handoff.test.ts tests/company-discovery.test.ts tests/company-period-range.test.ts tests/company-refresh-state.test.ts tests/compare-utils.test.ts tests/compare-page-data.test.ts tests/sectors-page-data.test.ts tests/desktop-bridge.test.ts tests/update-base.test.ts tests/update-prompt.test.ts",
     "test:e2e": "playwright test"
   },
   "dependencies": {

--- a/apps/web/tests/update-prompt.test.ts
+++ b/apps/web/tests/update-prompt.test.ts
@@ -1,0 +1,115 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  bridgeCheckUpdate,
+  bridgeApplyUpdate,
+} from "../lib/desktop-bridge.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type PyApi = NonNullable<NonNullable<typeof globalThis.window>["pywebview"]>["api"];
+
+function withPywebview(api: Partial<PyApi>) {
+  const win = globalThis as unknown as {
+    window?: { pywebview?: { api: Partial<PyApi> } };
+  };
+  const prev = win.window;
+  win.window = { pywebview: { api } };
+  return () => {
+    win.window = prev;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// bridgeCheckUpdate
+// ---------------------------------------------------------------------------
+
+test("bridgeCheckUpdate returns available update from bridge", async () => {
+  const restore = withPywebview({
+    check_update: async () => ({ available: true, version: "0.2.0", url: "https://example.com/release" }),
+  } as unknown as PyApi);
+  try {
+    const result = await bridgeCheckUpdate();
+    assert.equal(result.available, true);
+    assert.equal(result.version, "0.2.0");
+  } finally {
+    restore();
+  }
+});
+
+test("bridgeCheckUpdate returns not-available from bridge", async () => {
+  const restore = withPywebview({
+    check_update: async () => ({ available: false, version: "", url: "" }),
+  } as unknown as PyApi);
+  try {
+    const result = await bridgeCheckUpdate();
+    assert.equal(result.available, false);
+  } finally {
+    restore();
+  }
+});
+
+test("bridgeCheckUpdate throws when pywebview is not available", async () => {
+  await assert.rejects(
+    () => bridgeCheckUpdate(),
+    (err: Error) => err.message.includes("pywebview.api indisponível"),
+  );
+});
+
+test("bridgeCheckUpdate propagates bridge error envelope", async () => {
+  const restore = withPywebview({
+    check_update: async () => ({ error: "network_error" }),
+  } as unknown as PyApi);
+  try {
+    await assert.rejects(
+      () => bridgeCheckUpdate(),
+      (err: Error) => err.message.includes("network_error"),
+    );
+  } finally {
+    restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// bridgeApplyUpdate
+// ---------------------------------------------------------------------------
+
+test("bridgeApplyUpdate calls apply_update bridge method", async () => {
+  let called = false;
+  const restore = withPywebview({
+    apply_update: async () => {
+      called = true;
+      return undefined;
+    },
+  } as unknown as PyApi);
+  try {
+    await bridgeApplyUpdate();
+    assert.equal(called, true);
+  } finally {
+    restore();
+  }
+});
+
+test("bridgeApplyUpdate throws when pywebview is not available", async () => {
+  await assert.rejects(
+    () => bridgeApplyUpdate(),
+    (err: Error) => err.message.includes("pywebview.api indisponível"),
+  );
+});
+
+test("bridgeApplyUpdate propagates bridge error envelope", async () => {
+  const restore = withPywebview({
+    apply_update: async () => ({ error: "apply_failed" }),
+  } as unknown as PyApi);
+  try {
+    await assert.rejects(
+      () => bridgeApplyUpdate(),
+      (err: Error) => err.message.includes("apply_failed"),
+    );
+  } finally {
+    restore();
+  }
+});


### PR DESCRIPTION
## Summary

- Adds `UpdatePrompt` component that checks for updates via `window.pywebview.api.check_update()` on mount
- Shows modal with "Atualizar agora" (calls `apply_update()` with progress indicator) and "Lembrar depois" (7-day localStorage snooze)
- No-op when `window.pywebview` is not present (browser mode)
- Mounts in `apps/web/app/layout.tsx` inside `<Providers>` so it's always present in the desktop app
- Extends `desktop-bridge.ts` with `check_update`/`apply_update` bridge entries and `CheckUpdateResponse` type
- 7 new unit tests for bridge functions

## Test plan

- [ ] `npm run test:unit` passes (7 new tests + existing suite)
- [ ] `npm run build` succeeds
- [ ] `npm run lint` passes (no react-hooks/purity violations)
- [ ] Desktop: modal appears when `check_update` returns `available: true`
- [ ] Desktop: "Lembrar depois" sets localStorage snooze for 7 days
- [ ] Browser: component renders null (no pywebview)

Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)