### PR TITLE
chore(ops): classify landing path

### DIFF
--- a/.github/guardrails/path-policy.json
+++ b/.github/guardrails/path-policy.json
@@ -72,6 +72,7 @@
       "CONTRIBUTING.md",
       "README.md",
       "COMO_RODAR.md",
+      "landing/**",
       "pytest.ini",
       "railway.toml",
       "vercel.json",


### PR DESCRIPTION
## Summary
- Classifies `landing/**` under the `ops-quality` lane allowlist.

## Why
- PR #257 for #242 creates `landing/**`.
- The PR guardrail reads `.github/guardrails/path-policy.json` from base `main`, so this policy update must merge before #257 can pass.

## Validation
- `git diff --check`

Closes #258