### PR TITLE
fix(desktop): app local executavel com UI do site

### DIFF
--- a/COMO_RODAR.md
+++ b/COMO_RODAR.md
@@ -1,10 +1,10 @@
 # Como Rodar - CVM Analytics
 
-Guia pratico para subir a V1 operacional e o primeiro slice da V2 no ambiente local.
+Guia pratico para subir o app local oficial e as superficies de desenvolvimento.
 
 Fluxo principal atual:
 
-`runtime_doctor.py -> setup_db.py -> setup_companies_table.py -> python -m desktop.cvm_pyqt_app -> dashboard/app.py -> apps/api -> apps/web`
+`runtime_doctor.py -> setup_db.py -> setup_companies_table.py -> python -m desktop.app --dev -> desktop/build_desktop.ps1 -> dist/CVMAnalytics/CVMAnalytics.exe`
 
 ---
 
@@ -101,13 +101,20 @@ python scripts/expand_tickers.py --dry-run
 ### Opcao A - App desktop oficial
 
 ```powershell
-python -m desktop.cvm_pyqt_app
+python -m desktop.app --dev
 ```
 
-Compatibilidade:
+Para validar o modo distribuivel:
 
 ```powershell
-python desktop/cvm_pyqt_app.py
+.\desktop\build_desktop.ps1
+.\dist\CVMAnalytics\CVMAnalytics.exe
+```
+
+Compatibilidade legada:
+
+```powershell
+python -m desktop.cvm_pyqt_app
 ```
 
 ### Opcao B - CLI pontual
@@ -232,31 +239,22 @@ diretamente, sem precisar do servidor FastAPI para leitura.
 
 ### Modo dev (recomendado para desenvolvimento)
 
-Requer Next.js dev server e FastAPI rodando:
+O comando abaixo inicia ou reutiliza o Next.js dev server em `127.0.0.1:3000`
+e abre a janela pywebview. FastAPI nao e necessario para a leitura local,
+porque o bridge Python responde direto para a UI.
 
 ```powershell
-# Terminal 1 — FastAPI
-uvicorn apps.api.app.main:app --reload
-
-# Terminal 2 — Next.js
-cd apps/web
-npm run dev
-
-# Terminal 3 — janela pywebview
 python -m desktop.app --dev
 ```
 
 ### Modo standalone (sem npm run dev)
 
-Gere o build uma vez; o app sobe o servidor Node.js embutido automaticamente:
+Gere o executavel; o app empacotado sobe o servidor Node.js embutido
+automaticamente:
 
 ```powershell
-# Build (so precisa rodar quando a UI mudar)
-npm --prefix apps/web run build
-# → gera .next/standalone/server.js
-
-# Abrir o app (sem npm run dev, sem FastAPI)
-python -m desktop.app
+.\desktop\build_desktop.ps1
+.\dist\CVMAnalytics\CVMAnalytics.exe
 ```
 
 > O bridge Python responde diretamente no modo standalone; FastAPI nao e necessario
@@ -266,7 +264,7 @@ python -m desktop.app
 
 | Flag | Efeito |
 |---|---|
-| `--dev` | Carrega `http://localhost:3000` (Next.js dev server) |
+| `--dev` | Inicia ou reutiliza `http://127.0.0.1:3000` (Next.js dev server) |
 | `--debug` | Abre DevTools no modo ativo |
 | (nenhuma) | Inicia `.next/standalone/server.js` e carrega o app |
 
@@ -276,10 +274,10 @@ Abra o console do DevTools e execute:
 
 ```javascript
 await window.pywebview.api.ping()
-// → {pong: true, ts: 1234567890.0}
+// => {pong: true, ts: 1234567890.0}
 
 await window.pywebview.api.get_companies({page: 1, page_size: 5})
-// → {items: [...], pagination: {...}}
+// => {items: [...], pagination: {...}}
 ```
 
 ---
@@ -288,7 +286,7 @@ await window.pywebview.api.get_companies({page: 1, page_size: 5})
 
 | O que aconteceu | O que fazer |
 |---|---|
-| `ModuleNotFoundError` ao abrir o desktop | Prefira `python -m desktop.cvm_pyqt_app`; o entrypoint por arquivo tambem deve funcionar no estado atual. |
+| `ModuleNotFoundError` ao abrir o desktop | Prefira `python -m desktop.app --dev`; o PyQt6 (`desktop.cvm_pyqt_app`) e legado. |
 | `python` nao reconhecido | Instale o Python e coloque no `PATH`. |
 | `runtime_doctor.py` falha com `venv-broken` | Recrie a `.venv` com `python -m venv .venv`. |
 | App desktop abre sem empresas | Rode `setup_db.py`, `setup_companies_table.py` e atualize dados. |
@@ -296,5 +294,4 @@ await window.pywebview.api.get_companies({page: 1, page_size: 5})
 | API responde `503` | Valide o banco, tabelas obrigatorias e o `runtime_doctor.py`. |
 | Web app sem dados | Verifique `API_BASE_URL` e se `uvicorn apps.api.app.main:app --reload` esta rodando. |
 | Erro de permissao no PowerShell | Rode `Set-ExecutionPolicy -Scope CurrentUser RemoteSigned`. |
-| Standalone server nao encontrado | Execute `npm --prefix apps/web run build` para gerar `.next/standalone/server.js`. |
 | Servidor standalone nao respondeu | Verifique se `node` esta no PATH e se o build foi concluido com sucesso. |

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # CVM Reports Capture
 
-Projeto para captura, tratamento e consulta de demonstracoes financeiras da CVM, com persistencia em SQLite/PostgreSQL, app desktop operacional em PyQt6, dashboard analitico em Streamlit, API read-only da V2 em FastAPI e primeiro slice web em Next.js.
+Projeto para captura, tratamento e consulta de demonstracoes financeiras da CVM, com persistencia em SQLite/PostgreSQL, app desktop local em pywebview + UI Next.js, dashboard analitico em Streamlit, API read-only da V2 em FastAPI e app web em Next.js. O app PyQt6 continua no repositorio como legado.
 
 > Este repositorio tem proposito duplo: manter o sistema operacional atual funcionando e servir como trilha de aprendizado para evolui-lo rumo a uma web app mais proxima de producao. A direcao da V2 esta registrada em [docs/decisions/0002-student-pack-v2-stack.md](docs/decisions/0002-student-pack-v2-stack.md), [docs/STUDENT_PACK_PLAN.md](docs/STUDENT_PACK_PLAN.md), [docs/WEBAPP_TRANSFORMATION_PLAN.md](docs/WEBAPP_TRANSFORMATION_PLAN.md), [docs/V2_PHASE1_BACKEND.md](docs/V2_PHASE1_BACKEND.md), [docs/V2_API_CONTRACT.md](docs/V2_API_CONTRACT.md) e [docs/V2_PHASE2_WEB_SLICE.md](docs/V2_PHASE2_WEB_SLICE.md).
 
 ## Estrutura principal
 
-- `desktop/cvm_pyqt_app.py`: interface operacional principal para atualizacao local.
+- `desktop/app.py`: app local oficial em pywebview com a UI do site (`apps/web`) e bridge Python local.
+- `desktop/cvm_pyqt_app.py`: interface PyQt6 legada, mantida apenas para fallback operacional.
 - `main.py`: CLI suportada para refresh pontual.
 - `apps/api/`: API `FastAPI` read-only da V2.
 - `apps/web/`: primeiro slice web da V2 em `Next.js`.
@@ -46,13 +47,20 @@ python scripts/setup_db.py
 python scripts/setup_companies_table.py
 ```
 
-5. Atualizar dados:
+5. Abrir o app local oficial:
 
 ```bash
-python -m desktop.cvm_pyqt_app
+python -m desktop.app --dev
 ```
 
-6. Alternativas headless:
+6. Gerar executavel local quando precisar distribuir/validar standalone:
+
+```powershell
+.\desktop\build_desktop.ps1
+.\dist\CVMAnalytics\CVMAnalytics.exe
+```
+
+7. Alternativas headless:
 
 ```bash
 python main.py --companies PETROBRAS --start_year 2021 --end_year 2025 --type consolidated --skip_complete
@@ -60,7 +68,7 @@ python scripts/batch_completo.py --dry-run
 python scripts/atualizar_todos.py --anos 2024 2025
 ```
 
-7. Subir superficies de leitura:
+8. Subir superficies de leitura separadas, quando necessario:
 
 ```bash
 streamlit run dashboard/app.py
@@ -97,13 +105,17 @@ Regras detalhadas:
 
 ## Interfaces oficiais
 
-### 1. App Desktop PyQt6
+### 1. App local desktop
 
-Interface operacional principal para atualizar a base local. Reaproveita `src/refresh_service.py` e concentra ranking, lotes e saude da base.
+Interface principal local. Abre a UI do site (`apps/web`) em uma janela pywebview e usa o bridge Python local para leitura e refresh sem depender da API FastAPI.
 
 ```powershell
-python -m desktop.cvm_pyqt_app
+python -m desktop.app --dev
+.\desktop\build_desktop.ps1
+.\dist\CVMAnalytics\CVMAnalytics.exe
 ```
+
+`desktop/cvm_pyqt_app.py` e legado e deve ser usado apenas como fallback.
 
 ### 2. Dashboard Streamlit
 
@@ -186,8 +198,9 @@ python scripts/db_portability_smoke.py --database-url postgresql://user:pass@hos
 
 ## Observacoes
 
-- Prefira `desktop/cvm_pyqt_app.py` como interface operacional principal.
-- Prefira executar o app desktop como modulo: `python -m desktop.cvm_pyqt_app`.
+- Prefira `desktop/app.py` como app local oficial.
+- Prefira executar o app local como modulo em desenvolvimento: `python -m desktop.app --dev`.
+- `desktop/cvm_pyqt_app.py` e legado; nao o ressuscite como experiencia principal.
 - Prefira `src/refresh_service.py` e `src/read_service.py` como contratos de nucleo.
 - O frontend da V2 deve consumir a API, nao reimplementar queries do `src/`.
 - O dashboard atual continua sendo fallback read-only durante a transicao.

--- a/desktop/app.py
+++ b/desktop/app.py
@@ -2,7 +2,7 @@
 CVM Analytics — entry point pywebview.
 
 Uso:
-  python -m desktop.app --dev    # Next.js dev server em :3000 + FastAPI em :8000
+  python -m desktop.app --dev    # inicia/reusa Next.js dev server em :3000
   python -m desktop.app          # standalone server em .next/standalone/server.js
   python -m desktop.app --debug  # abre DevTools no modo que estiver ativo
 
@@ -25,7 +25,8 @@ import webview
 
 from desktop.bridge import CVMBridge
 
-_DEV_URL = "http://localhost:3000"
+_DEV_PORT = 3000
+_DEV_URL = f"http://127.0.0.1:{_DEV_PORT}"
 _WIDTH, _HEIGHT = 1280, 820
 _BG = "#0a0a0a"
 _STARTUP_TIMEOUT = 15  # segundos — bundle pode demorar mais no primeiro boot
@@ -43,10 +44,14 @@ def _repo_root() -> Path:
     return Path(__file__).parent.parent
 
 
+def _web_dir() -> Path:
+    return _repo_root() / "apps" / "web"
+
+
 def _standalone_path() -> Path:
     if _bundled():
         return _bundle_dir() / "web_standalone" / "server.js"
-    return _repo_root() / "apps" / "web" / ".next" / "standalone" / "server.js"
+    return _web_dir() / ".next" / "standalone" / "server.js"
 
 
 def _node_exe() -> str:
@@ -58,21 +63,55 @@ def _node_exe() -> str:
     return "node"
 
 
+def _npm_cmd() -> str:
+    return "npm.cmd" if os.name == "nt" else "npm"
+
+
 def _free_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("127.0.0.1", 0))
         return s.getsockname()[1]
 
 
+def _port_open(port: int) -> bool:
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+            return True
+    except OSError:
+        return False
+
+
 def _wait_for_port(port: int, timeout: float = _STARTUP_TIMEOUT) -> bool:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        try:
-            with socket.create_connection(("127.0.0.1", port), timeout=0.5):
-                return True
-        except OSError:
-            time.sleep(0.2)
+        if _port_open(port):
+            return True
+        time.sleep(0.2)
     return False
+
+
+def _start_dev_server() -> tuple[subprocess.Popen[bytes], int]:
+    web_dir = _web_dir()
+    if not (web_dir / "package.json").exists():
+        sys.exit(f"[desktop] Web app nao encontrado em {web_dir}.")
+
+    proc = subprocess.Popen(
+        [
+            _npm_cmd(),
+            "run",
+            "dev",
+            "--",
+            "--hostname",
+            "127.0.0.1",
+            "--port",
+            str(_DEV_PORT),
+        ],
+        cwd=str(web_dir),
+        env={**os.environ, "BROWSER": "none"},
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return proc, _DEV_PORT
 
 
 def _start_standalone_server(standalone: Path) -> tuple[subprocess.Popen[bytes], int]:
@@ -95,7 +134,17 @@ def main() -> None:
     server_proc: subprocess.Popen[bytes] | None = None
 
     if dev_mode:
-        url = _DEV_URL
+        if _port_open(_DEV_PORT):
+            url = _DEV_URL
+        else:
+            server_proc, port = _start_dev_server()
+            if not _wait_for_port(port, timeout=30):
+                server_proc.terminate()
+                sys.exit(
+                    f"[desktop] Next.js dev server nao respondeu na porta {port} "
+                    "apos 30s."
+                )
+            url = _DEV_URL
     else:
         standalone = _standalone_path()
         if not standalone.exists():

--- a/desktop/build_desktop.ps1
+++ b/desktop/build_desktop.ps1
@@ -54,15 +54,25 @@ if (-not $SkipNextBuild) {
 Write-Host "[2/5] Injetando versao em desktop/__version__.py..." -ForegroundColor Yellow
 
 if (-not $Version) {
-    $gitTag = (git -C $Root describe --tags --abbrev=0 2>$null)
-    if ($LASTEXITCODE -eq 0 -and $gitTag) {
+    $gitTag = ""
+    $gitDescribeExitCode = 1
+    try {
+        $gitTag = (git -C $Root describe --tags --abbrev=0 2>$null)
+        $gitDescribeExitCode = $LASTEXITCODE
+    } catch {
+        $gitTag = ""
+        $gitDescribeExitCode = 1
+    }
+    if ($gitDescribeExitCode -eq 0 -and $gitTag) {
         $Version = $gitTag -replace '^v', ''
     } else {
         $Version = "0.1.0"
     }
 }
 $VersionPy = Join-Path $DesktopDir "__version__.py"
-"__version__ = `"$Version`"" | Set-Content $VersionPy -Encoding utf8
+$VersionContent = "__version__ = `"$Version`""
+$Utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+[System.IO.File]::WriteAllText($VersionPy, "$VersionContent`n", $Utf8NoBom)
 Write-Host "  OK: versao $Version injetada em __version__.py" -ForegroundColor Green
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #260

## Resumo
- Faz `python -m desktop.app --dev` iniciar ou reutilizar o Next.js dev server em `127.0.0.1:3000` antes de abrir a janela pywebview.
- Corrige `desktop/build_desktop.ps1` para funcionar sem tags Git e escrever `desktop/__version__.py` em UTF-8 sem BOM.
- Atualiza README/COMO_RODAR para documentar `desktop.app` como app local oficial e PyQt6 como legado.

## Validacao local
- `python -m py_compile desktop\\app.py desktop\\bridge.py`
- `python -m pytest tests\\test_bridge_refresh.py -q` (4 passed)
- `npm --prefix apps/web run typecheck`
- `git diff --check`
- `desktop/build_desktop.ps1` (gerou `dist/CVMAnalytics/CVMAnalytics.exe`, ~86 MB)
- Smoke executavel: `EXE_HTTP 200 PORT 58806 LENGTH 65971`
- Smoke dev: `DEV_HTTP 200 LENGTH 92284`

## Observacao
PyInstaller ainda emite warnings opcionais de `sharp/libvips`; o build concluiu e o smoke do standalone respondeu 200.