### PR TITLE
fix(web): align update base refresh contract

### DIFF
--- a/apps/web/app/atualizar-base/page.tsx
+++ b/apps/web/app/atualizar-base/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 
 import { UpdateBasePage } from "@/components/update-base/update-base-page";
+import { fetchCompanyFilters } from "@/lib/api";
 
 export const metadata: Metadata = {
   title: "Atualizar base",
@@ -8,6 +9,7 @@ export const metadata: Metadata = {
     "Painel administrativo para acompanhar e iniciar atualizacoes em massa da base empresarial.",
 };
 
-export default function AtualizarBaseRoute() {
-  return <UpdateBasePage />;
+export default async function AtualizarBaseRoute() {
+  const filters = await fetchCompanyFilters().catch(() => null);
+  return <UpdateBasePage initialSectors={filters?.sectors ?? []} />;
 }

--- a/apps/web/components/update-base/update-base-page.tsx
+++ b/apps/web/components/update-base/update-base-page.tsx
@@ -29,8 +29,10 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 import {
   cancelBatchJob,
+  type CompanySectorFilter,
   fetchBatchJobStatus,
   fetchBatchRefresh,
+  resolveBatchRefreshCvmRange,
 } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
@@ -115,16 +117,6 @@ const UPDATE_TYPE_META: Record<
     icon: RotateCcwIcon,
   },
 };
-
-const SECTORS = [
-  "Todos os setores",
-  "Petroleo e Gas",
-  "Mineracao",
-  "Financeiro",
-  "Energia Eletrica",
-  "Varejo",
-  "Telecomunicacoes",
-];
 
 const STATUS_OPTIONS = [
   { value: "all", label: "Todos os status" },
@@ -434,13 +426,18 @@ function ConfirmationDialog({
   );
 }
 
-export function UpdateBasePage() {
+type UpdateBasePageProps = {
+  initialSectors?: CompanySectorFilter[];
+};
+
+export function UpdateBasePage({ initialSectors = [] }: UpdateBasePageProps) {
   const [appState, setAppState] = useState<AppState>("idle");
   const [updateType, setUpdateType] = useState<UpdateType>("full");
-  const [filterSector, setFilterSector] = useState("Todos os setores");
+  const [filterSector, setFilterSector] = useState("all");
   const [filterStatus, setFilterStatus] = useState("all");
   const [filterCvmFrom, setFilterCvmFrom] = useState("");
   const [filterCvmTo, setFilterCvmTo] = useState("");
+  const [dispatchError, setDispatchError] = useState<string | null>(null);
   const [progress, setProgress] = useState(0);
   const [processed, setProcessed] = useState(0);
   const [successCount, setSuccessCount] = useState(0);
@@ -460,17 +457,36 @@ export function UpdateBasePage() {
   const isCompleted = appState === "completed";
   const canRun = appState === "idle";
   const total = totalFromJob || UPDATE_TYPE_META[updateType].affected;
+  const sectorOptions = useMemo(
+    () => [
+      { value: "all", label: "Todos os setores" },
+      ...initialSectors.map((sector) => ({
+        value: sector.sector_slug,
+        label: `${sector.sector_name} (${formatNumber(sector.company_count)})`,
+      })),
+    ],
+    [initialSectors],
+  );
+  const selectedSector = initialSectors.find(
+    (sector) => sector.sector_slug === filterSector,
+  );
+  const resolvedCvmRange = useMemo(
+    () => resolveBatchRefreshCvmRange(filterCvmFrom, filterCvmTo),
+    [filterCvmFrom, filterCvmTo],
+  );
+  const cvmRangeError = resolvedCvmRange.error;
+  const hasInvalidCvmRange = cvmRangeError !== null;
 
   const activeFilters = useMemo(() => {
     const filters: string[] = [];
-    if (filterSector !== "Todos os setores") filters.push(`Setor: ${filterSector}`);
+    if (selectedSector) filters.push(`Setor: ${selectedSector.sector_name}`);
     if (filterStatus !== "all") {
       filters.push(`Status: ${STATUS_OPTIONS.find((item) => item.value === filterStatus)?.label ?? filterStatus}`);
     }
     if (filterCvmFrom) filters.push(`CVM >= ${filterCvmFrom}`);
     if (filterCvmTo) filters.push(`CVM <= ${filterCvmTo}`);
     return filters;
-  }, [filterCvmFrom, filterCvmTo, filterSector, filterStatus]);
+  }, [filterCvmFrom, filterCvmTo, filterStatus, selectedSector]);
 
   const navItems: NavItem[] = useMemo(
     () => [
@@ -495,9 +511,18 @@ export function UpdateBasePage() {
   }
 
   async function handleConfirm() {
+    const currentRange = resolveBatchRefreshCvmRange(filterCvmFrom, filterCvmTo);
+
+    if (currentRange.error) {
+      setAppState("idle");
+      setDispatchError(currentRange.error);
+      return;
+    }
+
     clearTimer();
     lastLogCountRef.current = 0;
     setAppState("running");
+    setDispatchError(null);
     setProgress(0);
     setProcessed(0);
     setSuccessCount(0);
@@ -516,14 +541,18 @@ export function UpdateBasePage() {
     try {
       dispatch = await fetchBatchRefresh({
         mode: updateType,
-        sector: filterSector !== "Todos os setores" ? filterSector : null,
+        sectorSlug: selectedSector?.sector_slug ?? null,
         statusFilter: filterStatus !== "all" ? filterStatus : null,
-        cvmFrom: filterCvmFrom ? parseInt(filterCvmFrom, 10) : null,
-        cvmTo: filterCvmTo ? parseInt(filterCvmTo, 10) : null,
+        cvmRange: currentRange.cvmRange,
       });
-    } catch {
+    } catch (error) {
       setAppState("source_unavailable");
-      addLog("Falha ao conectar ao servico de atualizacao.", "error");
+      addLog(
+        error instanceof Error
+          ? error.message
+          : "Falha ao conectar ao servico de atualizacao.",
+        "error",
+      );
       return;
     }
 
@@ -619,6 +648,7 @@ export function UpdateBasePage() {
   function handleReset() {
     clearTimer();
     setAppState("idle");
+    setDispatchError(null);
     setProgress(0);
     setProcessed(0);
     setSuccessCount(0);
@@ -627,6 +657,15 @@ export function UpdateBasePage() {
     setCurrentStep("");
     setElapsed(0);
     setLogs([]);
+  }
+
+  function handleStartRequest() {
+    if (cvmRangeError) {
+      setDispatchError(cvmRangeError);
+      return;
+    }
+    setDispatchError(null);
+    setAppState("confirming");
   }
 
   function scrollToSection(id: string) {
@@ -754,24 +793,6 @@ export function UpdateBasePage() {
                   Nova operacao
                 </Button>
               ) : null}
-              <div className="flex rounded-[0.9rem] border border-border/65 bg-muted/35 p-1">
-                {(["idle", "source_unavailable", "no_permission", "already_running"] as AppState[]).map((state) => (
-                  <button
-                    key={state}
-                    type="button"
-                    onClick={() => {
-                      clearTimer();
-                      setAppState(state);
-                    }}
-                    className={cn(
-                      "rounded-[0.7rem] px-2.5 py-1.5 font-mono text-xs transition",
-                      appState === state ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground",
-                    )}
-                  >
-                    {state}
-                  </button>
-                ))}
-              </div>
             </div>
           </header>
 
@@ -856,21 +877,27 @@ export function UpdateBasePage() {
                   variant="ghost"
                   size="sm"
                   onClick={() => {
-                    setFilterSector("Todos os setores");
+                    setFilterSector("all");
                     setFilterStatus("all");
                     setFilterCvmFrom("");
                     setFilterCvmTo("");
+                    setDispatchError(null);
                   }}
                 >
                   Limpar
                 </Button>
               </CardHeader>
               <CardContent className="grid gap-3 px-5 sm:grid-cols-2 xl:grid-cols-4">
-                <AdminSelect label="Setor" value={filterSector} onChange={setFilterSector} options={SECTORS} disabled={!canRun} />
+                <AdminSelect label="Setor" value={filterSector} onChange={setFilterSector} options={sectorOptions} disabled={!canRun || sectorOptions.length === 1} />
                 <AdminSelect label="Status" value={filterStatus} onChange={setFilterStatus} options={STATUS_OPTIONS} disabled={!canRun} />
-                <AdminInput label="Cod. CVM - de" placeholder="Ex: 1000" value={filterCvmFrom} onChange={setFilterCvmFrom} disabled={!canRun} />
-                <AdminInput label="Cod. CVM - ate" placeholder="Ex: 9999" value={filterCvmTo} onChange={setFilterCvmTo} disabled={!canRun} />
+                <AdminInput label="Cod. CVM - de" placeholder="Ex: 1000" value={filterCvmFrom} onChange={(value) => { setFilterCvmFrom(value); setDispatchError(null); }} disabled={!canRun} />
+                <AdminInput label="Cod. CVM - ate" placeholder="Ex: 9999" value={filterCvmTo} onChange={(value) => { setFilterCvmTo(value); setDispatchError(null); }} disabled={!canRun} />
               </CardContent>
+              {dispatchError || hasInvalidCvmRange ? (
+                <div className="mx-5 mb-4 rounded-[0.95rem] border border-destructive/20 bg-destructive/8 px-4 py-3 text-sm text-destructive">
+                  {dispatchError ?? cvmRangeError}
+                </div>
+              ) : null}
               {activeFilters.length ? (
                 <div className="flex items-center gap-2 px-5 pb-4 text-xs text-primary">
                   <FilterIcon className="size-4" />
@@ -881,7 +908,7 @@ export function UpdateBasePage() {
 
             {canRun ? (
               <div className="mt-4 flex flex-wrap items-center gap-3">
-                <Button size="lg" onClick={() => setAppState("confirming")}>
+                <Button size="lg" onClick={handleStartRequest} disabled={hasInvalidCvmRange}>
                   <PlayIcon className="size-4" />
                   Iniciar atualizacao
                 </Button>

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -240,6 +240,60 @@ export type BatchJobStatus = {
   error?: string | null;
 };
 
+export type BatchRefreshMode = "full" | "missing" | "outdated" | "failed";
+
+export type BatchRefreshCvmRange = {
+  start?: number;
+  end?: number;
+};
+
+export type BatchRefreshRequest = {
+  mode: BatchRefreshMode;
+  sectorSlug?: string | null;
+  cvmRange?: BatchRefreshCvmRange | null;
+  statusFilter?: string | null;
+};
+
+function parseCvmRangeInput(value: string): number | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (!/^\d+$/.test(trimmed)) return Number.NaN;
+  return Number(trimmed);
+}
+
+export function resolveBatchRefreshCvmRange(
+  from: string,
+  to: string,
+): { cvmRange: BatchRefreshCvmRange | null; error: string | null } {
+  const start = parseCvmRangeInput(from);
+  const end = parseCvmRangeInput(to);
+
+  if (Number.isNaN(start) || Number.isNaN(end)) {
+    return { cvmRange: null, error: "Use apenas numeros no intervalo CVM." };
+  }
+
+  if ((start != null && start <= 0) || (end != null && end <= 0)) {
+    return { cvmRange: null, error: "O codigo CVM deve ser maior que zero." };
+  }
+
+  if (start != null && end != null && start > end) {
+    return {
+      cvmRange: null,
+      error: "O codigo CVM inicial nao pode ser maior que o final.",
+    };
+  }
+
+  const cvmRange =
+    start != null || end != null
+      ? {
+          ...(start != null ? { start } : {}),
+          ...(end != null ? { end } : {}),
+        }
+      : null;
+
+  return { cvmRange, error: null };
+}
+
 export type TabularDataRow = Record<string, string | number | boolean | null>;
 
 export type TabularData = {
@@ -1280,26 +1334,34 @@ export async function fetchCompanyFreshness(
   return items[0] ? normalizeRefreshStatusItem(items[0]) : null;
 }
 
-export async function fetchBatchRefresh(params: {
-  mode: "full" | "missing" | "outdated" | "failed";
-  sector?: string | null;
-  statusFilter?: string | null;
-  cvmFrom?: number | null;
-  cvmTo?: number | null;
-}): Promise<BatchDispatchResponse> {
+function buildBatchRefreshBody(params: BatchRefreshRequest): Record<string, unknown> {
+  const cvmRange =
+    params.cvmRange &&
+    (params.cvmRange.start != null || params.cvmRange.end != null)
+      ? {
+          ...(params.cvmRange.start != null ? { start: params.cvmRange.start } : {}),
+          ...(params.cvmRange.end != null ? { end: params.cvmRange.end } : {}),
+        }
+      : null;
+
+  return {
+    mode: params.mode,
+    ...(params.sectorSlug ? { sector_slug: params.sectorSlug } : {}),
+    ...(cvmRange ? { cvm_range: cvmRange } : {}),
+    ...(params.statusFilter ? { status_filter: params.statusFilter } : {}),
+  };
+}
+
+export async function fetchBatchRefresh(
+  params: BatchRefreshRequest,
+): Promise<BatchDispatchResponse> {
   if (isDesktopMode()) return bridgeRequestBatchRefresh(params);
   return (await routeFetch<BatchDispatchResponse>(
     "/api/refresh-batch",
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        mode: params.mode,
-        ...(params.sector != null ? { sector: params.sector } : {}),
-        ...(params.statusFilter != null ? { status_filter: params.statusFilter } : {}),
-        ...(params.cvmFrom != null ? { cvm_from: params.cvmFrom } : {}),
-        ...(params.cvmTo != null ? { cvm_to: params.cvmTo } : {}),
-      }),
+      body: JSON.stringify(buildBatchRefreshBody(params)),
     },
     { invalidResponseMessage: "A rota interna retornou um payload invalido para o batch refresh." },
   )) as BatchDispatchResponse;

--- a/apps/web/lib/desktop-bridge.ts
+++ b/apps/web/lib/desktop-bridge.ts
@@ -23,6 +23,7 @@ import type {
   HealthResponse,
   RefreshDispatchResponse,
   RefreshStatusItem,
+  BatchRefreshRequest,
   BatchDispatchResponse,
   BatchJobStatus,
 } from "./api.ts";
@@ -234,19 +235,23 @@ export async function bridgeRequestRefresh(
   });
 }
 
-export async function bridgeRequestBatchRefresh(params: {
-  mode: "full" | "missing" | "outdated" | "failed";
-  sector?: string | null;
-  statusFilter?: string | null;
-  cvmFrom?: number | null;
-  cvmTo?: number | null;
-}): Promise<BatchDispatchResponse> {
+export async function bridgeRequestBatchRefresh(
+  params: BatchRefreshRequest,
+): Promise<BatchDispatchResponse> {
+  const cvmRange =
+    params.cvmRange &&
+    (params.cvmRange.start != null || params.cvmRange.end != null)
+      ? {
+          ...(params.cvmRange.start != null ? { start: params.cvmRange.start } : {}),
+          ...(params.cvmRange.end != null ? { end: params.cvmRange.end } : {}),
+        }
+      : null;
+
   return callBridge<BatchDispatchResponse>("request_refresh", {
     mode: params.mode,
-    ...(params.sector != null ? { sector: params.sector } : {}),
-    ...(params.statusFilter != null ? { status_filter: params.statusFilter } : {}),
-    ...(params.cvmFrom != null ? { cvm_from: params.cvmFrom } : {}),
-    ...(params.cvmTo != null ? { cvm_to: params.cvmTo } : {}),
+    ...(params.sectorSlug ? { sector_slug: params.sectorSlug } : {}),
+    ...(cvmRange ? { cvm_range: cvmRange } : {}),
+    ...(params.statusFilter ? { status_filter: params.statusFilter } : {}),
   });
 }
 

--- a/apps/web/tests/update-base.test.ts
+++ b/apps/web/tests/update-base.test.ts
@@ -5,6 +5,7 @@ import {
   fetchBatchRefresh,
   fetchBatchJobStatus,
   cancelBatchJob,
+  resolveBatchRefreshCvmRange,
 } from "../lib/api.ts";
 import {
   bridgeRequestBatchRefresh,
@@ -79,7 +80,7 @@ test("fetchBatchRefresh (web) posts to /api/refresh-batch and returns dispatch r
   }
 });
 
-test("fetchBatchRefresh (web) passes filters in the request body", async () => {
+test("fetchBatchRefresh (web) passes canonical filters in the request body", async () => {
   let capturedBody: Record<string, unknown> = {};
 
   const restore = withFetchMock((async (_: RequestInfo | URL, init?: RequestInit) => {
@@ -93,16 +94,17 @@ test("fetchBatchRefresh (web) passes filters in the request body", async () => {
   try {
     await fetchBatchRefresh({
       mode: "outdated",
-      sector: "Financeiro",
+      sectorSlug: "financeiro",
       statusFilter: "failed",
-      cvmFrom: 100,
-      cvmTo: 999,
+      cvmRange: { start: 100, end: 999 },
     });
     assert.equal(capturedBody.mode, "outdated");
-    assert.equal(capturedBody.sector, "Financeiro");
+    assert.equal(capturedBody.sector_slug, "financeiro");
     assert.equal(capturedBody.status_filter, "failed");
-    assert.equal(capturedBody.cvm_from, 100);
-    assert.equal(capturedBody.cvm_to, 999);
+    assert.deepEqual(capturedBody.cvm_range, { start: 100, end: 999 });
+    assert.equal("sector" in capturedBody, false);
+    assert.equal("cvm_from" in capturedBody, false);
+    assert.equal("cvm_to" in capturedBody, false);
   } finally {
     restore();
   }
@@ -207,7 +209,7 @@ test("bridgeRequestBatchRefresh calls request_refresh with mode param", async ()
   }
 });
 
-test("bridgeRequestBatchRefresh passes optional filters", async () => {
+test("bridgeRequestBatchRefresh passes canonical optional filters", async () => {
   let capturedParams: Record<string, unknown> = {};
 
   const restore = withPywebview({
@@ -220,15 +222,35 @@ test("bridgeRequestBatchRefresh passes optional filters", async () => {
   try {
     await bridgeRequestBatchRefresh({
       mode: "missing",
-      sector: "Energia Eletrica",
-      cvmFrom: 200,
+      sectorSlug: "energia",
+      statusFilter: "failed",
+      cvmRange: { start: 200 },
     });
-    assert.equal(capturedParams.sector, "Energia Eletrica");
-    assert.equal(capturedParams.cvm_from, 200);
+    assert.equal(capturedParams.sector_slug, "energia");
+    assert.equal(capturedParams.status_filter, "failed");
+    assert.deepEqual(capturedParams.cvm_range, { start: 200 });
+    assert.equal("sector" in capturedParams, false);
+    assert.equal("cvm_from" in capturedParams, false);
     assert.equal("cvm_to" in capturedParams, false);
   } finally {
     restore();
   }
+});
+
+test("resolveBatchRefreshCvmRange blocks invalid client ranges before dispatch", () => {
+  assert.deepEqual(resolveBatchRefreshCvmRange("4000", "12000"), {
+    cvmRange: { start: 4000, end: 12000 },
+    error: null,
+  });
+  assert.deepEqual(resolveBatchRefreshCvmRange("4000", ""), {
+    cvmRange: { start: 4000 },
+    error: null,
+  });
+  assert.equal(resolveBatchRefreshCvmRange("abc", "12000").cvmRange, null);
+  assert.match(
+    resolveBatchRefreshCvmRange("12000", "4000").error ?? "",
+    /inicial nao pode ser maior/i,
+  );
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #261

## Summary
- Aligns Update Base web dispatch body to canonical `{ mode, sector_slug?, cvm_range?, status_filter? }`.
- Aligns desktop bridge batch refresh dispatch to the same canonical payload.
- Loads real sector filter options into `/atualizar-base` and submits sector slugs instead of display labels.
- Blocks invalid CVM ranges on the client before confirmation/dispatch.
- Removes the product-visible demo/debug state selector.

## Validation
- `node --test-isolation=none --test tests/update-base.test.ts` passed, 11 tests.
- `npm run typecheck` passed.
- `npm run lint` passed with 5 existing unrelated warnings.
- `npm run build` passed.
- `npm run test:unit` passed, 111 tests.
- Playwright smoke on `/atualizar-base`: debug state buttons count = 0; sector options use slugs; invalid CVM range disables start and shows validation.
