### PR TITLE
fix(backend): resolve batch refresh modes precisely

### DIFF
--- a/apps/api/app/routes/refresh.py
+++ b/apps/api/app/routes/refresh.py
@@ -19,7 +19,10 @@ router = APIRouter(prefix="/refresh", tags=["operations"])
 class RefreshBatchRequestPayload(BaseModel):
     mode: str = Field(default="missing", description="full, missing, outdated ou failed.")
     sector_slug: str | None = None
-    cvm_range: dict[str, int] | list[int] | str | None = None
+    sector: str | None = None
+    cvm_range: dict[str, Any] | list[Any] | str | None = None
+    cvm_from: int | None = None
+    cvm_to: int | None = None
     status_filter: str | None = None
     search: str | None = None
     cd_cvm: int | None = None

--- a/apps/api/app/services/refresh_jobs.py
+++ b/apps/api/app/services/refresh_jobs.py
@@ -44,8 +44,12 @@ class ApiRefreshJobManager:
         if mode not in self.VALID_MODES:
             raise RefreshBatchRequestError(f"Modo de refresh invalido: {mode}")
 
-        companies = self._resolve_companies(request_params, mode=mode)
-        start_year, end_year = self._resolve_year_range(request_params)
+        try:
+            selection = self._resolve_batch_selection(request_params, mode=mode)
+        except ValueError as exc:
+            raise RefreshBatchRequestError(str(exc)) from exc
+        companies = list(selection.companies)
+        start_year, end_year = selection.start_year, selection.end_year
         if not companies:
             now = self._now_iso()
             return {
@@ -201,27 +205,18 @@ class ApiRefreshJobManager:
         )
         self._threads.pop(job_id, None)
 
-    def _resolve_companies(self, params: dict[str, Any], *, mode: str) -> list[str]:
-        cd_cvm = params.get("cd_cvm")
-        if cd_cvm not in (None, ""):
-            return [str(int(cd_cvm))]
+    def _resolve_batch_selection(self, params: dict[str, Any], *, mode: str):
+        from src.read_service import resolve_refresh_batch_selection  # noqa: PLC0415
 
-        sector_slug = params.get("sector_slug") or params.get("sector")
-        page = self.read_service.list_companies(
-            search=str(params.get("search") or ""),
-            sector_slug=str(sector_slug) if sector_slug else None,
-            page=1,
-            page_size=int(params.get("limit") or 10000),
+        return resolve_refresh_batch_selection(
+            self.read_service,
+            params,
+            mode=mode,
+            default_start_year=self.DEFAULT_START_YEAR,
         )
-        companies = [str(item.cd_cvm) for item in page.items]
-        companies = self._filter_cvm_range(companies, params.get("cvm_range"))
 
-        status_filter = params.get("status_filter")
-        if mode == "failed" and not status_filter:
-            status_filter = "failed"
-        if status_filter:
-            companies = self._filter_by_status(companies, str(status_filter))
-        return companies
+    def _resolve_companies(self, params: dict[str, Any], *, mode: str) -> list[str]:
+        return list(self._resolve_batch_selection(params, mode=mode).companies)
 
     def _filter_by_status(self, companies: list[str], status_filter: str) -> list[str]:
         normalized = status_filter.strip().lower()

--- a/apps/api/tests/test_refresh_api.py
+++ b/apps/api/tests/test_refresh_api.py
@@ -100,6 +100,31 @@ def test_refresh_batch_accepts_bridge_filter_params(client: TestClient) -> None:
     ]
 
 
+def test_refresh_batch_accepts_desktop_bridge_alias_params(client: TestClient) -> None:
+    manager = FakeRefreshJobManager()
+    client.app.state.refresh_job_manager = manager
+
+    response = client.post(
+        "/refresh/batch",
+        json={
+            "mode": "missing",
+            "sector": "energia",
+            "cvm_from": 4000,
+            "cvm_to": 12000,
+        },
+    )
+
+    assert response.status_code == 202
+    assert manager.requests == [
+        {
+            "mode": "missing",
+            "sector": "energia",
+            "cvm_from": 4000,
+            "cvm_to": 12000,
+        }
+    ]
+
+
 def test_refresh_job_polling_returns_progress(client: TestClient) -> None:
     manager = FakeRefreshJobManager()
     client.app.state.refresh_job_manager = manager
@@ -137,21 +162,20 @@ def test_refresh_job_polling_unknown_id_returns_404(client: TestClient) -> None:
 
 
 class FakeReadService:
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        items: list[SimpleNamespace] | None = None,
+        statuses: list[SimpleNamespace] | None = None,
+        complete_years: dict[int, tuple[int, ...]] | None = None,
+    ) -> None:
         self.list_company_calls: list[dict[str, object]] = []
-
-    def list_companies(self, **kwargs: object) -> SimpleNamespace:
-        self.list_company_calls.append(dict(kwargs))
-        return SimpleNamespace(
-            items=[
-                SimpleNamespace(cd_cvm=9512),
-                SimpleNamespace(cd_cvm=4170),
-                SimpleNamespace(cd_cvm=11223),
-            ]
-        )
-
-    def list_refresh_status(self) -> list[SimpleNamespace]:
-        return [
+        self.items = items or [
+            SimpleNamespace(cd_cvm=9512),
+            SimpleNamespace(cd_cvm=4170),
+            SimpleNamespace(cd_cvm=11223),
+        ]
+        self.statuses = statuses or [
             SimpleNamespace(
                 cd_cvm=9512,
                 tracking_state="success",
@@ -171,6 +195,30 @@ class FakeReadService:
                 latest_attempt_outcome="queued",
             ),
         ]
+        self.complete_years = complete_years or {}
+
+    def list_companies(self, **kwargs: object) -> SimpleNamespace:
+        self.list_company_calls.append(dict(kwargs))
+        return SimpleNamespace(items=list(self.items))
+
+    def list_refresh_status(self) -> list[SimpleNamespace]:
+        return list(self.statuses)
+
+    def _load_complete_annual_years_map(
+        self,
+        cd_cvms: list[int],
+        *,
+        start_year: int,
+        end_year: int,
+    ) -> dict[int, tuple[int, ...]]:
+        return {
+            int(cd_cvm): tuple(
+                year
+                for year in self.complete_years.get(int(cd_cvm), ())
+                if int(start_year) <= int(year) <= int(end_year)
+            )
+            for cd_cvm in cd_cvms
+        }
 
 
 def test_refresh_job_manager_reuses_bridge_filter_semantics(api_settings: AppSettings) -> None:
@@ -212,3 +260,258 @@ def test_refresh_job_manager_rejects_invalid_mode(api_settings: AppSettings) -> 
 
     with pytest.raises(RefreshBatchRequestError):
         manager.request_refresh({"mode": "unknown"})
+
+
+def test_refresh_job_manager_resolves_missing_from_real_coverage(
+    api_settings: AppSettings,
+) -> None:
+    read_service = FakeReadService(
+        items=[
+            SimpleNamespace(cd_cvm=100),
+            SimpleNamespace(cd_cvm=200),
+            SimpleNamespace(cd_cvm=300),
+        ],
+        statuses=[],
+        complete_years={
+            100: (2023, 2024),
+            200: (2023,),
+            300: (),
+        },
+    )
+    manager = ApiRefreshJobManager(
+        settings=api_settings,
+        read_service=read_service,
+        autostart=False,
+    )
+
+    result = manager.request_refresh(
+        {"mode": "missing", "start_year": 2023, "end_year": 2024}
+    )
+
+    assert result["queued"] == 2
+    job = manager._jobs[str(result["job_id"])]
+    assert job["request"]["companies"] == ["200", "300"]
+
+
+def test_refresh_job_manager_resolves_full_after_filters_and_limit(
+    api_settings: AppSettings,
+) -> None:
+    read_service = FakeReadService(
+        items=[
+            SimpleNamespace(cd_cvm=100),
+            SimpleNamespace(cd_cvm=200),
+            SimpleNamespace(cd_cvm=300),
+        ],
+        statuses=[],
+    )
+    manager = ApiRefreshJobManager(
+        settings=api_settings,
+        read_service=read_service,
+        autostart=False,
+    )
+
+    result = manager.request_refresh(
+        {
+            "mode": "full",
+            "cvm_range": {"start": 100, "end": 300},
+            "limit": 2,
+        }
+    )
+
+    assert result["queued"] == 2
+    job = manager._jobs[str(result["job_id"])]
+    assert job["request"]["companies"] == ["100", "200"]
+    assert read_service.list_company_calls[0]["page_size"] == 10000
+
+
+def test_refresh_job_manager_composes_cd_cvm_with_explicit_filters(
+    api_settings: AppSettings,
+) -> None:
+    manager = ApiRefreshJobManager(
+        settings=api_settings,
+        read_service=FakeReadService(
+            items=[
+                SimpleNamespace(cd_cvm=100),
+                SimpleNamespace(cd_cvm=200),
+                SimpleNamespace(cd_cvm=300),
+            ],
+            statuses=[],
+        ),
+        autostart=False,
+    )
+
+    result = manager.request_refresh(
+        {
+            "mode": "full",
+            "cd_cvm": 300,
+            "cvm_range": {"start": 100, "end": 250},
+        }
+    )
+
+    assert result["status"] == "already_current"
+    assert result["queued"] == 0
+
+
+def test_refresh_job_manager_resolves_outdated_from_freshness_metadata(
+    api_settings: AppSettings,
+) -> None:
+    read_service = FakeReadService(
+        items=[
+            SimpleNamespace(cd_cvm=100),
+            SimpleNamespace(cd_cvm=200),
+            SimpleNamespace(cd_cvm=300),
+        ],
+        statuses=[
+            SimpleNamespace(
+                cd_cvm=100,
+                tracking_state="success",
+                last_status="success",
+                latest_attempt_outcome="success",
+                freshness_summary_code="refresh_completed_readable",
+                freshness_summary_severity="success",
+                has_readable_current_data=True,
+                latest_readable_year=2024,
+                last_end_year=2024,
+            ),
+            SimpleNamespace(
+                cd_cvm=200,
+                tracking_state="success",
+                last_status="success",
+                latest_attempt_outcome="success",
+                freshness_summary_code="mixed_no_new_data_readable",
+                freshness_summary_severity="warning",
+                has_readable_current_data=True,
+                latest_readable_year=2023,
+                last_end_year=2023,
+            ),
+            SimpleNamespace(
+                cd_cvm=300,
+                tracking_state="error",
+                last_status="error",
+                latest_attempt_outcome="error",
+                is_retry_allowed=True,
+                has_readable_current_data=True,
+                freshness_summary_severity="warning",
+            ),
+        ],
+    )
+    manager = ApiRefreshJobManager(
+        settings=api_settings,
+        read_service=read_service,
+        autostart=False,
+    )
+
+    result = manager.request_refresh(
+        {"mode": "outdated", "start_year": 2023, "end_year": 2024}
+    )
+
+    assert result["queued"] == 1
+    job = manager._jobs[str(result["job_id"])]
+    assert job["request"]["companies"] == ["200"]
+
+
+def test_refresh_job_manager_resolves_failed_retryable_only(
+    api_settings: AppSettings,
+) -> None:
+    read_service = FakeReadService(
+        items=[
+            SimpleNamespace(cd_cvm=100),
+            SimpleNamespace(cd_cvm=200),
+            SimpleNamespace(cd_cvm=300),
+        ],
+        statuses=[
+            SimpleNamespace(
+                cd_cvm=100,
+                tracking_state="error",
+                last_status="error",
+                latest_attempt_outcome="error",
+                is_retry_allowed=True,
+            ),
+            SimpleNamespace(
+                cd_cvm=200,
+                tracking_state="error",
+                last_status="error",
+                latest_attempt_outcome="error",
+                is_retry_allowed=False,
+            ),
+            SimpleNamespace(
+                cd_cvm=300,
+                tracking_state="success",
+                last_status="success",
+                latest_attempt_outcome="success",
+            ),
+        ],
+    )
+    manager = ApiRefreshJobManager(
+        settings=api_settings,
+        read_service=read_service,
+        autostart=False,
+    )
+
+    result = manager.request_refresh({"mode": "failed"})
+
+    assert result["queued"] == 1
+    job = manager._jobs[str(result["job_id"])]
+    assert job["request"]["companies"] == ["100"]
+
+
+@pytest.mark.parametrize(
+    "params, expected_message",
+    [
+        ({"mode": "missing", "start_year": 2025, "end_year": 2024}, "start_year"),
+        (
+            {"mode": "full", "cvm_range": {"start": 200, "end": 100}},
+            "cvm_range.start",
+        ),
+    ],
+)
+def test_refresh_job_manager_rejects_invalid_ranges(
+    api_settings: AppSettings,
+    params: dict[str, object],
+    expected_message: str,
+) -> None:
+    manager = ApiRefreshJobManager(
+        settings=api_settings,
+        read_service=FakeReadService(),
+        autostart=False,
+    )
+
+    with pytest.raises(RefreshBatchRequestError, match=expected_message):
+        manager.request_refresh(params)
+
+
+def test_refresh_batch_invalid_manager_request_returns_422(client: TestClient) -> None:
+    class FailingManager:
+        def request_refresh(self, params: dict[str, object]) -> dict[str, object]:
+            raise RefreshBatchRequestError("start_year nao pode ser maior que end_year.")
+
+    client.app.state.refresh_job_manager = FailingManager()
+
+    response = client.post(
+        "/refresh/batch",
+        json={"mode": "missing", "start_year": 2025, "end_year": 2024},
+    )
+
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "invalid_request"
+    assert "start_year" in response.json()["error"]["message"]
+
+
+def test_refresh_batch_actual_manager_invalid_range_returns_422(
+    client: TestClient,
+    api_settings: AppSettings,
+) -> None:
+    client.app.state.refresh_job_manager = ApiRefreshJobManager(
+        settings=api_settings,
+        read_service=FakeReadService(),
+        autostart=False,
+    )
+
+    response = client.post(
+        "/refresh/batch",
+        json={"mode": "full", "cvm_range": {"start": "200", "end": "100"}},
+    )
+
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "invalid_request"
+    assert "cvm_range.start" in response.json()["error"]["message"]

--- a/desktop/services.py
+++ b/desktop/services.py
@@ -1359,8 +1359,9 @@ class DesktopRefreshJobManager:
             }
 
         try:
-            companies = self._resolve_companies(p, mode=mode)
-            start_year, end_year = self._resolve_year_range(p)
+            selection = self._resolve_batch_selection(p, mode=mode)
+            companies = list(selection.companies)
+            start_year, end_year = selection.start_year, selection.end_year
         except Exception as exc:
             return {
                 "status": "error",
@@ -1538,32 +1539,22 @@ class DesktopRefreshJobManager:
         )
         self._cleanup_job_runtime(job_id)
 
+    def _resolve_batch_selection(self, params: dict[str, Any], *, mode: str):
+        from src.read_service import resolve_refresh_batch_selection  # noqa: PLC0415
+
+        return resolve_refresh_batch_selection(
+            self._read_service(),
+            params,
+            mode=mode,
+            default_start_year=self.DEFAULT_START_YEAR,
+        )
+
     def _cleanup_job_runtime(self, job_id: str) -> None:
         self._threads.pop(job_id, None)
         self._cancel_events.pop(job_id, None)
 
     def _resolve_companies(self, params: dict[str, Any], *, mode: str) -> list[str]:
-        cd_cvm = params.get("cd_cvm")
-        if cd_cvm not in (None, ""):
-            return [str(int(cd_cvm))]
-
-        service = self._read_service()
-        sector_slug = params.get("sector_slug") or params.get("sector")
-        page = service.list_companies(
-            search=str(params.get("search") or ""),
-            sector_slug=str(sector_slug) if sector_slug else None,
-            page=1,
-            page_size=int(params.get("limit") or 10000),
-        )
-        companies = [str(item.cd_cvm) for item in page.items]
-        companies = self._filter_cvm_range(companies, params.get("cvm_range"))
-
-        status_filter = params.get("status_filter")
-        if mode == "failed" and not status_filter:
-            status_filter = "failed"
-        if status_filter:
-            companies = self._filter_by_status(companies, str(status_filter))
-        return companies
+        return list(self._resolve_batch_selection(params, mode=mode).companies)
 
     def _read_service(self):
         if self.read_service is None:

--- a/docs/INTERFACE_MAP.md
+++ b/docs/INTERFACE_MAP.md
@@ -235,7 +235,7 @@ lote disponivel para consumo.
 
 | Endpoint | Params | Para que serve |
 |---|---|---|
-| `POST /refresh/batch` | body `{mode, sector_slug?, cvm_range?, status_filter?}` | Dispara refresh em lote com os filtros do painel |
+| `POST /refresh/batch` | body `{mode, sector_slug?, cvm_range?, status_filter?, search?, cd_cvm?, start_year?, end_year?, limit?}` | Dispara refresh em lote; `full`, `missing`, `outdated` e `failed` resolvem exatamente as empresas elegiveis antes de enfileirar |
 | `GET /refresh/jobs` | - | Lista jobs ativos do refresh em lote |
 | `GET /refresh/jobs/{job_id}` | - | Polling de progresso, falhas, CVM atual e logs |
 
@@ -244,7 +244,8 @@ lote disponivel para consumo.
 - os estados de fonte indisponivel e permissao insuficiente seguem simulados
   na propria tela ate existir contrato dedicado de auth/roles;
 - a API de batch exposta nesta fase cobre start, lista de jobs ativos e polling
-  de progresso; cancelamento e historico ficam para contrato futuro.
+  de progresso; tambem aceita os aliases do bridge desktop (`sector`,
+  `cvm_from`, `cvm_to`); cancelamento e historico ficam para contrato futuro.
 
 ---
 
@@ -320,4 +321,4 @@ for entregue.
 
 ---
 
-_Ultima atualizacao: 2026-05-03 - API batch de atualizacao da base_
+_Ultima atualizacao: 2026-05-04 - API batch de atualizacao da base_

--- a/docs/V2_API_CONTRACT.md
+++ b/docs/V2_API_CONTRACT.md
@@ -223,8 +223,15 @@ Regras do endpoint:
 - `202` quando o lote foi aceito, ja esta em execucao, ou nao encontrou empresas elegiveis
 - `mode` aceita `full`, `missing`, `outdated` e `failed`
 - `sector_slug`, `cvm_range`, `status_filter`, `search`, `cd_cvm`, `start_year`, `end_year` e `limit` sao filtros opcionais
-- `mode = failed` aplica `status_filter = failed` quando nenhum filtro de status foi informado
+- para equivalencia com o bridge desktop, `sector` e aceito como alias de `sector_slug`, e `cvm_from`/`cvm_to` como alias de `cvm_range`
+- os filtros sao compostos antes da regra do `mode`; `limit` corta a lista final ja resolvida
+- `mode = full` enfileira todas as empresas restantes depois dos filtros explicitos
+- `mode = missing` enfileira apenas empresas com lacuna real de cobertura anual completa (`BPA`, `BPP`, `DRE`, `DFC`) dentro de `start_year`/`end_year`
+- `mode = outdated` enfileira apenas empresas marcadas como desatualizadas pelos metadados de freshness/status ja existentes
+- `mode = failed` aplica `status_filter = failed` quando nenhum filtro de status foi informado e enfileira somente falhas retryable
 - `cvm_range` aceita objeto `{start, end}`, objeto `{from, to}`, lista `[start, end]` ou string `"start-end"`
+- `cvm_range.start > cvm_range.end`, `start_year > end_year`, `cd_cvm` invalido e `limit` fora de `1..10000` retornam `422 invalid_request`
+- `queued` e sempre igual ao numero de empresas resolvidas para o job
 - a API permite um job de batch ativo por processo; novo disparo durante execucao retorna `already_running` com o `job_id` ativo
 - `job_id` pode vir `null` quando `status = already_current`
 

--- a/src/contracts.py
+++ b/src/contracts.py
@@ -70,6 +70,29 @@ class RefreshRequest:
 
 
 @dataclass(frozen=True)
+class RefreshBatchSelection:
+    mode: str
+    companies: tuple[str, ...]
+    start_year: int
+    end_year: int
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "mode", str(self.mode).strip().lower())
+        object.__setattr__(
+            self,
+            "companies",
+            tuple(str(company) for company in self.companies),
+        )
+        object.__setattr__(self, "start_year", int(self.start_year))
+        object.__setattr__(self, "end_year", int(self.end_year))
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["companies"] = list(self.companies)
+        return payload
+
+
+@dataclass(frozen=True)
 class CompanyRefreshResult:
     company_name: str
     cvm_code: int

--- a/src/read_service.py
+++ b/src/read_service.py
@@ -30,6 +30,7 @@ from src.contracts import (
     KPIBundle,
     RankedRefreshQueueItem,
     RankedRefreshQueueResult,
+    RefreshBatchSelection,
     RefreshDispatchDTO,
     RefreshPolicy,
     RefreshRequest,
@@ -100,6 +101,405 @@ def _parse_years(raw_years: str | None) -> tuple[int, ...]:
     return tuple(sorted(set(result)))
 
 
+BATCH_REFRESH_VALID_MODES = {"full", "missing", "outdated", "failed"}
+BATCH_REFRESH_FAILED_STATES = {"failed", "error", "dispatch_failed"}
+BATCH_REFRESH_ACTIVE_STATES = {"queued", "running"}
+BATCH_REFRESH_CURRENT_CODES = {
+    "already_current",
+    "local_data_ready",
+    "readable_history_available",
+    "refresh_completed",
+    "refresh_completed_readable",
+}
+BATCH_REFRESH_OUTDATED_CODES = {
+    "mixed_retryable_error_readable",
+    "mixed_refresh_stalled_readable",
+    "mixed_no_new_data_readable",
+    "refresh_completed_no_readable",
+}
+BATCH_REFRESH_MAX_PAGE_SIZE = 10000
+
+
+def resolve_refresh_batch_selection(
+    read_service: Any,
+    params: dict[str, Any] | None = None,
+    *,
+    mode: str = "missing",
+    default_start_year: int = 2010,
+    max_page_size: int = BATCH_REFRESH_MAX_PAGE_SIZE,
+) -> RefreshBatchSelection:
+    """Resolve the exact company queue for API and desktop batch refreshes."""
+
+    request_params = dict(params or {})
+    normalized_mode = str(mode or "missing").strip().lower()
+    if normalized_mode not in BATCH_REFRESH_VALID_MODES:
+        raise ValueError(f"Modo de refresh invalido: {normalized_mode}")
+
+    start_year, end_year = _resolve_batch_year_range(
+        request_params,
+        default_start_year=default_start_year,
+    )
+    limit = _resolve_batch_limit(request_params.get("limit"))
+    companies = _load_batch_candidate_companies(
+        read_service,
+        request_params,
+        page_size=max(1, min(int(max_page_size), BATCH_REFRESH_MAX_PAGE_SIZE)),
+    )
+    companies = _filter_batch_cvm_range(
+        companies,
+        _resolve_batch_cvm_range_param(request_params),
+    )
+    companies = _filter_batch_cd_cvm(companies, request_params.get("cd_cvm"))
+
+    status_items = _load_batch_refresh_status_map(read_service)
+    status_filter = request_params.get("status_filter")
+    if normalized_mode == "failed" and not status_filter:
+        status_filter = "failed"
+    if status_filter:
+        companies = _filter_batch_status(companies, status_items, str(status_filter))
+
+    if normalized_mode == "missing":
+        companies = _filter_batch_missing_companies(
+            read_service,
+            companies,
+            start_year=start_year,
+            end_year=end_year,
+        )
+    elif normalized_mode == "outdated":
+        companies = _filter_batch_outdated_companies(
+            companies,
+            status_items,
+            end_year=end_year,
+        )
+    elif normalized_mode == "failed":
+        companies = _filter_batch_failed_companies(companies, status_items)
+
+    if limit is not None:
+        companies = companies[:limit]
+
+    return RefreshBatchSelection(
+        mode=normalized_mode,
+        companies=tuple(companies),
+        start_year=start_year,
+        end_year=end_year,
+    )
+
+
+def _resolve_batch_year_range(
+    params: dict[str, Any],
+    *,
+    default_start_year: int,
+) -> tuple[int, int]:
+    end_default = datetime.now(timezone.utc).year - 1
+    try:
+        start_year = int(params.get("start_year") or default_start_year)
+        end_year = int(params.get("end_year") or end_default)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("start_year e end_year devem ser inteiros.") from exc
+    if start_year > end_year:
+        raise ValueError("start_year nao pode ser maior que end_year.")
+    return start_year, end_year
+
+
+def _resolve_batch_limit(raw_limit: Any) -> int | None:
+    if raw_limit in (None, ""):
+        return None
+    try:
+        limit = int(raw_limit)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("limit deve ser um inteiro entre 1 e 10000.") from exc
+    if limit < 1 or limit > BATCH_REFRESH_MAX_PAGE_SIZE:
+        raise ValueError("limit deve ser um inteiro entre 1 e 10000.")
+    return limit
+
+
+def _load_batch_candidate_companies(
+    read_service: Any,
+    params: dict[str, Any],
+    *,
+    page_size: int,
+) -> list[str]:
+    sector_slug = params.get("sector_slug") or params.get("sector")
+    page = read_service.list_companies(
+        search=str(params.get("search") or ""),
+        sector_slug=str(sector_slug) if sector_slug else None,
+        page=1,
+        page_size=int(page_size),
+    )
+    return _unique_company_codes(getattr(page, "items", ()))
+
+
+def _unique_company_codes(items: Any) -> list[str]:
+    companies: list[str] = []
+    seen: set[int] = set()
+    for item in items:
+        cd_cvm = _get_batch_attr(item, "cd_cvm")
+        try:
+            code = int(cd_cvm)
+        except (TypeError, ValueError):
+            continue
+        if code in seen:
+            continue
+        seen.add(code)
+        companies.append(str(code))
+    return companies
+
+
+def _resolve_batch_cvm_range_param(params: dict[str, Any]) -> Any:
+    raw_range = params.get("cvm_range")
+    if raw_range not in (None, ""):
+        return raw_range
+    cvm_from = params.get("cvm_from")
+    cvm_to = params.get("cvm_to")
+    if cvm_from not in (None, "") or cvm_to not in (None, ""):
+        return {"start": cvm_from, "end": cvm_to}
+    return None
+
+
+def _filter_batch_cvm_range(companies: list[str], raw_range: Any) -> list[str]:
+    if raw_range in (None, ""):
+        return companies
+
+    start: Any | None = None
+    end: Any | None = None
+    if isinstance(raw_range, dict):
+        start = raw_range.get("start") or raw_range.get("from")
+        end = raw_range.get("end") or raw_range.get("to")
+    elif isinstance(raw_range, (list, tuple)):
+        if len(raw_range) != 2:
+            raise ValueError("cvm_range deve conter exatamente dois limites.")
+        start, end = raw_range[0], raw_range[1]
+    elif isinstance(raw_range, str):
+        if "-" not in raw_range:
+            raise ValueError(
+                "cvm_range deve usar {start,end}, [start,end] ou 'start-end'."
+            )
+        left, right = raw_range.split("-", 1)
+        start, end = left.strip(), right.strip()
+    else:
+        raise ValueError(
+            "cvm_range deve usar {start,end}, [start,end] ou 'start-end'."
+        )
+
+    if start in (None, "") and end in (None, ""):
+        return companies
+    try:
+        start_int = int(start) if start not in (None, "") else -1
+        end_int = int(end) if end not in (None, "") else 10**9
+    except (TypeError, ValueError) as exc:
+        raise ValueError("cvm_range deve conter numeros inteiros.") from exc
+    if start_int > end_int:
+        raise ValueError("cvm_range.start nao pode ser maior que cvm_range.end.")
+    return [code for code in companies if start_int <= int(code) <= end_int]
+
+
+def _filter_batch_cd_cvm(companies: list[str], raw_cd_cvm: Any) -> list[str]:
+    if raw_cd_cvm in (None, ""):
+        return companies
+    try:
+        target = int(raw_cd_cvm)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("cd_cvm deve ser um inteiro.") from exc
+    return [code for code in companies if int(code) == target]
+
+
+def _load_batch_refresh_status_map(read_service: Any) -> dict[int, Any]:
+    try:
+        statuses = read_service.list_refresh_status()
+    except AttributeError:
+        return {}
+    return {
+        int(_get_batch_attr(item, "cd_cvm")): item
+        for item in statuses
+        if _get_batch_attr(item, "cd_cvm") is not None
+    }
+
+
+def _filter_batch_status(
+    companies: list[str],
+    status_items: dict[int, Any],
+    status_filter: str,
+) -> list[str]:
+    normalized = str(status_filter or "").strip().lower()
+    if not normalized or normalized in {"all", "todos"}:
+        return companies
+    return [
+        code
+        for code in companies
+        if _batch_status_matches(status_items.get(int(code)), normalized)
+    ]
+
+
+def _batch_status_matches(status_item: Any, normalized_filter: str) -> bool:
+    if status_item is None:
+        return normalized_filter in {"missing", "idle"}
+    if normalized_filter == "failed":
+        return _batch_status_has_failure(status_item)
+    if normalized_filter == "outdated":
+        return _batch_status_is_outdated(status_item, end_year=None)
+    if normalized_filter in {"active", "ativo"}:
+        return bool(_batch_status_values(status_item) & BATCH_REFRESH_ACTIVE_STATES)
+    if normalized_filter in {"missing", "sem_dados"}:
+        return not bool(_get_batch_attr(status_item, "has_readable_current_data"))
+    return normalized_filter in _batch_status_values(status_item)
+
+
+def _filter_batch_missing_companies(
+    read_service: Any,
+    companies: list[str],
+    *,
+    start_year: int,
+    end_year: int,
+) -> list[str]:
+    if not companies:
+        return []
+    years_scope = set(range(int(start_year), int(end_year) + 1))
+    if not years_scope:
+        return []
+    complete_years_map = _load_batch_complete_years_map(
+        read_service,
+        companies,
+        start_year=start_year,
+        end_year=end_year,
+    )
+    return [
+        code
+        for code in companies
+        if not years_scope.issubset(
+            {int(year) for year in complete_years_map.get(int(code), ())}
+        )
+    ]
+
+
+def _load_batch_complete_years_map(
+    read_service: Any,
+    companies: list[str],
+    *,
+    start_year: int,
+    end_year: int,
+) -> dict[int, tuple[int, ...]]:
+    codes = [int(code) for code in companies]
+    load_complete = getattr(read_service, "_load_complete_annual_years_map", None)
+    if callable(load_complete):
+        return {
+            int(code): tuple(int(year) for year in years)
+            for code, years in load_complete(
+                codes,
+                start_year=int(start_year),
+                end_year=int(end_year),
+            ).items()
+        }
+
+    get_available_years = getattr(read_service, "get_available_years", None)
+    if not callable(get_available_years):
+        return {}
+
+    complete_years_map: dict[int, tuple[int, ...]] = {}
+    for code in codes:
+        years = [
+            int(year)
+            for year in get_available_years(int(code))
+            if int(start_year) <= int(year) <= int(end_year)
+        ]
+        complete_years_map[int(code)] = tuple(sorted(set(years)))
+    return complete_years_map
+
+
+def _filter_batch_outdated_companies(
+    companies: list[str],
+    status_items: dict[int, Any],
+    *,
+    end_year: int,
+) -> list[str]:
+    return [
+        code
+        for code in companies
+        if _batch_status_is_outdated(status_items.get(int(code)), end_year=end_year)
+    ]
+
+
+def _batch_status_is_outdated(status_item: Any, *, end_year: int | None) -> bool:
+    if status_item is None:
+        return False
+    if _batch_status_has_failure(status_item):
+        return False
+    values = _batch_status_values(status_item)
+    if values & BATCH_REFRESH_ACTIVE_STATES:
+        return False
+    if values & BATCH_REFRESH_OUTDATED_CODES:
+        return True
+
+    severity = str(_get_batch_attr(status_item, "freshness_summary_severity") or "").lower()
+    has_readable_data = bool(_get_batch_attr(status_item, "has_readable_current_data"))
+    if severity in {"warning", "error"} and has_readable_data:
+        return True
+
+    if end_year is not None and has_readable_data:
+        latest_year = _get_batch_attr(status_item, "latest_readable_year")
+        if latest_year is not None and int(latest_year) < int(end_year):
+            return True
+        last_end_year = _get_batch_attr(status_item, "last_end_year")
+        if last_end_year is not None and int(last_end_year) < int(end_year):
+            return True
+    if values & BATCH_REFRESH_CURRENT_CODES:
+        return False
+    return False
+
+
+def _filter_batch_failed_companies(
+    companies: list[str],
+    status_items: dict[int, Any],
+) -> list[str]:
+    return [
+        code
+        for code in companies
+        if _batch_status_is_retryable_failure(status_items.get(int(code)))
+    ]
+
+
+def _batch_status_is_retryable_failure(status_item: Any) -> bool:
+    if status_item is None or not _batch_status_has_failure(status_item):
+        return False
+    retry_flags = [
+        _get_batch_attr(status_item, "is_retry_allowed"),
+        _get_batch_attr(status_item, "latest_attempt_retryable"),
+    ]
+    explicit_flags = [flag for flag in retry_flags if flag is not None]
+    if not explicit_flags:
+        return True
+    return any(bool(flag) for flag in explicit_flags)
+
+
+def _batch_status_has_failure(status_item: Any) -> bool:
+    values = _batch_status_values(status_item)
+    if values & BATCH_REFRESH_ACTIVE_STATES:
+        return False
+    return bool(values & BATCH_REFRESH_FAILED_STATES)
+
+
+def _batch_status_values(status_item: Any) -> set[str]:
+    fields = (
+        "tracking_state",
+        "last_status",
+        "latest_attempt_outcome",
+        "latest_attempt_reason_code",
+        "status_reason_code",
+        "freshness_summary_code",
+    )
+    return {
+        str(value).strip().lower()
+        for field in fields
+        for value in (_get_batch_attr(status_item, field),)
+        if value not in (None, "")
+    }
+
+
+def _get_batch_attr(item: Any, field: str) -> Any:
+    if isinstance(item, dict):
+        return item.get(field)
+    return getattr(item, field, None)
+
+
 class CVMReadService:
     REQUIRED_PACKAGE_STATEMENTS = ("BPA", "BPP", "DRE", "DFC")
     BASE_HEALTH_OK_THRESHOLD = 90.0
@@ -149,6 +549,22 @@ class CVMReadService:
                 timeout=self.settings.company_list_timeout
             )
         return self._company_catalog
+
+    def resolve_batch_refresh_selection(
+        self,
+        params: dict[str, Any] | None = None,
+        *,
+        mode: str = "missing",
+        default_start_year: int = 2010,
+        max_page_size: int = BATCH_REFRESH_MAX_PAGE_SIZE,
+    ) -> RefreshBatchSelection:
+        return resolve_refresh_batch_selection(
+            self,
+            params,
+            mode=mode,
+            default_start_year=default_start_year,
+            max_page_size=max_page_size,
+        )
 
     def search_companies(self, search: str = "") -> list[CompanySearchResult]:
         df = self.query_layer.get_companies(search)

--- a/tests/test_bridge_refresh.py
+++ b/tests/test_bridge_refresh.py
@@ -5,6 +5,7 @@ import time
 from pathlib import Path
 from types import SimpleNamespace
 
+from apps.api.app.services.refresh_jobs import ApiRefreshJobManager
 from desktop.bridge import CVMBridge
 from desktop.services import DesktopRefreshJobManager
 from src.contracts import CompanyRefreshResult, RefreshResult
@@ -12,9 +13,10 @@ from src.settings import build_settings
 
 
 class FakeReadService:
-    def __init__(self, items=None, statuses=None):
+    def __init__(self, items=None, statuses=None, complete_years=None):
         self.items = items or [SimpleNamespace(cd_cvm=9512)]
         self.statuses = statuses or []
+        self.complete_years = complete_years or {}
         self.calls = []
 
     def list_companies(self, **kwargs):
@@ -23,6 +25,16 @@ class FakeReadService:
 
     def list_refresh_status(self):
         return tuple(self.statuses)
+
+    def _load_complete_annual_years_map(self, cd_cvms, *, start_year, end_year):
+        return {
+            int(cd_cvm): tuple(
+                int(year)
+                for year in self.complete_years.get(int(cd_cvm), ())
+                if int(start_year) <= int(year) <= int(end_year)
+            )
+            for cd_cvm in cd_cvms
+        }
 
 
 class FakeRefreshService:
@@ -147,6 +159,94 @@ def test_request_refresh_applies_sector_status_and_cvm_range_filters(tmp_path: P
         "start_year": 2023,
         "end_year": 2024,
     }
+
+
+def test_api_and_desktop_batch_refresh_resolve_same_companies(tmp_path: Path):
+    items = [
+        SimpleNamespace(cd_cvm=100),
+        SimpleNamespace(cd_cvm=150),
+        SimpleNamespace(cd_cvm=180),
+        SimpleNamespace(cd_cvm=250),
+    ]
+    statuses = [
+        SimpleNamespace(
+            cd_cvm=100,
+            tracking_state="success",
+            last_status="success",
+            latest_attempt_outcome="success",
+            freshness_summary_code="refresh_completed_readable",
+            freshness_summary_severity="success",
+            has_readable_current_data=True,
+            latest_readable_year=2024,
+            last_end_year=2024,
+        ),
+        SimpleNamespace(
+            cd_cvm=150,
+            tracking_state="success",
+            last_status="success",
+            latest_attempt_outcome="success",
+            freshness_summary_code="mixed_no_new_data_readable",
+            freshness_summary_severity="warning",
+            has_readable_current_data=True,
+            latest_readable_year=2023,
+            last_end_year=2023,
+        ),
+        SimpleNamespace(
+            cd_cvm=180,
+            tracking_state="error",
+            last_status="error",
+            latest_attempt_outcome="error",
+            is_retry_allowed=True,
+            has_readable_current_data=True,
+        ),
+    ]
+    params = {
+        "mode": "outdated",
+        "sector": "energia",
+        "cvm_from": 100,
+        "cvm_to": 200,
+        "start_year": 2023,
+        "end_year": 2024,
+    }
+    settings = build_settings(project_root=tmp_path)
+    api_manager = ApiRefreshJobManager(
+        settings=settings,
+        read_service=FakeReadService(items=items, statuses=statuses),
+        autostart=False,
+    )
+    desktop_manager = _make_manager(
+        tmp_path,
+        read_service=FakeReadService(items=items, statuses=statuses),
+        autostart=False,
+    )
+
+    api_dispatch = api_manager.request_refresh(params)
+    desktop_dispatch = desktop_manager.request_refresh(params)
+
+    api_job = api_manager._jobs[str(api_dispatch["job_id"])]
+    saved = json.loads((tmp_path / "data" / "refresh_jobs.json").read_text(encoding="utf-8"))
+    desktop_job = saved["jobs"][0]
+    assert api_dispatch["queued"] == desktop_dispatch["queued"] == 1
+    assert api_job["request"] == desktop_job["request"] == {
+        "companies": ["150"],
+        "start_year": 2023,
+        "end_year": 2024,
+    }
+
+
+def test_desktop_refresh_rejects_invalid_batch_range(tmp_path: Path):
+    manager = _make_manager(tmp_path, autostart=False)
+
+    dispatch = manager.request_refresh(
+        {
+            "mode": "full",
+            "cvm_range": {"start": 300, "end": 100},
+        }
+    )
+
+    assert dispatch["status"] == "error"
+    assert dispatch["status_reason_code"] == "invalid_request"
+    assert "cvm_range.start" in dispatch["message"]
 
 
 def test_running_jobs_are_marked_interrupted_after_restart(tmp_path: Path):


### PR DESCRIPTION
## Summary

- Centraliza a resolucao de escopo do batch refresh para API e desktop.
- Define `full`, `missing`, `outdated` e `failed` com filtros compostos e `queued` igual ao escopo final.
- Aceita aliases do bridge desktop na API (`sector`, `cvm_from`, `cvm_to`) e documenta o contrato.

## Compatibilidade

- Politica: additive-only.
- Endpoints existentes continuam iguais.
- `sector` e `cvm_from`/`cvm_to` sao aliases de compatibilidade; `sector_slug` e `cvm_range` seguem suportados.
- Erros de range/ano invalidos continuam em `422 invalid_request`, agora com validacao explicita do resolver compartilhado.

## Validation

- `python -m pytest apps/api/tests/test_refresh_api.py tests/test_bridge_refresh.py` -> 23 passed
- `python -m pytest apps/api/tests/test_api_contract.py` -> 95 passed
- `python -m pytest apps/api/tests tests` -> 278 passed
- `git diff --check` -> sem erros

Closes #262